### PR TITLE
Improve the process of releasing into Maven repository

### DIFF
--- a/build/build-maven-publish.xml
+++ b/build/build-maven-publish.xml
@@ -88,14 +88,14 @@ SPDX-License-Identifier: Apache-2.0
     <macrodef name="stage-solver-file">
       <attribute name="filename"/>
       <attribute name="fileending"/>
-      <attribute name="filedirectory" default="java/runtime-${stage.solver}"/>
+      <attribute name="filedirectory" default="lib/java/runtime-${stage.solver}"/>
       <sequential>
         <artifact:mvn>
           <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
           <arg value="-Durl=${ossrh-staging-repository-url}" />
           <arg value="-DrepositoryId=${ossrh-server-id}" />
           <arg value="-DpomFile=solvers_maven_conf/maven_${stage.solver}_pom.xml" />
-          <arg value="-Dfile=lib/@{filedirectory}/@{filename}.@{fileending}" />
+          <arg value="-Dfile=@{filedirectory}/@{filename}.@{fileending}" />
           <arg value="-Dclassifier=@{filename}" />
           <arg value="-Dpackaging=@{fileending}" />
           <arg value="-Dversion=${stage.revision}" />

--- a/build/build-maven-publish.xml
+++ b/build/build-maven-publish.xml
@@ -71,16 +71,18 @@ SPDX-License-Identifier: Apache-2.0
          (push into the staging area, from there manual publication is required afterwards) -->
     <macrodef name="stage-solver-file">
       <attribute name="filename"/>
+      <attribute name="classifier" default="@{filename}"/>
       <attribute name="fileending"/>
       <attribute name="filedirectory" default="lib/java/runtime-${stage.solver}"/>
+      <attribute name="pomFile" default="solvers_maven_conf/maven_${stage.solver}_pom.xml"/>
       <sequential>
         <artifact:mvn>
           <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
           <arg value="-Durl=${ossrh-staging-repository-url}" />
           <arg value="-DrepositoryId=${ossrh-server-id}" />
-          <arg value="-DpomFile=solvers_maven_conf/maven_${stage.solver}_pom.xml" />
+          <arg value="-DpomFile=@{pomFile}" />
           <arg value="-Dfile=@{filedirectory}/@{filename}.@{fileending}" />
-          <arg value="-Dclassifier=@{filename}" />
+          <arg value="-Dclassifier=@{classifier}" />
           <arg value="-Dpackaging=@{fileending}" />
           <arg value="-Dversion=${stage.revision}" />
           <arg value="-DgeneratePom=false" />
@@ -141,5 +143,34 @@ SPDX-License-Identifier: Apache-2.0
         <stage-solver-file filename="libcvc4" fileending="so"/>
         <stage-solver-file filename="libcvc4jni" fileending="so"/>
         <stage-solver-file filename="libcvc4parser" fileending="so"/>
+    </target>
+
+    <!--
+    Yices2 consists of two parts:
+     - we release our JavaSMT-based bindings for Yices2.
+     - we release our Yices2 itself.
+    We do currently not track any dependency within Maven, but rely on the developer to provide them,
+    i.e., by including both packages in a proper JavaSMT deployment.
+    -->
+    <target name="stage-javasmt-yices2" depends="build-dependencies, install-contrib"
+            description="deploy current version of Yices2 to Maven staging repository">
+        <!-- get revision from dependencies -->
+        <ivy:artifactproperty name="[artifact].revision" value="[revision]"/>
+        <property name="stage.solver" value="yices2"/> <!-- <==unused -->
+        <property name="stage.revision" value="${javasmt-yices2.revision}"/>
+        <!-- then publish the files -->
+        <stage-solver-file filename="javasmt-yices2" fileending="jar" classifier="sources"
+            pomFile="solvers_maven_conf/maven_javasmt_yices2_pom.xml"/>
+        <stage-solver-file filename="javasmt-yices2-sources" fileending="jar" classifier="sources"
+            pomFile="solvers_maven_conf/maven_javasmt_yices2_pom.xml" filedirectory="lib/java-contrib"/>
+    </target>
+    <target name="stage-yices2" depends="build-dependencies"
+            description="deploy current version of Yices2 to Maven staging repository">
+        <!-- get revision from dependencies -->
+        <ivy:artifactproperty name="[artifact].revision" value="[revision]"/>
+        <property name="stage.solver" value="yices2"/>
+        <property name="stage.revision" value="${libyices2j.revision}"/>
+        <!-- then publish the file -->
+        <stage-solver-file filename="libyices2j" fileending="so"/>
     </target>
 </project>

--- a/build/build-maven-publish.xml
+++ b/build/build-maven-publish.xml
@@ -49,39 +49,35 @@ SPDX-License-Identifier: Apache-2.0
 
     <!-- before this, update project version (both build.xml and pom.xml) from SNAPSHOT to RELEASE -->
     <target name="stage" depends="dist, gen-pom, jar, sources" description="deploy release version to Maven staging repository">
-
-        <!-- Sign and deploy the main artifact. -->
-        <artifact:mvn>
-            <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
-            <arg value="-Durl=${ossrh-staging-repository-url}" />
-            <arg value="-DrepositoryId=${ossrh-server-id}" />
-            <arg value="-DpomFile=pom.xml" />
-            <arg value="-Dfile=${jar.file}" />
-            <arg value="-Pgpg" />
-        </artifact:mvn>
-
-        <!-- Sign and deploy the sources artifact -->
-        <artifact:mvn>
-            <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
-            <arg value="-Durl=${ossrh-staging-repository-url}" />
-            <arg value="-DrepositoryId=${ossrh-server-id}" />
-            <arg value="-DpomFile=pom.xml" />
-            <arg value="-Dfile=${ivy.module}-${version}-sources.jar" />
-            <arg value="-Dclassifier=sources" />
-            <arg value="-Pgpg" />
-        </artifact:mvn>
-
-        <!-- sign and deploy the javadoc artifact -->
-        <artifact:mvn>
-            <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
-            <arg value="-Durl=${ossrh-staging-repository-url}" />
-            <arg value="-DrepositoryId=${ossrh-server-id}" />
-            <arg value="-DpomFile=pom.xml" />
-            <arg value="-Dfile=${ivy.module}-${version}-javadoc.jar" />
-            <arg value="-Dclassifier=javadoc" />
-            <arg value="-Pgpg" />
-        </artifact:mvn>
+		<fail message="unexpected filename of jar">
+			<condition> <!-- see property in build-jar.xml -->
+                <not><equals arg1="${jar.file}" arg2="${ivy.module}-${version}.jar"/></not>
+            </condition>
+        </fail>
+        <stage-javasmt-file filename="${ivy.module}-${version}" fileending="jar"/>
+        <stage-javasmt-file filename="${ivy.module}-${version}-sources" fileending="jar" classifier="sources"/>
+        <stage-javasmt-file filename="${ivy.module}-${version}-javadoc" fileending="jar" classifier="javadoc"/>
     </target>
+
+    <!-- macro for pushing a JavaSMT file into a Maven repository
+         (push into the staging area, from there manual publication is required afterwards) -->
+    <macrodef name="stage-javasmt-file">
+      <attribute name="filename"/>
+      <attribute name="fileending"/>
+      <attribute name="filedirectory" default="."/>
+      <attribute name="classifier" default=""/>
+      <sequential>
+        <artifact:mvn>
+          <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
+          <arg value="-Durl=${ossrh-staging-repository-url}" />
+          <arg value="-DrepositoryId=${ossrh-server-id}" />
+          <arg value="-DpomFile=pom.xml" />
+          <arg value="-Dfile=@{filedirectory}/@{filename}.@{fileending}" />
+          <arg value="-Dclassifier=@{classifier}" />
+          <arg value="-Pgpg" />
+        </artifact:mvn>
+      </sequential>
+    </macrodef>
 
     <!-- macro for pushing solvers into a Maven repository
          (push into the staging area, from there manual publication is required afterwards) -->

--- a/build/build-maven-publish.xml
+++ b/build/build-maven-publish.xml
@@ -159,7 +159,7 @@ SPDX-License-Identifier: Apache-2.0
         <property name="stage.solver" value="yices2"/> <!-- <==unused -->
         <property name="stage.revision" value="${javasmt-yices2.revision}"/>
         <!-- then publish the files -->
-        <stage-solver-file filename="javasmt-yices2" fileending="jar" classifier="sources"
+        <stage-solver-file filename="javasmt-yices2" fileending="jar" classifier=""
             pomFile="solvers_maven_conf/maven_javasmt_yices2_pom.xml"/>
         <stage-solver-file filename="javasmt-yices2-sources" fileending="jar" classifier="sources"
             pomFile="solvers_maven_conf/maven_javasmt_yices2_pom.xml" filedirectory="lib/java-contrib"/>

--- a/build/build-maven-publish.xml
+++ b/build/build-maven-publish.xml
@@ -35,19 +35,7 @@ SPDX-License-Identifier: Apache-2.0
         </replace>
     </target>
 
-    <target name="deploy-to-maven-central" depends="dist, gen-pom, jar"
-        description="deploy snapshot version to Maven snapshot repository">
-
-        <artifact:mvn>
-            <arg value="org.apache.maven.plugins:maven-deploy-plugin:2.6:deploy-file" />
-            <arg value="-Durl=${ossrh-snapshots-repository-url}" />
-            <arg value="-DrepositoryId=${ossrh-server-id}" />
-            <arg value="-DpomFile=pom.xml" />
-            <arg value="-Dfile=${jar.file}" />
-        </artifact:mvn>
-    </target>
-
-    <!-- before this, update project version (both build.xml and pom.xml) from SNAPSHOT to RELEASE -->
+    <!-- before this, please check that the project version is set correctly! -->
     <target name="stage" depends="dist, gen-pom, jar, sources" description="deploy release version to Maven staging repository">
 		<fail message="unexpected filename of jar">
 			<condition> <!-- see property in build-jar.xml -->

--- a/doc/Developers-How-to-Release-into-Ivy.md
+++ b/doc/Developers-How-to-Release-into-Ivy.md
@@ -1,0 +1,197 @@
+<!--
+This file is part of JavaSMT,
+an API wrapper for a collection of SMT solvers:
+https://github.com/sosy-lab/java-smt
+
+SPDX-FileCopyrightText: 2021 Dirk Beyer <https://www.sosy-lab.org>
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Release JavaSMT or Solver Binaries to Ivy
+
+Please read the hints on release in the [developer documentation](Developers.md) first.
+
+## Releasing JavaSMT
+
+If you have write permission to the [Ivy Repository][] you can perform the release as follows:
+
+ - Symlink the `repository` folder in the JavaSMT to the root of the SVN checkout of the Ivy repository.
+ - Run the `publish` ANT task and inspect the files for correctness and completeness!
+ - Manually perform the commit in SVN.
+
+
+## Releasing Solvers
+
+Before actually releasing a new version of a solver into the public world,
+make sure, it is tested sufficiently.
+This is one of the most critical steps in JavaSMT development.
+
+
+### Publishing Princess and SMTInterpol
+
+By default, Java-based solvers are copied over from Maven Central.
+Please execute the following in the root directory of the [Ivy Repository][]:
+
+- ant install -Dorganisation=io.github.uuverifiers -Dmodule=princess_2.13 -Drevision=????-??-??
+- ant install -Dorganisation=de.uni-freiburg.informatik.ultimate -Dmodule=smtinterpol -Drevision=?.?-???-g???????
+
+Potentially outdated:
+For manually uploading a Java-based solver to the [Ivy Repository][],
+there are scripts for publishing available at the root of the [Ivy Repository](https://svn.sosy-lab.org/software/ivy).
+
+
+### Publishing Z3
+
+We prefer to use the official Z3 binaries,
+please build from source only if necessary (e.g., in case of an important bugfix).
+
+To publish Z3, download the **Ubuntu 16.04**, **Windows**, and **OSX** binary
+and the sources (for JavaDoc) for the [latest release](https://github.com/Z3Prover/z3/releases) and unzip them.
+In the unpacked sources directory, prepare Java sources via `python scripts/mk_make.py --java`.
+For simpler handling, we then copy the files from the three `bin` directories together into one directory,
+and include the sources (we can keep the internal structure of each directory, just copy them above each other).
+Then execute the following command in the JavaSMT directory,
+where `$Z3_DIR` is the absolute path of the unpacked Z3 directory
+and `$Z3_VERSION` is the version number:
+```
+ant publish-z3 -Dz3.path=$Z3_DIR/bin -Dz3.version=$Z3_VERSION
+```
+Finally follow the instructions shown in the message at the end.
+
+#### Optional
+To publish Z3 from source, [download it](https://github.com/Z3Prover/z3) and build
+it with the following command in its directory on a 64bit Ubuntu 16.04 system:
+```
+./configure --staticlib --java --git-describe && cd build && make -j 2
+```
+(Note that additional binaries for other operating systems need to be provided, too.
+This step is currently not fully tested from our side.)
+Then execute the following command in the JavaSMT directory, where `$Z3_DIR` is the absolute path of the Z3 directory:
+```
+ant publish-z3 -Dz3.path=$Z3_DIR/build
+```
+Finally follow the instructions shown in the message at the end.
+
+
+### Publishing CVC4
+
+We prefer to use our own CVC4 binaries and Java bindings.
+
+To publish CVC4, checkout the [CVC4 repository](https://github.com/kfriedberger/CVC4).
+Then execute the following command in the JavaSMT directory,
+where `$CVC4_DIR` is the path to the CVC4 directory
+and `$CVC4_VERSION` is the version number:
+```
+ant publish-cvc4 -Dcvc4.path=$CVC4_DIR -Dcvc4.customRev=$CVC4_VERSION
+```
+Example:
+```
+ant publish-cvc4 -Dcvc4.path=../CVC4 -Dcvc4.customRev=1.8-prerelease-2019-10-05
+```
+Finally follow the instructions shown in the message at the end.
+
+
+### Publishing Boolector
+
+We prefer to use our own Boolector binaries and Java bindings.
+Boolector's dependencies, mainly Minisat, requires GCC version 7 and does not yet compile with newer compilers.
+We prefer to directly build diretly on Ubuntu 18.04, where gcc-7 is the default compiler.
+It should also be possible to set environment varables like CC=gcc-7 on newer systems.
+
+To publish Boolector, checkout the [Boolector repository](https://github.com/Boolector/boolector).
+Then execute the following command in the JavaSMT directory,
+where `$BTOR_DIR` is the path to the Boolector directory
+and `$BTOR_VERSION` is the version number:
+```
+CC=gcc-7 ant publish-boolector -Dboolector.path=$BTOR_DIR -Dboolector.customRev=$BTOR_VERSION
+```
+Example:
+```
+ant publish-boolector -Dboolector.path=../boolector -Dboolector.customRev=3.0.0-2019-11-29
+```
+Finally follow the instructions shown in the message at the end.
+
+
+### Publishing (Opti)-MathSAT5
+
+We publish MathSAT for both Linux and Windows systems at once.
+The build process can fully be done on a Linux system.
+
+For publishing MathSAT5, you need to use a Linux machine with at least GCC 7.5.0 and x86_64-w64-mingw32-gcc 7.3.
+First, [download the (reentrant!) Linux and Windows64 binary release](http://mathsat.fbk.eu/download.html) in the same version, unpack them,
+then provide the necessary dependencies (GMP for Linux and MPIR/JDK for Windows) as described in the compilation scripts.
+(see `lib/native/source/libmathsat5j/`), and then execute the following command in the JavaSMT directory,
+where `$MATHSAT_PATH_LINUX` and `$MATHSAT_PATH_WINDOWS` are the paths to the MathSAT root directory,
+and `$MATHSAT_VERSION` is the version number of MathSAT (all-in-one, runtime: less than 5s):
+```
+  ant publish-mathsat \
+      -Dmathsat.path=$MATHSAT_PATH_LINUX \
+      -Dgmp.path=$GMP_PATH \
+      -Dmathsat-windows.path=$MATHSAT_PATH_WINDOWS \
+      -Dmpir-windows.path=$MPIR_PATH \
+      -Djdk-windows.path=$JDK_11_PATH \
+      -Dmathsat.version=$MATHSAT_VERSION
+```
+Concrete example (`$WD` is a working directory where all dependencies are located):
+```
+  ant publish-mathsat \
+      -Dmathsat.path=$WD/mathsat-5.6.4-linux-x86_64-reentrant \
+      -Dgmp.path=$WD/gmp-6.1.2 \
+      -Dmathsat-windows.path=$WD/mathsat-5.6.4-win64-msvc \
+      -Dmpir-windows.path=$WD/mpir-2.7.2-win \
+      -Djdk-windows.path=$WD/jdk-11 \
+      -Dmathsat.version=5.6.4-debug
+```
+Finally follow the instructions shown in the message at the end.
+
+A similar procedure applies to [OptiMathSAT](http://optimathsat.disi.unitn.it/) solver,
+except that Windows is not yet supported and the publishing command is simpler:
+```
+ant publish-optimathsat -Dmathsat.path=$OPTIMATHSAT_PATH -Dgmp.path=$GMP_PATH -Dmathsat.version=$OPTIMATHSAT_VERSION
+```
+
+
+### Publishing Yices2
+
+Yices2 consists of two components: the solver binary and the Java components in JavaSMT.
+The Java components were splitt from the rest of JavaSMT because of the GPL.
+
+#### Publishing the solver binary for Yices2
+
+Prepare gperf and gmp (required for our own static binary):
+```
+wget http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz && tar -zxvf gperf-3.1.tar.gz && cd gperf-3.1 && ./configure --enable-cxx --with-pic --disable-shared --enable-fat && make
+wget https://gmplib.org/download/gmp/gmp-6.2.0.tar.xz && tar -xvf gmp-6.2.0.tar.xz && cd gmp-6.2.0 && ./configure --enable-cxx --with-pic --disable-shared --enable-fat && make
+```
+
+Download and build Yices2 from source:
+```
+git clone git@github.com:SRI-CSL/yices2.git && cd yices2 && autoconf && ./configure --with-pic-gmp=../gmp-6.2.0/.libs/libgmp.a && make
+```
+
+Get the version of Yices2:
+```
+git describe --tags
+```
+
+Publish the solver binary from within JavaSMT (adjust all paths to your system!):
+```
+ant publish-yices2 -Dyices2.path=../solver/yices2 -Dgmp.path=../solver/gmp-6.2.0 -Dgperf.path=../solver/gperf-3.1 -Dyices2.version=2.6.2-89-g0f77dc4b
+```
+
+Afterwards you need to update the version number in `solvers_ivy_conf/ivy_javasmt_yices2.xml` and publish new Java components for Yices2.
+
+#### Publish the Java components for Yices2
+
+Info: There is a small cyclic dependency: JavaSMT itself depends on the Java components of Yices2.
+
+As long as no API was changed and compilation suceeds, simply execute `ant publish-artifacts-yices2`.
+
+If the API was changed, we need to break the dependency cycle for the publication and revert this later:
+edit `lib/ivy.xml` and replace the dependency towards `javasmt-yices2` with the dependency towards `javasmt-solver-yices2`
+(the line can be copied from `solvers_ivy_conf/ivy_javasmt_yices2.xml`).
+Then run `ant publish-artifact-yices2`.
+We still need to figure out how to avoid the warning about a dirty repository in that case, e.g. by a temporary commit.
+
+[Ivy Repository]: http://www.sosy-lab.org/ivy/org.sosy_lab/

--- a/doc/Developers-How-to-Release-into-Maven.md
+++ b/doc/Developers-How-to-Release-into-Maven.md
@@ -1,0 +1,101 @@
+<!--
+This file is part of JavaSMT,
+an API wrapper for a collection of SMT solvers:
+https://github.com/sosy-lab/java-smt
+
+SPDX-FileCopyrightText: 2021 Dirk Beyer <https://www.sosy-lab.org>
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Release JavaSMT or Solver Binaries to Maven Central
+
+Please read the hints on release in the [developer documentation](Developers.md) first.
+
+We only release something to Maven after doing an Ivy release.
+With our project infrastructure is much simpler to test packages from (local) Ivy repository than from Maven.
+
+Make sure that all necessary dependency libraries are already released on Maven Central,
+before (or at least while) publishing a new version of JavaSMT.
+Maven does not check for existing or non-existing dependencies automatically.
+Dependencies like `SMTIntinterpol`, `Princess`, and `SoSy-Lab Common` need to be available via Maven in the correct version.
+A release of `SoSy-Lab Common` can be uploaded to Maven by us, even afterwards :-).
+
+
+## Automation vs. Manual Steps
+
+The release to Maven Central is currently not fully automated due to the bug in the
+ANT script provided by Maven Central documentation.
+For publishing to Maven Central, we use the [Nexus Repository Manager][].
+We first upload files into that repository, and later manually publish them from there.
+There is no need to manually change any file for the upload process.
+
+
+## Requirements
+
+Please make sure that you have a valid user account and configured your local settings accordingly.
+For example, insert the following content into `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>USER</username>
+      <password>PASSWORD</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>gpg</id>
+      <properties>
+        <gpg.executable>gpg</gpg.executable>
+        <!-- optional <gpg.passphrase>PASSPHRASE</gpg.passphrase> -->
+      </properties>
+    </profile>
+  </profiles>
+  <mirrors>
+    <mirror>
+      <id>centralhttps</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven central https</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </mirror>
+  </mirrors>
+</settings>
+```
+
+If default system settings are not configured for HTTPS,
+we get an 501 error when downloading further maven dependencies.
+Thus, we add a mirror for HTTPS.
+
+You might need to store `maven-ant-tasks-2.1.3.jar` (or newer version) under `~/.ant/lib/`
+to avoid a failure when creating the task `antlib:org.apache.maven.artifact.ant:mvn`.
+
+
+## Publishing
+
+For publishing JavaSMT itself:
+- Execute `ant stage` to upload the local build of JavaSMT into the [Nexus Repository Manager][].
+  This is ideally done directly after an release to our [Ivy Repository][].
+- Login to the [Nexus Repository Manager][] and freeze (`close`) the entry in the [staging repositories][],
+  and inspect the files for correctness and completeness!
+- Later `release` your staged bundle.
+  After some delay (a few hours) the release is automatically synced to Maven Central.
+
+For publishing binary solvers like Boolector, CVC4, MathSAT5, or Z3, the process is similar:
+- Execute `ant stage-SOLVER` to upload the currently installed binary solvers into the [Nexus Repository Manager]
+  whenever there was an update for the corresponding solver.
+  This is ideally done directly after an release of the solver to our [Ivy Repository][].
+- Login to the [Nexus Repository Manager][] and freeze (`close`) the entry in the [staging repositories][],
+  and inspect the files for correctness and completeness!
+- Later `release` your staged bundle.
+  After some delay (a few hours) the release is automatically synced to Maven Central.
+
+Additional instructions are available at the official [OSSRH][] page and
+the [documentation](http://central.sonatype.org/pages/releasing-the-deployment.html).
+
+[Ivy Repository]: http://www.sosy-lab.org/ivy/org.sosy_lab/
+[OSSRH]: http://central.sonatype.org/pages/ossrh-guide.html
+[Nexus Repository Manager]: https://oss.sonatype.org/
+[staging repositories]: https://oss.sonatype.org/#stagingRepositories

--- a/doc/Developers-How-to-Release-into-Maven.md
+++ b/doc/Developers-How-to-Release-into-Maven.md
@@ -83,10 +83,11 @@ For publishing JavaSMT itself:
 - Later `release` your staged bundle.
   After some delay (a few hours) the release is automatically synced to Maven Central.
 
-For publishing binary solvers like Boolector, CVC4, MathSAT5, or Z3, the process is similar:
+For publishing binary solvers like Boolector, CVC4, MathSAT5, Yices2, or Z3, the process is similar:
 - Execute `ant stage-SOLVER` to upload the currently installed binary solvers into the [Nexus Repository Manager]
   whenever there was an update for the corresponding solver.
   This is ideally done directly after an release of the solver to our [Ivy Repository][].
+  For Yices2, we might require the execution of `ant stage-javasmt-yices2` to release the package `javasmt-yices2`.
 - Login to the [Nexus Repository Manager][] and freeze (`close`) the entry in the [staging repositories][],
   and inspect the files for correctness and completeness!
 - Later `release` your staged bundle.

--- a/doc/Developers.md
+++ b/doc/Developers.md
@@ -3,12 +3,17 @@ This file is part of JavaSMT,
 an API wrapper for a collection of SMT solvers:
 https://github.com/sosy-lab/java-smt
 
-SPDX-FileCopyrightText: 2020 Dirk Beyer <https://www.sosy-lab.org>
+SPDX-FileCopyrightText: 2021 Dirk Beyer <https://www.sosy-lab.org>
 
 SPDX-License-Identifier: Apache-2.0
 -->
 
 # JavaSMT Developers Documentation
+
+This file contains hints and documentation for developers,
+i.e., for developing JavaSMT, adding code, integrating or updating SMT solvers,
+and releasing JavaSMT into a public repository.
+
 
 ## Style Guide
 
@@ -23,270 +28,39 @@ Additionally, refer to the CPAchecker
 [style guide](https://github.com/sosy-lab/cpachecker/blob/trunk/doc/StyleGuide.txt)
 for more information.
 
+
 ## Continuous Integration
 
-We rely on [GitLab-CI][] for continuous integration, which picks up code style violations,
+We rely on [GitLab-CI](https://gitlab.com/sosy-lab/software/java-smt/pipelines)
+for continuous integration, which picks up code style violations,
 compile warnings for both ECJ and javac (for several versions of Java),
 [SpotBugs](https://github.com/spotbugs/spotbugs) errors,...
 
+
 ## Releasing JavaSMT
 
-Currently, releases are pushed to two software repositories:
-[Ivy Repository][] and
-[Maven Central](http://search.maven.org/).
+Currently, releases are pushed to two software repositories,
+and there is seperate documentation for uploading packages into those repositories:
+- [Ivy Repository](http://www.sosy-lab.org/ivy/org.sosy_lab/):
+  see [Developers-How-to-Release-into-Ivy](Developers-How-to-Release-into-Ivy.md)
+- [Maven Central](http://search.maven.org/):
+  see [Developers-How-to-Release-into-Maven.md](Developers-How-to-Release-into-Maven.md).
+
 The release version number is derived from the `git describe` command,
 which output is either a git tag (if the release version corresponds exactly
 to the tagged commit), or a latest git tag together with a distance measured
 in number of commits and a git hash corresponding to the current revision.
 
+
 ### Creating new release numbers
 
-New JavaSMT version is defined by creating a new git tag with a version number.
+A new JavaSMT version is defined by creating a new git tag with a version number.
 Git tags should be signed (`git tag -s` command).
 When creating a new version number, populate the `CHANGELOG.md` file with the
 changes which are exposed by the new release.
 
-[Semantic versioning][] guidelines should be followed when defining a new
+[Semantic versioning](http://semver.org/) guidelines should be followed when defining a new
 version.
-
-### Release to Ivy
-
-If you have write permission to the [Ivy Repository][] you can perform the
-release as follows:
-
- - Symlink the `repository` folder in the JavaSMT to the root of the SVN
-    checkout of the Ivy repository.
- - Run the `publish` ANT task.
- - Manually perform the commit in SVN.
-
-### Release to Maven Central
-
-Release to Maven Central is currently not fully automated due to the bug in the
-ANT script provided by Maven Central documentation.
-For publishing to Maven Central, we use the [Nexus Repository Manager](https://oss.sonatype.org/).
-
-#### Requirements
-
-Please make sure that all necessary libraries are already released on Maven Central,
-before (or at least while) publishing a new version of JavaSMT.
-Maven does not check for existing dependencies automatically.
-
-Please make sure that you have a valid user account and configured your local settings accordingly.
-For example, insert the following content into `~/.m2/settings.xml`:
-```xml
-<settings>
-  <servers>
-    <server>
-      <id>ossrh</id>
-      <username>USER</username>
-      <password>PASSWORD</password>
-    </server>
-  </servers>
-  <profiles>
-    <profile>
-      <id>gpg</id>
-      <properties>
-        <gpg.executable>gpg</gpg.executable>
-        <!-- optional <gpg.passphrase>PASSPHRASE</gpg.passphrase> -->
-      </properties>
-    </profile>
-  </profiles>
-  <mirrors>
-    <mirror>
-      <id>centralhttps</id>
-      <mirrorOf>central</mirrorOf>
-      <name>Maven central https</name>
-      <url>https://repo1.maven.org/maven2/</url>
-    </mirror>
-  </mirrors>
-</settings>
-```
-
-If default system settings are not configured for HTTPS,
-we get an 501 error when downloading further maven dependencies.
-Thus, we add a mirror for HTTPS.
-
-You might need to store `maven-ant-tasks-2.1.3.jar` (or newer version) under `~/.ant/lib/`
-to avoid a failure when creating the task `antlib:org.apache.maven.artifact.ant:mvn`.
-
-#### Publishing
-
-The following steps are required:
-
- - Run the `stage` ANT target.
-   (There is currently no need to change any label from `SNAPSHOT` to `RELEASE` or vice versa,
-   as written somewhere in the documentation, because we only produce `RELEASE` versions.)
- - Login to [Nexus Repository Manager](https://oss.sonatype.org/)
-   and open the [list of staging repositories](https://oss.sonatype.org/#stagingRepositories).
- - Run `close` and `release` tasks on your pushed bundle
-   (see [documentation](http://central.sonatype.org/pages/releasing-the-deployment.html) for details).
- - After some delay (a few hours or days) the release is automatically synced to Maven Central.
-
-Additional instructions are available at the official [OSSRH][] page.
-
-## Releasing Solvers
-
-Before actually releasing a new version of a solver into the public world,
-make sure, it is tested sufficiently.
-This is one of the most critical steps in JavaSMT development.
-
-
-### Publishing Z3
-
-We prefer to use the official Z3 binaries,
-please build from source only if necessary (e.g., in case of an important bugfix).
-
-To publish Z3, download the **Ubuntu 16.04**, **Windows**, and **OSX** binary
-and the sources (for JavaDoc) for the [latest release](https://github.com/Z3Prover/z3/releases) and unzip them.
-In the unpacked sources directory, prepare Java sources via `python scripts/mk_make.py --java`.
-For simpler handling, we then copy the files from the three `bin` directories together into one directory,
-and include the sources (we can keep the internal structure of each directory, just copy them above each other).
-Then execute the following command in the JavaSMT directory,
-where `$Z3_DIR` is the absolute path of the unpacked Z3 directory
-and `$Z3_VERSION` is the version number:
-```
-ant publish-z3 -Dz3.path=$Z3_DIR/bin -Dz3.version=$Z3_VERSION
-```
-Finally follow the instructions shown in the message at the end.
-
-To publish Z3 from source, [download it](https://github.com/Z3Prover/z3) and build
-it with the following command in its directory on a 64bit Ubuntu 16.04 system:
-```
-./configure --staticlib --java --git-describe && cd build && make -j 2
-```
-(Note that additional binaries for other operating systems need to be provided, too.
-This step is currently not fully tested from our side.)
-Then execute the following command in the JavaSMT directory, where `$Z3_DIR` is the absolute path of the Z3 directory:
-```
-ant publish-z3 -Dz3.path=$Z3_DIR/build
-```
-Finally follow the instructions shown in the message at the end.
-
-
-### Publishing CVC4
-
-We prefer to use our own CVC4 binaries and Java bindings.
-
-To publish CVC4, checkout the [CVC4 repository](https://github.com/kfriedberger/CVC4).
-Then execute the following command in the JavaSMT directory,
-where `$CVC4_DIR` is the path to the CVC4 directory
-and `$CVC4_VERSION` is the version number:
-```
-ant publish-cvc4 -Dcvc4.path=$CVC4_DIR -Dcvc4.customRev=$CVC4_VERSION
-```
-Example:
-```
-ant publish-cvc4 -Dcvc4.path=../CVC4 -Dcvc4.customRev=1.8-prerelease-2019-10-05
-```
-Finally follow the instructions shown in the message at the end.
-
-
-### Publishing Boolector
-
-We prefer to use our own Boolector binaries and Java bindings.
-Boolector's dependencies, mainly Minisat, requires GCC version 7 and does not yet compile with newer compilers.
-We prefer to directly build diretly on Ubuntu 18.04, where gcc-7 is the default compiler.
-It should also be possible to set environment varables like CC=gcc-7 on newer systems.
-
-To publish Boolector, checkout the [Boolector repository](https://github.com/Boolector/boolector).
-Then execute the following command in the JavaSMT directory,
-where `$BTOR_DIR` is the path to the Boolector directory
-and `$BTOR_VERSION` is the version number:
-```
-CC=gcc-7 ant publish-boolector -Dboolector.path=$BTOR_DIR -Dboolector.customRev=$BTOR_VERSION
-```
-Example:
-```
-ant publish-boolector -Dboolector.path=../boolector -Dboolector.customRev=3.0.0-2019-11-29
-```
-Finally follow the instructions shown in the message at the end.
-
-
-### Publishing (Opti)-MathSAT5
-
-We publish MathSAT for both Linux and Windows systems at once.
-The build process can fully be done on a Linux system.
-
-For publishing MathSAT5, you need to use a Linux machine with at least GCC 7.5.0 and x86_64-w64-mingw32-gcc 7.3.
-First, [download the (reentrant!) Linux and Windows64 binary release](http://mathsat.fbk.eu/download.html) in the same version, unpack them,
-then provide the necessary dependencies (GMP for Linux and MPIR/JDK for Windows) as described in the compilation scripts.
-(see `lib/native/source/libmathsat5j/`), and then execute the following command in the JavaSMT directory,
-where `$MATHSAT_PATH_LINUX` and `$MATHSAT_PATH_WINDOWS` are the paths to the MathSAT root directory,
-and `$MATHSAT_VERSION` is the version number of MathSAT (all-in-one, runtime: less than 5s):
-```
-  ant publish-mathsat \
-      -Dmathsat.path=$MATHSAT_PATH_LINUX \
-      -Dgmp.path=$GMP_PATH \
-      -Dmathsat-windows.path=$MATHSAT_PATH_WINDOWS \
-      -Dmpir-windows.path=$MPIR_PATH \
-      -Djdk-windows.path=$JDK_11_PATH \
-      -Dmathsat.version=$MATHSAT_VERSION
-```
-Concrete example (`$WD` is a working directory where all dependencies are located):
-```
-  ant publish-mathsat \
-      -Dmathsat.path=$WD/mathsat-5.6.4-linux-x86_64-reentrant \
-      -Dgmp.path=$WD/gmp-6.1.2 \
-      -Dmathsat-windows.path=$WD/mathsat-5.6.4-win64-msvc \
-      -Dmpir-windows.path=$WD/mpir-2.7.2-win \
-      -Djdk-windows.path=$WD/jdk-11 \
-      -Dmathsat.version=5.6.4-debug
-```
-Finally follow the instructions shown in the message at the end.
-
-A similar procedure applies to [OptiMathSAT](http://optimathsat.disi.unitn.it/) solver,
-except that Windows is not yet supported and the publishing command is simpler:
-```
-ant publish-optimathsat -Dmathsat.path=$OPTIMATHSAT_PATH -Dgmp.path=$GMP_PATH -Dmathsat.version=$OPTIMATHSAT_VERSION
-```
-
-### Publishing Princess and SMTInterpol
-
-The scripts for publishing Princess and SMTInterpol are available
-at the root of the [Ivy Repository](https://svn.sosy-lab.org/software/ivy).
-
-
-### Publishing Yices2
-
-Yices2 consists of two components: the solver binary and the Java components in JavaSMT.
-The Java components were splitt from the rest of JavaSMT because of the GPL.
-
-#### Publishing the solver binary for Yices2
-
-Prepare gperf and gmp (required for our own static binary):
-```
-wget http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz && tar -zxvf gperf-3.1.tar.gz && cd gperf-3.1 && ./configure --enable-cxx --with-pic --disable-shared --enable-fat && make
-wget https://gmplib.org/download/gmp/gmp-6.2.0.tar.xz && tar -xvf gmp-6.2.0.tar.xz && cd gmp-6.2.0 && ./configure --enable-cxx --with-pic --disable-shared --enable-fat && make
-```
-
-Download and build Yices2 from source:
-```
-git clone git@github.com:SRI-CSL/yices2.git && cd yices2 && autoconf && ./configure --with-pic-gmp=../gmp-6.2.0/.libs/libgmp.a && make
-```
-
-Get the version of Yices2:
-```
-git describe --tags
-```
-
-Publish the solver binary from within JavaSMT (adjust all paths to your system!):
-```
-ant publish-yices2 -Dyices2.path=../solver/yices2 -Dgmp.path=../solver/gmp-6.2.0 -Dgperf.path=../solver/gperf-3.1 -Dyices2.version=2.6.2-89-g0f77dc4b
-```
-
-Afterwards you need to update the version number in `solvers_ivy_conf/ivy_javasmt_yices2.xml` and publish new Java components for Yices2.
-
-#### Publish the Java components for Yices2
-
-Info: There is a small cyclic dependency: JavaSMT itself depends on the Java components of Yices2.
-
-As long as no API was changed and compilation suceeds, simply execute `ant publish-artifacts-yices2`.
-
-If the API was changed, we need to break the dependency cycle for the publication and revert this later:
-edit `lib/ivy.xml` and replace the dependency towards `javasmt-yices2` with the dependency towards `javasmt-solver-yices2`
-(the line can be copied from `solvers_ivy_conf/ivy_javasmt_yices2.xml`).
-Then run `ant publish-artifact-yices2`.
-We still need to figure out how to avoid the warning about a dirty repository in that case, e.g. by a temporary commit.
 
 
 ## Writing Solver Backends
@@ -304,8 +78,3 @@ to include the new solver.
 The new solver can be added from outside of JavaSMT as well: in that case,
 the user might wish to have their own factory which can create
 a suitable `SolverContext`.
-
-[GitLab-CI]: https://gitlab.com/sosy-lab/software/java-smt/pipelines
-[Ivy Repository]: http://www.sosy-lab.org/ivy/org.sosy_lab/
-[OSSRH]: http://central.sonatype.org/pages/ossrh-guide.html
-[Semantic Versioning]: http://semver.org/

--- a/doc/Example-Maven-Project/pom.xml
+++ b/doc/Example-Maven-Project/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.sosy_lab.java_smt_example</groupId>
   <artifactId>java-smt-maven-example</artifactId>
-  <version>1.4</version>
+  <version>1.5</version>
   <name>java-smt-maven-example</name>
   <description>Example Maven project to show how to use JavaSMT with native solver libraries.</description>
   <url>https://github.com/sosy-lab/java-smt</url>
@@ -160,6 +160,21 @@ SPDX-License-Identifier: Apache-2.0
       <version>1.8-prerelease-2020-06-24-g7825d8f28</version>
       <type>so</type>
       <classifier>libcvc4parser</classifier>
+    </dependency>
+
+    <!-- Yices2 has two dependencies (on Linux) -->
+    <dependency>
+      <groupId>org.sosy-lab</groupId>
+      <artifactId>javasmt-yices2</artifactId>
+      <version>3.10.0</version> <!-- version of Yices2 bindings in JavaSMT -->
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.sosy-lab</groupId>
+      <artifactId>javasmt-solver-yices2</artifactId>
+      <version>2.6.2-396-g194350c1</version> <!-- version of Yices2 release -->
+      <type>so</type>
+      <classifier>libyices2j</classifier>
     </dependency>
 
     <!-- JUnit for testing -->
@@ -323,6 +338,15 @@ SPDX-License-Identifier: Apache-2.0
                 <destFileName>libcvc4parser.so</destFileName>
               </artifactItem>
 
+              <!-- Yices2 has two dependencies (on Linux),
+                   and renaming the JAR file is not required to be copied.-->
+              <artifactItem>
+                <groupId>org.sosy-lab</groupId>
+                <artifactId>javasmt-solver-yices2</artifactId>
+                <type>so</type>
+                <classifier>libyices2j</classifier>
+                <destFileName>libyices2j.so</destFileName>
+              </artifactItem>
             </artifactItems>
           </configuration>
       </plugin>

--- a/doc/Example-Maven-Web-Project/pom.xml
+++ b/doc/Example-Maven-Web-Project/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.sosy_lab.java_smt_web_example</groupId>
   <artifactId>java-smt-web-example</artifactId>
-  <version>1.4</version>
+  <version>1.5</version>
   <packaging>war</packaging>
 
   <name>java-smt-maven-web-example</name>
@@ -164,6 +164,21 @@ SPDX-License-Identifier: Apache-2.0
       <classifier>libcvc4parser</classifier>
     </dependency>
 
+    <!-- Yices2 has two dependencies (on Linux) -->
+    <dependency>
+      <groupId>org.sosy-lab</groupId>
+      <artifactId>javasmt-yices2</artifactId>
+      <version>3.10.0</version> <!-- version of Yices2 bindings in JavaSMT -->
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.sosy-lab</groupId>
+      <artifactId>javasmt-solver-yices2</artifactId>
+      <version>2.6.2-396-g194350c1</version> <!-- version of Yices2 release -->
+      <type>so</type>
+      <classifier>libyices2j</classifier>
+    </dependency>
+
     <!-- JUnit for testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -219,6 +234,7 @@ SPDX-License-Identifier: Apache-2.0
                             <include>libcvc4.so</include>
                             <include>libcvc4jni.so</include>
                             <include>libcvc4parser.so</include>
+                            <include>libyices2j.so</include>
                         </includes>
                         <targetPath>WEB-INF/lib</targetPath>
                     </resource>
@@ -362,6 +378,15 @@ SPDX-License-Identifier: Apache-2.0
                 <destFileName>libcvc4parser.so</destFileName>
               </artifactItem>
 
+              <!-- Yices2 has two dependencies (on Linux),
+                   and renaming the JAR file is not required to be copied.-->
+              <artifactItem>
+                <groupId>org.sosy-lab</groupId>
+                <artifactId>javasmt-solver-yices2</artifactId>
+                <type>so</type>
+                <classifier>libyices2j</classifier>
+                <destFileName>libyices2j.so</destFileName>
+              </artifactItem>
             </artifactItems>
           </configuration>
       </plugin>

--- a/lib/ivy.xml
+++ b/lib/ivy.xml
@@ -164,7 +164,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency org="org.sosy_lab" name="javasmt-solver-boolector" rev="3.2.1-30-g95859db8" conf="runtime-boolector->solver-boolector" />
 
         <!-- additional JavaSMT components with Solver Binaries -->
-        <dependency org="org.sosy_lab" name="javasmt-yices2" rev="3.6.0-27-g42532e0b" conf="runtime-yices2->runtime; contrib->sources" />
+        <dependency org="org.sosy_lab" name="javasmt-yices2" rev="3.10.0" conf="runtime-yices2->runtime; contrib->sources" />
         <!-- <dependency org="org.sosy_lab" name="javasmt-solver-yices2" rev="2.6.2-89-g0f77dc4b" conf="runtime-yices2->solver-yices2" /> -->
 
         <!-- Several JARs declare animal-sniffer-annotations.jar as dependency in their manifest although they do not really need it.

--- a/solvers_maven_conf/maven_javasmt_yices2_pom.xml
+++ b/solvers_maven_conf/maven_javasmt_yices2_pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+<!--
+This file is part of JavaSMT,
+an API wrapper for a collection of SMT solvers:
+https://github.com/sosy-lab/java-smt
+
+SPDX-FileCopyrightText: 2021 Dirk Beyer <https://www.sosy-lab.org>
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.sosy-lab</groupId>
+  <artifactId>javasmt-yices2</artifactId>
+  <packaging>pom</packaging>
+  <name>javasmt-yices2</name>
+  <description>JavaSMT bindings for the SMT solver Yices</description>
+  <url>https://github.com/sosy-lab/java-smt</url>
+
+  <licenses>
+      <license>
+          <name>Apache License, Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      </license>
+      <license>
+          <name>GPL v3</name>
+          <url>http://www.gnu.org/licenses/gpl-3.0.de.html</url>
+      </license>
+  </licenses>
+
+  <organization>
+      <name>Software Systems Lab</name>
+      <url>https://www.sosy-lab.org/</url>
+  </organization>
+
+  <scm>
+      <url>https://github.com/sosy-lab/java-smt/</url>
+      <connection>scm:git:git://github.com/sosy-lab/java-smt.git</connection>
+      <developerConnection>scm:git:git@github.com:sosy-lab/java-smt.git</developerConnection>
+  </scm>
+
+  <developers>
+      <developer>
+          <name>Karlheinz Friedberger</name>
+          <email>kfriedberger@gmail.com</email>
+          <organization>Software Systems Lab</organization>
+          <url>https://www.sosy-lab.org/people/friedberger/</url>
+          <roles>
+              <role>project maintainer</role>
+          </roles>
+      </developer>
+      <developer>
+          <name>Dirk Beyer</name>
+          <email>dirk.beyer@sosy-lab.org</email>
+          <url>https://www.sosy-lab.org/people/beyer/</url>
+          <organization>Software Systems Lab</organization>
+          <organizationUrl>http://www.sosy-lab.org/</organizationUrl>
+          <roles>
+              <role>project manager</role>
+          </roles>
+      </developer>
+  </developers>
+</project>
+

--- a/solvers_maven_conf/maven_yices2_pom.xml
+++ b/solvers_maven_conf/maven_yices2_pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+<!--
+This file is part of JavaSMT,
+an API wrapper for a collection of SMT solvers:
+https://github.com/sosy-lab/java-smt
+
+SPDX-FileCopyrightText: 2021 Dirk Beyer <https://www.sosy-lab.org>
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.sosy-lab</groupId>
+  <artifactId>javasmt-solver-yices2</artifactId>
+  <packaging>pom</packaging>
+  <name>javasmt-solver-yices2</name>
+  <description>SMT solver Yices for use in JavaSMT</description>
+  <url>https://github.com/sosy-lab/java-smt</url>
+
+  <licenses>
+      <license>
+          <name>Apache License, Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      </license>
+      <license>
+          <name>GPL v3</name>
+          <url>http://www.gnu.org/licenses/gpl-3.0.de.html</url>
+      </license>
+  </licenses>
+
+  <organization>
+      <name>Software Systems Lab</name>
+      <url>https://www.sosy-lab.org/</url>
+  </organization>
+
+  <scm>
+      <url>https://github.com/sosy-lab/java-smt/</url>
+      <connection>scm:git:git://github.com/sosy-lab/java-smt.git</connection>
+      <developerConnection>scm:git:git@github.com:sosy-lab/java-smt.git</developerConnection>
+  </scm>
+
+  <developers>
+      <developer>
+          <name>Karlheinz Friedberger</name>
+          <email>kfriedberger@gmail.com</email>
+          <organization>Software Systems Lab</organization>
+          <url>https://www.sosy-lab.org/people/friedberger/</url>
+          <roles>
+              <role>project maintainer</role>
+          </roles>
+      </developer>
+      <developer>
+          <name>Dirk Beyer</name>
+          <email>dirk.beyer@sosy-lab.org</email>
+          <url>https://www.sosy-lab.org/people/beyer/</url>
+          <organization>Software Systems Lab</organization>
+          <organizationUrl>http://www.sosy-lab.org/</organizationUrl>
+          <roles>
+              <role>project manager</role>
+          </roles>
+      </developer>
+  </developers>
+</project>
+


### PR DESCRIPTION
This PR simplifies the process of releasing into Maven repository.
We update the corresponding documentation.
And we take a look at releasing Yices2 to Maven (#221), too, as this is still missing for JavaSMT.