### PR TITLE
Appvoyer-CI has an internal limitation for unit-test-upload.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ test_script:
 on_finish:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
-      $files = Get-ChildItem -Path ".\junit\TEST-*.xml" -Exclude "VariableNames*"
+      $files = Get-ChildItem -Path ".\junit\TEST-*.xml" -Exclude "*VariableNames*"
       $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
       foreach($file in $files){
         echo $file.FullName

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ test_script:
 on_finish:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
-      $files = Get-ChildItem -Path ".\junit\" -Filter *.xml
+      $files = Get-ChildItem -Path ".\junit\" -Filter TEST-*.xml
       $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
       foreach($file in $files){
         echo $file.FullName

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,9 +30,9 @@ on_finish:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
       $files = Get-ChildItem -Path ".\junit\" -Filter *.xml
-      echo $files
+      $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
       foreach($file in $files){
-        $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
+        echo $file.FullName
         $wc.UploadFile($url, $file.FullName)
       }
   - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,8 +33,6 @@ on_finish:
       (New-Object 'System.Net.WebClient').UploadFile($url, (Resolve-Path $file))
   - ps: |
       Push-AppveyorArtifact JUnit.html -DeploymentName "JUnit Report"
-  - ps: |
-      Push-AppveyorArtifact junit\TESTS-TestSuites.xml -DeploymentName "JUnit TestSuites"
 
 cache:
   - C:\ant

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,10 +27,12 @@ test_script:
   - ant unit-tests
 
 on_finish:
-  - ps: |
-      $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
-      $file = '.\junit\TESTS-TestSuites.xml'
-      (New-Object 'System.Net.WebClient').UploadFile($url, (Resolve-Path $file))
+  - ps: >-
+      $wc = New-Object 'System.Net.WebClient'
+      foreach ($file in Get-ChildItem -Path .\junit\" -Filter *.xml) {
+        $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
+        $wc.UploadFile($url, $file.FullName)
+      }
   - ps: |
       Push-AppveyorArtifact JUnit.html -DeploymentName "JUnit Report"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ test_script:
 on_finish:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
-      $files = Get-ChildItem -Path ".\junit\" -Filter TEST-*.xml
+      $files = Get-ChildItem -Path ".\junit\TEST-*.xml" -Exclude "VariableNames*"
       $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
       foreach($file in $files){
         echo $file.FullName

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,6 @@ on_finish:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
       $files = Get-ChildItem -Path .\junit\" -Filter *.xml
-      echo "$files"
       foreach($file in $files){
         $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
         $wc.UploadFile($url, $file.FullName)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,9 +27,11 @@ test_script:
   - ant unit-tests
 
 on_finish:
-  - ps: >-
+  - ps: |
       $wc = New-Object 'System.Net.WebClient'
-      foreach ($file in Get-ChildItem -Path .\junit\" -Filter *.xml) {
+      $files = Get-ChildItem -Path .\junit\" -Filter *.xml
+      echo $files
+      foreach($file in $files){
         $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
         $wc.UploadFile($url, $file.FullName)
       }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,8 @@ test_script:
 on_finish:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
-      $files = Get-ChildItem -Path .\junit\" -Filter *.xml
+      $files = Get-ChildItem -Path ".\junit\" -Filter *.xml
+      echo $files
       foreach($file in $files){
         $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
         $wc.UploadFile($url, $file.FullName)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ on_finish:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
       $files = Get-ChildItem -Path .\junit\" -Filter *.xml
-      echo $files
+      echo "$files"
       foreach($file in $files){
         $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
         $wc.UploadFile($url, $file.FullName)


### PR DESCRIPTION
The upload of JUnit-tests is limited by 30.000 (plus some overhead).
Since several months we got timeouts or strange errors from the upload step.
Now we ignore a large subset of JUnit-tests in the upload-step (the tests are executed!) to stay under the limitation.