### PR TITLE
Simplify n-ary and/or with duplicate operands like and(x, y, x)

### DIFF
--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractBooleanFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractBooleanFormulaManager.java
@@ -139,15 +139,19 @@ public abstract class AbstractBooleanFormulaManager<TFormulaInfo, TType, TEnv, T
 
   /**
    * Create an n-ary conjunction. The default implementation delegates to {@link #and(Object,
-   * Object)} and assumes that all simplifications are done by that method. This method can be
-   * overridden, in which case it should filter out irrelevant operands.
+   * Object)}. This method can be overridden, in which case it should filter out irrelevant
+   * operands.
    *
    * @param pParams A collection of at least 3 operands.
    * @return A term that is equivalent to a conjunction of pParams.
    */
   protected TFormulaInfo andImpl(Collection<TFormulaInfo> pParams) {
+    // Binary or cannot eliminate duplicates in cases like or(x, y, x), so we use Stream.distinct()
+    // Need to use iterator for short-circuiting on "false".
+    Iterator<TFormulaInfo> it = pParams.stream().filter(f -> !isTrue(f)).distinct().iterator();
     TFormulaInfo result = makeBooleanImpl(true);
-    for (TFormulaInfo formula : pParams) {
+    while (it.hasNext()) {
+      TFormulaInfo formula = it.next();
       if (isFalse(formula)) {
         return formula;
       }
@@ -201,15 +205,19 @@ public abstract class AbstractBooleanFormulaManager<TFormulaInfo, TType, TEnv, T
 
   /**
    * Create an n-ary disjunction. The default implementation delegates to {@link #or(Object,
-   * Object)} and assumes that all simplifications are done by that method. This method can be
-   * overridden, in which case it should filter out irrelevant operands.
+   * Object)}. This method can be overridden, in which case it should filter out irrelevant
+   * operands.
    *
    * @param pParams A collection of at least 3 operands.
    * @return A term that is equivalent to a disjunction of pParams.
    */
   protected TFormulaInfo orImpl(Collection<TFormulaInfo> pParams) {
+    // Binary or cannot eliminate duplicates in cases like or(x, y, x), so we use Stream.distinct()
+    // Need to use iterator for short-circuiting on "true".
+    Iterator<TFormulaInfo> it = pParams.stream().filter(f -> !isFalse(f)).distinct().iterator();
     TFormulaInfo result = makeBooleanImpl(false);
-    for (TFormulaInfo formula : pParams) {
+    while (it.hasNext()) {
+      TFormulaInfo formula = it.next();
       if (isTrue(formula)) {
         return formula;
       }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3BooleanFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3BooleanFormulaManager.java
@@ -21,6 +21,7 @@ package org.sosy_lab.java_smt.solvers.z3;
 
 import com.microsoft.z3.Native;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -91,17 +92,18 @@ class Z3BooleanFormulaManager extends AbstractBooleanFormulaManager<Long, Long, 
 
   @Override
   protected Long orImpl(Collection<Long> params) {
-    // Z3 does not do any simplifications, so we filter "false" and short-circuit on "true".
+    // Z3 does not do any simplifications, so we filter "false" and duplicate elements.
+    // Need to use iterator for short-circuiting on "true".
+    final Iterator<Long> it = params.stream().filter(f -> !isFalse(f)).distinct().iterator();
     final long[] operands = new long[params.size()]; // over-approximate size
     int count = 0;
-    for (final Long operand : params) {
+    while (it.hasNext()) {
+      final Long operand = it.next();
       if (isTrue(operand)) {
         return operand;
       }
-      if (!isFalse(operand)) {
-        operands[count] = operand;
-        count++;
-      }
+      operands[count] = operand;
+      count++;
     }
     switch (count) {
       case 0:
@@ -120,17 +122,18 @@ class Z3BooleanFormulaManager extends AbstractBooleanFormulaManager<Long, Long, 
 
   @Override
   protected Long andImpl(Collection<Long> params) {
-    // Z3 does not do any simplifications, so we filter "true" and short-circuit on "false".
+    // Z3 does not do any simplifications, so we filter "true" and duplicate elements.
+    // Need to use iterator for short-circuiting on "false".
+    final Iterator<Long> it = params.stream().filter(f -> !isTrue(f)).distinct().iterator();
     final long[] operands = new long[params.size()]; // over-approximate size
     int count = 0;
-    for (final Long operand : params) {
+    while (it.hasNext()) {
+      final Long operand = it.next();
       if (isFalse(operand)) {
         return operand;
       }
-      if (!isTrue(operand)) {
-        operands[count] = operand;
-        count++;
-      }
+      operands[count] = operand;
+      count++;
     }
     switch (count) {
       case 0:

--- a/src/org/sosy_lab/java_smt/test/BooleanFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/BooleanFormulaManagerTest.java
@@ -217,11 +217,10 @@ public class BooleanFormulaManagerTest extends SolverBasedTest0 {
     Truth.assertThat(bmgr.and(tru, tru, tru)).isEqualTo(tru);
     Truth.assertThat(bmgr.and(fals, x, x)).isEqualTo(fals);
     Truth.assertThat(bmgr.and(tru, x, tru)).isEqualTo(x);
+    Truth.assertThat(bmgr.and(x, x, tru)).isEqualTo(x);
 
+    Truth.assertThat(bmgr.and(tru, tru, x, y, tru, x, y)).isEqualTo(bmgr.and(x, y));
     Truth.assertThat(bmgr.and(tru, tru, x, fals, y, tru, x, y)).isEqualTo(fals);
-
-    // recursive simplification needed
-    // Truth.assertThat(bmgr.and(x, x, x, y, y)).isEqualTo(bmgr.and(x, y));
 
     // OR
     Truth.assertThat(bmgr.or(tru)).isEqualTo(tru);
@@ -237,7 +236,9 @@ public class BooleanFormulaManagerTest extends SolverBasedTest0 {
     Truth.assertThat(bmgr.or(fals, fals, fals)).isEqualTo(fals);
     Truth.assertThat(bmgr.or(tru, x, x)).isEqualTo(tru);
     Truth.assertThat(bmgr.or(fals, x, fals)).isEqualTo(x);
+    Truth.assertThat(bmgr.or(x, x, fals)).isEqualTo(x);
 
+    Truth.assertThat(bmgr.or(fals, fals, x, y, fals, x, y)).isEqualTo(bmgr.or(x, y));
     Truth.assertThat(bmgr.or(fals, fals, x, tru, y, fals, x, y)).isEqualTo(tru);
   }
 }


### PR DESCRIPTION
SMTInterpol already does this, now we do it for all other solvers as well.
This basically re-adds 36e47b5b (which was only for Z3), but in a more memory-efficient way (`Stream.distinct()` typically uses a regular `HashSet`, the old commit used a `LinkedHashSet`).

The performance and memory consumption are O(n) (amortized), just like the existing code. The overhead is basically one additional `HashSet`.

In the discussion of 36e47b5b it was decided to not do this, and I am also not really convinced this is worth it (we now consistently do simplifications of `true` and `false` operands including short-circuiting, this PR would only filter out duplicate operands, which are probably rare).
But given the new implementation and that this is the first time we have an implementation that would make the behavior across all solvers consistent, I would like to put this up for discussion. At the least we will have this PR as permanent record of this potential solution.

Cf. #73