### PR TITLE
CPAchecker LassoRanker Update

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolEnvironment.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolEnvironment.java
@@ -344,7 +344,7 @@ public class SmtInterpolEnvironment {
     return script.checkAllsat(importantPredicates);
   }
 
-  /** This function returns a map, that contains assignments term->term for all terms in terms. */
+  /** This function returns a map, that contains assignments for all terms. */
   public Model getModel() {
     try {
       return script.getModel();

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolEnvironment.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolEnvironment.java
@@ -77,7 +77,7 @@ import org.sosy_lab.java_smt.api.SolverException;
  * set a logfile for all Smt-Queries (default "smtinterpol.smt2").
  */
 @Options(prefix = "solver.smtinterpol")
-class SmtInterpolEnvironment {
+public class SmtInterpolEnvironment {
 
   /** SMTInterpol does not allow to use key-functions as identifiers. */
   private static final ImmutableSet<String> UNSUPPORTED_IDENTIFIERS =

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaManager.java
@@ -43,7 +43,7 @@ import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.basicimpl.AbstractFormulaManager;
 
-class SmtInterpolFormulaManager
+public class SmtInterpolFormulaManager
     extends AbstractFormulaManager<Term, Sort, SmtInterpolEnvironment, FunctionSymbol> {
 
   SmtInterpolFormulaManager(


### PR DESCRIPTION
This PR contains changes required by CPAchecker for updating the LassoRanker library that strongly depends on SMTInterpol and requires direct access to its components.