### PR TITLE
Concurrency tests

### DIFF
--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -35,10 +35,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
@@ -66,7 +64,6 @@ import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 
 @SuppressWarnings("resource")
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @RunWith(Parameterized.class)
 public class SolverConcurrencyTest {
 

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -70,6 +70,35 @@ public class SolverConcurrencyTest {
   private static final int NUMBER_OF_THREADS = 4;
   private static final int TIMEOUT_SECONDS = 30;
 
+  /**
+   * As some Solvers are slower/faster, we choose an appropriate number of formulas to solve here
+   */
+  private final Map<Solvers, Integer> integerFormulaGen =
+      Map.of(
+          Solvers.SMTINTERPOL,
+          12,
+          Solvers.CVC4,
+          16,
+          Solvers.MATHSAT5,
+          16,
+          Solvers.PRINCESS,
+          12,
+          Solvers.Z3,
+          16);
+
+  private final Map<Solvers, Integer> bitvectorFormulaGen =
+      Map.of(
+          Solvers.BOOLECTOR,
+          60,
+          Solvers.CVC4,
+          9,
+          Solvers.MATHSAT5,
+          60,
+          Solvers.PRINCESS,
+          9,
+          Solvers.Z3,
+          50);
+
   private static List<Throwable> exceptionsList;
 
   @Parameters(name = "{0}")
@@ -125,10 +154,12 @@ public class SolverConcurrencyTest {
         .isNoneOf(Solvers.SMTINTERPOL, Solvers.BOOLECTOR, Solvers.PRINCESS, Solvers.CVC4);
   }
 
+  /**
+   * Test concurrency of integers (while every thread creates its unique context on its own
+   * concurrently)
+   */
   @Test
   public void testIntConcurrencyWithConcurrentContext() {
-    // Test concurrency of integers (while every thread creates its unique context on its own
-    // concurrently)
     requireIntegers();
     List<Runnable> runnableList = new ArrayList<>();
     for (int i = 0; i < NUMBER_OF_THREADS; i++) {
@@ -150,10 +181,12 @@ public class SolverConcurrencyTest {
     assertConcurrency(runnableList, "testBasicIntConcurrency");
   }
 
+  /**
+   * Test concurrency of bitvectors (while every thread creates its unique context on its own
+   * concurrently)
+   */
   @Test
   public void testBvConcurrencyWithConcurrentContext() {
-    // Test concurrency of bitvectors (while every thread creates its unique context on its own
-    // concurrently)
     requireBitvectors();
     List<Runnable> runnableList = new ArrayList<>();
     for (int i = 0; i < NUMBER_OF_THREADS; i++) {
@@ -175,10 +208,12 @@ public class SolverConcurrencyTest {
     assertConcurrency(runnableList, "testBasicIntConcurrency");
   }
 
+  /**
+   * Test concurrency with already present and unique context per thread
+   */
   @SuppressWarnings("resource")
   @Test
   public void testIntConcurrencyWithoutConcurrentContext() throws InvalidConfigurationException {
-    // Test concurrency with already present and unique context per thread
     assume().withMessage("Solver %s does not support the theory of bitvectors", solverToUse())
         .that(solverToUse())
         .isNotEqualTo(Solvers.BOOLECTOR);
@@ -204,10 +239,12 @@ public class SolverConcurrencyTest {
     assertConcurrency(runnableList, "testBasicIntConcurrency");
   }
 
+  /**
+   * Test concurrency with already present and unique context per thread
+   */
   @SuppressWarnings("resource")
   @Test
   public void testBvConcurrencyWithoutConcurrentContext() throws InvalidConfigurationException {
-    // Test concurrency with already present and unique context per thread
     requireBitvectors();
     List<Runnable> runnableList = new ArrayList<>();
     ConcurrentLinkedQueue<SolverContext> contextList = new ConcurrentLinkedQueue<>();
@@ -305,8 +342,6 @@ public class SolverConcurrencyTest {
    * the test!)
    *
    * @param context used context for the test-thread (Do not reuse contexts!)
-   * @throws SolverException
-   * @throws InterruptedException
    */
   private void bvConcurrencyTest(SolverContext context)
       throws SolverException, InterruptedException {
@@ -331,8 +366,6 @@ public class SolverConcurrencyTest {
    *
    * @param context used context for the test-thread (Do not reuse contexts unless you know what you
    *        are doing!)
-   * @throws SolverException
-   * @throws InterruptedException
    */
   private void intConcurrencyTest(SolverContext context)
       throws SolverException, InterruptedException {
@@ -392,8 +425,7 @@ public class SolverConcurrencyTest {
    * Creates and returns a completely new SolverContext for the currently used solver (We need this
    * to get more than one Context in 1 method in a controlled way)
    *
-   * @return new SolverContext
-   * @throws InvalidConfigurationException
+   * @return new and unique SolverContext for current solver (Parameter(0))
    */
   private SolverContext initSolver() throws InvalidConfigurationException {
     try {
@@ -414,7 +446,7 @@ public class SolverConcurrencyTest {
     }
   }
 
-  // TODO: make a Collection of used contextes and end them with annotation after
+  // TODO: make a Collection of used contexts and end them with annotation after
   private void closeSolver(SolverContext context) {
     if (context != null) {
       context.close();
@@ -472,34 +504,5 @@ public class SolverConcurrencyTest {
         exceptionsList.isEmpty());
   }
 
-  /**
-   * As some Solvers are slow... very slow.... and we don't want to wait till the heat death of the
-   * universe nor a 0,1 second test for the faster ones we choose an appropriate number of formulas
-   * to solve here
-   */
-  Map<Solvers, Integer> integerFormulaGen =
-      Map.of(
-          Solvers.SMTINTERPOL,
-          12,
-          Solvers.CVC4,
-          16,
-          Solvers.MATHSAT5,
-          16,
-          Solvers.PRINCESS,
-          12,
-          Solvers.Z3,
-          16);
 
-  Map<Solvers, Integer> bitvectorFormulaGen =
-      Map.of(
-          Solvers.BOOLECTOR,
-          60,
-          Solvers.CVC4,
-          9,
-          Solvers.MATHSAT5,
-          60,
-          Solvers.PRINCESS,
-          9,
-          Solvers.Z3,
-          50);
 }

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -214,13 +214,14 @@ public class SolverConcurrencyTest {
   @SuppressWarnings("resource")
   @Test
   public void testIntConcurrencyWithoutConcurrentContext() throws InvalidConfigurationException {
-    assume().withMessage("Solver %s does not support the theory of bitvectors", solverToUse())
-        .that(solverToUse())
-        .isNotEqualTo(Solvers.BOOLECTOR);
+    requireBitvectors();
     List<Runnable> runnableList = new ArrayList<>();
     ConcurrentLinkedQueue<SolverContext> contextList = new ConcurrentLinkedQueue<>();
+    // Initialize contexts before using them in the threads
     for (int i = 0; i < NUMBER_OF_THREADS; i++) {
       contextList.add(initSolver());
+    }
+    for (int i = 0; i < NUMBER_OF_THREADS; i++) {
       Runnable test = new Runnable() {
         @SuppressWarnings("resource")
         @Override

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -175,7 +175,7 @@ public class SolverConcurrencyTest {
   @SuppressWarnings("resource")
   @Test
   public void testIntConcurrencyWithoutConcurrentContext() throws InvalidConfigurationException {
-    requireBitvectors();
+    requireIntegers();
     ConcurrentLinkedQueue<SolverContext> contextList = new ConcurrentLinkedQueue<>();
     // Initialize contexts before using them in the threads
     for (int i = 0; i < NUMBER_OF_THREADS; i++) {

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -75,15 +75,15 @@ public class SolverConcurrencyTest {
   private static final Map<Solvers, Integer> INTEGER_FORMULA_GEN =
       Map.of(
           Solvers.SMTINTERPOL,
-          12,
+          10,
           Solvers.CVC4,
-          16,
+          14,
           Solvers.MATHSAT5,
           16,
           Solvers.PRINCESS,
-          12,
+          10,
           Solvers.Z3,
-          16);
+          14);
 
   private static final Map<Solvers, Integer> BITVECTOR_FORMULA_GEN =
       Map.of(

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -109,6 +110,15 @@ public class SolverConcurrencyTest {
 
   protected Solvers solverToUse() {
     return solver;
+  }
+
+  /**
+   * If UnsatisfiedLinkError (wrapped in InvalidConfigurationException) is thrown, abort the test.
+   * On some systems (like Windows), some solvers are not available.
+   */
+  @Before
+  public void checkThatSolverIsAvailable() throws InvalidConfigurationException {
+    initSolver().close();
   }
 
   private void requireConcurrentMultipleStackSupport() {

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -1,0 +1,436 @@
+/*
+ *  JavaSMT is an API wrapper for a collection of SMT solvers.
+ *  This file is part of JavaSMT.
+ *
+ *  Copyright (C) 2007-2020  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.sosy_lab.java_smt.test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.sosy_lab.common.ShutdownManager;
+import org.sosy_lab.common.ShutdownNotifier;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.common.log.LogManager;
+import org.sosy_lab.common.rationals.Rational;
+import org.sosy_lab.java_smt.SolverContextFactory;
+import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
+import org.sosy_lab.java_smt.api.BasicProverEnvironment;
+import org.sosy_lab.java_smt.api.BitvectorFormulaManager;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.FormulaManager;
+import org.sosy_lab.java_smt.api.IntegerFormulaManager;
+import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
+import org.sosy_lab.java_smt.api.OptimizationProverEnvironment;
+import org.sosy_lab.java_smt.api.OptimizationProverEnvironment.OptStatus;
+import org.sosy_lab.java_smt.api.SolverContext;
+import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
+import org.sosy_lab.java_smt.api.SolverException;
+
+@RunWith(Parameterized.class)
+public class SolverConcurrencyTest {
+
+  private static final int NUMBER_OF_THREADS = 4;
+  private static final int TIMEOUT_SECONDS = 30;
+
+  private static List<Throwable> exceptionsList;
+
+  @Parameters(name = "{0}")
+  public static Object[] getAllSolvers() {
+    return Solvers.values();
+  }
+
+  @Parameter(0)
+  public Solvers solver;
+
+
+  protected Solvers solverToUse() {
+    return solver;
+  }
+
+  @BeforeClass
+  public static void createExceptionsList() {
+    exceptionsList = Collections.synchronizedList(new ArrayList<Throwable>());
+  }
+
+  @After
+  public void resetExceptionsList() {
+    exceptionsList.clear();
+  }
+
+  @Test
+  public void testIntConcurrencyWithConcurrentContext() {
+    // Test concurrency of integers (while every thread creates its unique context on its own
+    // concurrently)
+    assume().withMessage("Solver %s does not support the theory of bitvectors", solverToUse())
+        .that(solverToUse())
+        .isNotEqualTo(Solvers.BOOLECTOR);
+    List<Runnable> runnableList = new ArrayList<>();
+    for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+      Runnable test = new Runnable() {
+        @SuppressWarnings("resource")
+        @Override
+        public void run() {
+          try {
+            SolverContext context = initSolver();
+            intConcurrencyTest(context);
+            closeSolver(context);
+          } catch (Throwable e) {
+            exceptionsList.add(e);
+          }
+        }
+      };
+      runnableList.add(test);
+    }
+    assertConcurrency(runnableList, "testBasicIntConcurrency");
+  }
+
+  @Test
+  public void testBvConcurrencyWithConcurrentContext() {
+    // Test concurrency of bitvectors (while every thread creates its unique context on its own
+    // concurrently)
+    assume().withMessage("Solver %s does not support the theory of bitvectors", solverToUse())
+        .that(solverToUse())
+        .isNotEqualTo(Solvers.SMTINTERPOL);
+    List<Runnable> runnableList = new ArrayList<>();
+    for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+      Runnable test = new Runnable() {
+        @SuppressWarnings("resource")
+        @Override
+        public void run() {
+          try {
+            SolverContext context = initSolver();
+            bvConcurrencyTest(context);
+            closeSolver(context);
+          } catch (Throwable e) {
+            exceptionsList.add(e);
+          }
+        }
+      };
+      runnableList.add(test);
+    }
+    assertConcurrency(runnableList, "testBasicIntConcurrency");
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  public void testIntConcurrencyWithoutConcurrentContext() throws InvalidConfigurationException {
+    // Test concurrency with already present and unique context per thread
+    assume().withMessage("Solver %s does not support the theory of bitvectors", solverToUse())
+        .that(solverToUse())
+        .isNotEqualTo(Solvers.BOOLECTOR);
+    List<Runnable> runnableList = new ArrayList<>();
+    ConcurrentLinkedQueue<SolverContext> contextList = new ConcurrentLinkedQueue<>();
+    for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+      contextList.add(initSolver());
+      Runnable test = new Runnable() {
+        @SuppressWarnings("resource")
+        @Override
+        public void run() {
+          try {
+            SolverContext context = contextList.poll();
+            intConcurrencyTest(context);
+            closeSolver(context);
+          } catch (Throwable e) {
+            exceptionsList.add(e);
+          }
+        }
+      };
+      runnableList.add(test);
+    }
+    assertConcurrency(runnableList, "testBasicIntConcurrency");
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  public void testBvConcurrencyWithoutConcurrentContext() throws InvalidConfigurationException {
+    // Test concurrency with already present and unique context per thread
+    assume().withMessage("Solver %s does not support the theory of bitvectors", solverToUse())
+        .that(solverToUse())
+        .isNotEqualTo(Solvers.SMTINTERPOL);
+    List<Runnable> runnableList = new ArrayList<>();
+    ConcurrentLinkedQueue<SolverContext> contextList = new ConcurrentLinkedQueue<>();
+    for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+      contextList.add(initSolver());
+      Runnable test = new Runnable() {
+        @SuppressWarnings("resource")
+        @Override
+        public void run() {
+          try {
+            SolverContext context = contextList.poll();
+            bvConcurrencyTest(context);
+            closeSolver(context);
+          } catch (Throwable e) {
+            exceptionsList.add(e);
+          }
+        }
+      };
+      runnableList.add(test);
+    }
+    assertConcurrency(runnableList, "testBasicIntConcurrency");
+  }
+
+  @Test
+  public void testConcurrentOptimization() {
+    assume().that(solverToUse()).isAnyOf(Solvers.Z3, Solvers.MATHSAT5);
+    List<Runnable> runnableList = new ArrayList<>();
+    for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+      Runnable test = new Runnable() {
+        @SuppressWarnings("resource")
+        @Override
+        public void run() {
+          try {
+            SolverContext context = initSolver();
+            optimizationTest(context);
+            closeSolver(context);
+          } catch (Throwable e) {
+            exceptionsList.add(e);
+          }
+        }
+      };
+      runnableList.add(test);
+    }
+    assertConcurrency(runnableList, "testBasicIntConcurrency");
+  }
+
+
+  /**
+   * Uses HardBitvectorFormulaGenerator for longer test-cases to assess concurrency problems. Length
+   * is very solver depended, so make sure you choose a appropriate number for the used solver. Make
+   * sure to not call this method with a SolverContext that does not support bitvectors! (No
+   * requireBitvector() because the exceptionList would collect it and throw an exception failing
+   * the test!)
+   *
+   * @param context used context for the test-thread (Do not reuse contexts!)
+   * @throws SolverException
+   * @throws InterruptedException
+   */
+  private void bvConcurrencyTest(SolverContext context)
+      throws SolverException, InterruptedException {
+    FormulaManager mgr = context.getFormulaManager();
+    BitvectorFormulaManager bvmgr = mgr.getBitvectorFormulaManager();
+    BooleanFormulaManager bmgr = mgr.getBooleanFormulaManager();
+
+    HardBitvectorFormulaGenerator gen = new HardBitvectorFormulaGenerator(bvmgr, bmgr);
+    BooleanFormula instance = gen.generate(bitvectorFormulaGen.getOrDefault(solver, 9));
+    try (BasicProverEnvironment<?> pe = context.newProverEnvironment()) {
+      pe.push(instance);
+      assertTrue("Solver %s failed a concurrency test", pe.isUnsat());
+    }
+  }
+
+  /**
+   * Uses HardIntegerFormulaGenerator for longer test-cases to assess concurrency problems. Length
+   * is very solver depended, so make sure you choose a appropriate number for the used solver. Make
+   * sure to not call this method with a SolverContext that does not support integers! (No
+   * requireIntegers() because the exceptionList would collect it and throw an exception failing the
+   * test!)
+   *
+   * @param context used context for the test-thread (Do not reuse contexts unless you know what you
+   *        are doing!)
+   * @throws SolverException
+   * @throws InterruptedException
+   */
+  private void intConcurrencyTest(SolverContext context)
+      throws SolverException, InterruptedException {
+    FormulaManager mgr = context.getFormulaManager();
+    IntegerFormulaManager imgr = mgr.getIntegerFormulaManager();
+    BooleanFormulaManager bmgr = mgr.getBooleanFormulaManager();
+
+    HardIntegerFormulaGenerator gen = new HardIntegerFormulaGenerator(imgr, bmgr);
+    BooleanFormula instance = gen.generate(integerFormulaGen.getOrDefault(solver, 9));
+    try (BasicProverEnvironment<?> pe = context.newProverEnvironment()) {
+      pe.push(instance);
+      assertTrue("Solver %s failed a concurrency test", pe.isUnsat());
+    }
+  }
+
+  private void optimizationTest(SolverContext context)
+      throws InterruptedException, SolverException {
+    FormulaManager mgr = context.getFormulaManager();
+    IntegerFormulaManager imgr = mgr.getIntegerFormulaManager();
+    BooleanFormulaManager bmgr = mgr.getBooleanFormulaManager();
+    try (OptimizationProverEnvironment prover =
+        context.newOptimizationProverEnvironment(ProverOptions.GENERATE_MODELS)) {
+
+      IntegerFormula x = imgr.makeVariable("x");
+      IntegerFormula y = imgr.makeVariable("y");
+      IntegerFormula obj = imgr.makeVariable("obj");
+
+      prover.addConstraint(
+          bmgr.and(
+              imgr.lessOrEquals(x, imgr.makeNumber(10)),
+              imgr.lessOrEquals(y, imgr.makeNumber(15)),
+              imgr.equal(obj, imgr.add(x, y)),
+              imgr.greaterOrEquals(imgr.subtract(x, y), imgr.makeNumber(1))));
+      int handle = prover.maximize(obj);
+
+      // Maximize for x.
+      OptStatus response = prover.check();
+      assertThat(response).isEqualTo(OptStatus.OPT);
+
+      // Check the value.
+      assertThat(prover.upper(handle, Rational.ZERO)).hasValue(Rational.ofString("19"));
+
+      try (Model model = prover.getModel()) {
+        BigInteger xValue = model.evaluate(x);
+        BigInteger objValue = model.evaluate(obj);
+        BigInteger yValue = model.evaluate(y);
+
+        assertThat(objValue).isEqualTo(BigInteger.valueOf(19));
+        assertThat(xValue).isEqualTo(BigInteger.valueOf(10));
+        assertThat(yValue).isEqualTo(BigInteger.valueOf(9));
+      }
+    }
+  }
+
+  /**
+   * Creates and returns a completely new SolverContext for the currently used solver (We need this
+   * to get more than one Context in 1 method in a controlled way)
+   *
+   * @return new SolverContext
+   * @throws InvalidConfigurationException
+   */
+  private SolverContext initSolver() throws InvalidConfigurationException {
+    try {
+      Configuration config =
+          Configuration.builder().setOption("solver.solver", solverToUse().toString()).build();
+      LogManager logger = LogManager.createTestLogManager();
+      ShutdownNotifier shutdownNotifier = ShutdownManager.create().getNotifier();
+
+      SolverContextFactory factory = new SolverContextFactory(config, logger, shutdownNotifier);
+      return factory.generateContext();
+    } catch (InvalidConfigurationException e) {
+      assume()
+          .withMessage(e.getMessage())
+          .that(e)
+          .hasCauseThat()
+          .isNotInstanceOf(UnsatisfiedLinkError.class);
+      throw e;
+    }
+  }
+
+  // TODO: make a Collection of used contextes and end them with annotation after
+  private void closeSolver(SolverContext context) {
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  /**
+   * Synchronizes start and stop of a concurrency test with NUMBER_OF_THREADS threads. This method
+   * will make sure that all exceptions are collected and assessed at the end, as well as stop the
+   * execution after TIMEOUT_SECONDS seconds in case of a deadlock or long calculation.
+   *
+   * @param runnableList A list of Runnable to be tested (make sure its NUMBER_OF_THREADS long for
+   *        proper testing)
+   * @param testName Name of the test for accurate error messages
+   */
+  private static void assertConcurrency(List<? extends Runnable> runnableList, String testName) {
+    final ExecutorService threadPool = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+    try {
+      // Waits for all threads to be started
+      final CountDownLatch allExecutorThreadsReady = new CountDownLatch(NUMBER_OF_THREADS);
+      // Syncs start of tests after all threads are already created
+      final CountDownLatch afterInitBlocker = new CountDownLatch(1);
+      // Syncs end of tests (And prevents Deadlocks in test-threads etc.)
+      final CountDownLatch allDone = new CountDownLatch(NUMBER_OF_THREADS);
+      for (Runnable runnable : runnableList) {
+        threadPool.submit(new Runnable() {
+          @Override
+          public void run() {
+            allExecutorThreadsReady.countDown();
+            try {
+              afterInitBlocker.await();
+              runnable.run();
+            } catch (Throwable e) {
+              exceptionsList.add(e);
+            } finally {
+              allDone.countDown();
+            }
+          }
+        });
+      }
+      assertTrue(
+          "Timeout initializing the Threads for " + testName,
+          allExecutorThreadsReady.await(NUMBER_OF_THREADS * 10, TimeUnit.MILLISECONDS));
+      afterInitBlocker.countDown();
+      assertTrue("Timeout in " + testName, allDone.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    } catch (Throwable e) {
+      exceptionsList.add(e);
+    } finally {
+      threadPool.shutdownNow();
+    }
+    assertTrue(
+        "Test " + testName + " failed with exception(s): " + exceptionsList,
+        exceptionsList.isEmpty());
+  }
+
+  /**
+   * As some Solvers are slow... very slow.... and we don't want to wait till the heat death of the
+   * universe nor a 0,1 second test for the faster ones we choose an appropriate number of formulas
+   * to solve here
+   */
+  Map<Solvers, Integer> integerFormulaGen =
+      Map.of(
+          Solvers.SMTINTERPOL,
+          12,
+          Solvers.CVC4,
+          16,
+          Solvers.MATHSAT5,
+          16,
+          Solvers.PRINCESS,
+          12,
+          Solvers.Z3,
+          16);
+
+  Map<Solvers, Integer> bitvectorFormulaGen =
+      Map.of(
+          Solvers.BOOLECTOR,
+          60,
+          Solvers.CVC4,
+          9,
+          Solvers.MATHSAT5,
+          60,
+          Solvers.PRINCESS,
+          9,
+          Solvers.Z3,
+          50);
+}

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -363,15 +363,16 @@ public class SolverConcurrencyTest {
    * @param testName Name of the test for accurate error messages
    */
   private static void assertConcurrency(List<? extends Runnable> runnableList, String testName) {
-    final ExecutorService threadPool = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+    int numOfThreads = runnableList.size();
+    final ExecutorService threadPool = Executors.newFixedThreadPool(numOfThreads);
 
     try {
       // Waits for all threads to be started
-      final CountDownLatch allExecutorThreadsReady = new CountDownLatch(NUMBER_OF_THREADS);
+      final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numOfThreads);
       // Syncs start of tests after all threads are already created
       final CountDownLatch afterInitBlocker = new CountDownLatch(1);
       // Syncs end of tests (And prevents Deadlocks in test-threads etc.)
-      final CountDownLatch allDone = new CountDownLatch(NUMBER_OF_THREADS);
+      final CountDownLatch allDone = new CountDownLatch(numOfThreads);
       for (Runnable runnable : runnableList) {
         threadPool.submit(new Runnable() {
           @Override
@@ -390,7 +391,7 @@ public class SolverConcurrencyTest {
       }
       assertTrue(
           "Timeout initializing the Threads for " + testName,
-          allExecutorThreadsReady.await(NUMBER_OF_THREADS * 10, TimeUnit.MILLISECONDS));
+          allExecutorThreadsReady.await(numOfThreads * 10, TimeUnit.MILLISECONDS));
       afterInitBlocker.countDown();
       assertTrue("Timeout in " + testName, allDone.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
     } catch (Throwable e) {

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -24,11 +24,11 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.Truth8.assertThat;
 import static com.google.common.truth.TruthJUnit.assume;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -73,8 +73,8 @@ public class SolverConcurrencyTest {
   /**
    * As some Solvers are slower/faster, we choose an appropriate number of formulas to solve here.
    */
-  private static final Map<Solvers, Integer> INTEGER_FORMULA_GEN =
-      Map.of(
+  private static final ImmutableMap<Solvers, Integer> INTEGER_FORMULA_GEN =
+      ImmutableMap.of(
           Solvers.SMTINTERPOL,
           10,
           Solvers.CVC4,
@@ -86,8 +86,8 @@ public class SolverConcurrencyTest {
           Solvers.Z3,
           14);
 
-  private static final Map<Solvers, Integer> BITVECTOR_FORMULA_GEN =
-      Map.of(
+  private static final ImmutableMap<Solvers, Integer> BITVECTOR_FORMULA_GEN =
+      ImmutableMap.of(
           Solvers.BOOLECTOR,
           60,
           Solvers.CVC4,
@@ -214,7 +214,8 @@ public class SolverConcurrencyTest {
   public void testConcurrentOptimization() {
     requireOptimization();
 
-    assume().withMessage("Solver does support optimization, but is not yet reentrant.")
+    assume()
+        .withMessage("Solver does support optimization, but is not yet reentrant.")
         .that(solver)
         .isNotEqualTo(Solvers.MATHSAT5);
 

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -35,8 +35,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
@@ -64,6 +66,7 @@ import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 
 @SuppressWarnings("resource")
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @RunWith(Parameterized.class)
 public class SolverConcurrencyTest {
 
@@ -213,10 +216,11 @@ public class SolverConcurrencyTest {
   @Test
   public void testConcurrentOptimization() {
     requireOptimization();
-    assume()
-        .withMessage("Solver does support optimization, but is not yet reentrant.")
+
+    assume().withMessage("Solver does support optimization, but is not yet reentrant.")
         .that(solver)
         .isNotEqualTo(Solvers.MATHSAT5);
+
     assertConcurrency(
         "testConcurrentOptimization",
         () -> {
@@ -308,7 +312,7 @@ public class SolverConcurrencyTest {
     }
   }
 
-  // TODO: make proper "long" test
+  // As optimization is not used much at the moment this small test is ok
   private void optimizationTest(SolverContext context)
       throws InterruptedException, SolverException {
     FormulaManager mgr = context.getFormulaManager();
@@ -379,7 +383,6 @@ public class SolverConcurrencyTest {
     }
   }
 
-  // TODO: make a Collection of used contexts and end them with annotation after
   private void closeSolver(SolverContext context) {
     if (context != null) {
       context.close();


### PR DESCRIPTION
This branch is by no means done!

I just wanted a first impression of @kfriedberger concerning the complexity and because i break with our test paradigm quite a bit.

Main idea is to test SolverContext concurrency with pre-made contexts (each thread gets a single unique context that exists to work concurrenlty), each thread creating its own SolverContext and work concurrently, test parallel optimization (we need to recompile OptimathSAT for that) and test parallel stack usage in a single context.

The main reason for not using `SolverBasedTest0` is that control of the creation and closing of SolverContexts is needed.
Methods `initSolver `and `closeSolver`.

I tried to start the threads of a test as synchronous as possible and wait for all of them to finish before continuing, providing maximum concurrency (especially while creating new contexts as i read that that may be problematic in some solvers!)
There is a timeout that filters possible problems like deadlocks or long computation times and all exceptions are saved and will be returned to be checked.
See the method `assertConcurrency()` for that.

`bvConcurrencyTest()` and `intConcurrencyTest` (should be renamed or simply merged with the test) are just split from the tests because they would seem a little massive. 

The optimization test is just a plain copy at the moment that will be reworked.

Tests for concurrent stack use will be added next.

(I tested a very naive, different version first, extending the JUnit parallel test class. I could reuse `SolverBasedTest0` in that, had to sacrifice any control however and we would have to repeat every test x amount of times, x being the number of threads wanted, and pray that nothing bad happens that throws everything off. I didn't like that.)

Input is very appreciated.

(I have seen the compile problems/errors/checks etc. and will address them in the next few days)