### PR TITLE
Update package name in README examples and Javadoc overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,16 +178,16 @@ do not require any configuration and work out of the box.
 Below is a small example showing how to initialize the library using the entry point [SolverContextFactory][]:
 
 ```java
-package org.sosy_lab.solver.test;
+package org.sosy_lab.java_smt.test;
 
 import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.common.log.LogManager;
-import org.sosy_lab.solver.SolverContextFactory;
-import org.sosy_lab.solver.SolverContextFactory.Solvers;
-import org.sosy_lab.solver.api.SolverContext;
+import org.sosy_lab.java_smt.SolverContextFactory;
+import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
+import org.sosy_lab.java_smt.api.SolverContext;
 
 public class TestApp {
   public static void main(String[] args) throws InvalidConfigurationException {

--- a/doc/javadoc_overview.html
+++ b/doc/javadoc_overview.html
@@ -4,8 +4,8 @@
 <p>JavaSMT is a generic API allowing unified access to different SMT solvers.</p>
 
 <p>All the interaction with a solver is performed through the
-{@link org.sosy_lab.solver.api.SolverContext} interface, which encapsulates a
+{@link org.sosy_lab.java_smt.api.SolverContext} interface, which encapsulates a
 single context.
-{@link org.sosy_lab.solver.api.SolverContext} instances are created using
-{@link org.sosy_lab.solver.SolverContextFactory}.</p>
+{@link org.sosy_lab.java_smt.api.SolverContext} instances are created using
+{@link org.sosy_lab.java_smt.SolverContextFactory}.</p>
 </body>


### PR DESCRIPTION
The example in the README uses the old package name, `org.sosy_lab.solver`, but in the current version the root package is now `org.sosy_lab.java_smt`; this commit updates the example to use the correct package.