### PR TITLE
Enable model and unsat-core generation in Z3 only for solver instances where we need it.

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3SolverContext.java
@@ -165,8 +165,6 @@ final class Z3SolverContext extends AbstractSolverContext {
     }
 
     long cfg = Native.mkConfig();
-    Native.setParamValue(cfg, "MODEL", "true");
-
     if (extraOptions.requireProofs) {
       Native.setParamValue(cfg, "PROOF", "true");
     }
@@ -230,11 +228,27 @@ final class Z3SolverContext extends AbstractSolverContext {
 
   @Override
   protected ProverEnvironment newProverEnvironment0(Set<ProverOptions> options) {
+    long z3context = creator.getEnv();
+    Native.paramsSetBool(
+        z3context,
+        z3params,
+        Native.mkStringSymbol(z3context, ":model"),
+        options.contains(ProverOptions.GENERATE_MODELS));
+    Native.paramsSetBool(
+        z3context,
+        z3params,
+        Native.mkStringSymbol(z3context, ":unsat_core"),
+        options.contains(ProverOptions.GENERATE_UNSAT_CORE)
+            || options.contains(ProverOptions.GENERATE_UNSAT_CORE_OVER_ASSUMPTIONS));
     return new Z3TheoremProver(creator, manager, z3params, options);
   }
 
   @Override
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0() {
+    long z3context = creator.getEnv();
+    Native.paramsSetBool(z3context, z3params, Native.mkStringSymbol(z3context, ":model"), true);
+    Native.paramsSetBool(
+        z3context, z3params, Native.mkStringSymbol(z3context, ":unsat_core"), false);
     return new Z3InterpolatingProver(creator, z3params, logger, dumpFailedInterpolationQueries);
   }
 


### PR DESCRIPTION
Previously model generation was always turned on, and unsat-core generation never.

I wonder why unsat-core generation seems to succeed anyway (the [default is false](https://github.com/Z3Prover/z3/blob/e8f4dd76c21b52460b6bd95487183aea88749ce0/src/cmd_context/context_params.cpp#L169)), so I would like to have your opinion on this.
