### PR TITLE
Update Boolector to version 3.2.2 with a build process via a new Docker image

### DIFF
--- a/docker/buildUbuntu1804.sh
+++ b/docker/buildUbuntu1804.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t devel:ubuntu1804 - < ubuntu1804.Dockerfile

--- a/docker/buildUbuntu1804.sh
+++ b/docker/buildUbuntu1804.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
+# This file is part of JavaSMT,
+# an API wrapper for a collection of SMT solvers:
+# https://github.com/sosy-lab/java-smt
+#
+# SPDX-FileCopyrightText: 2021 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 docker build -t devel:ubuntu1804 - < ubuntu1804.Dockerfile

--- a/docker/runUbuntu1804.sh
+++ b/docker/runUbuntu1804.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# This file is part of JavaSMT,
+# an API wrapper for a collection of SMT solvers:
+# https://github.com/sosy-lab/java-smt
+#
+# SPDX-FileCopyrightText: 2021 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # specific for my system:
 # JavaSMT and all solver files are located in the directory "workspace".
 WORKSPACE=$HOME/workspace

--- a/docker/runUbuntu1804.sh
+++ b/docker/runUbuntu1804.sh
@@ -6,5 +6,6 @@ WORKSPACE=$HOME/workspace
 
 docker run -it \
     --mount type=bind,source=${WORKSPACE},target=/workspace \
-    -u $(id -u ${USER}):$(id -g ${USER}) \
+    --workdir /workspace/java-smt \
+    --user $(id -u ${USER}):$(id -g ${USER}) \
     devel:ubuntu1804

--- a/docker/runUbuntu1804.sh
+++ b/docker/runUbuntu1804.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# specific for my system:
+# JavaSMT and all solver files are located in the directory "workspace".
+WORKSPACE=$HOME/workspace
+
+docker run -it \
+    --mount type=bind,source=${WORKSPACE},target=/workspace \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
+    devel:ubuntu1804

--- a/docker/ubuntu1804.Dockerfile
+++ b/docker/ubuntu1804.Dockerfile
@@ -1,3 +1,11 @@
+# This file is part of JavaSMT,
+# an API wrapper for a collection of SMT solvers:
+# https://github.com/sosy-lab/java-smt
+#
+# SPDX-FileCopyrightText: 2021 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM ubuntu:bionic
 
 RUN apt-get update \

--- a/docker/ubuntu1804.Dockerfile
+++ b/docker/ubuntu1804.Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:bionic
+
+RUN apt-get update \
+ && apt-get install -y \
+        wget curl git \
+        build-essential cmake patchelf \
+        openjdk-11-jdk ant maven \
+        mingw-w64 zlib1g-dev
+
+# Add the user "developer" with UID:1000, GID:1000, home at /developer.
+# This allows to map the docker-internal user to the local user 1000:1000 outside of the container.
+# This avoids to have new files created with root-rights.
+RUN groupadd -r developer -g 1000 \
+ && useradd -u 1000 -r -g developer -m -d /developer -s /sbin/nologin -c "JavaSMT Development User" developer \
+ && chmod 755 /developer
+
+USER developer

--- a/docker/ubuntu1804.Dockerfile
+++ b/docker/ubuntu1804.Dockerfile
@@ -15,3 +15,6 @@ RUN groupadd -r developer -g 1000 \
  && chmod 755 /developer
 
 USER developer
+
+# JNI is not found when compiling Boolector in the image, so we need to set JAVA_HOME
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/

--- a/lib/ivy.xml
+++ b/lib/ivy.xml
@@ -161,7 +161,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency org="org.sosy_lab" name="javasmt-solver-z3" rev="4.8.10" conf="runtime-z3->solver-z3; contrib->sources,javadoc" />
         <dependency org="org.sosy_lab" name="javasmt-solver-optimathsat" rev="1.7.1-sosy0" conf="runtime-optimathsat->solver-optimathsat" />
         <dependency org="org.sosy_lab" name="javasmt-solver-cvc4" rev="1.8-prerelease-2020-06-24-g7825d8f28" conf="runtime-cvc4->solver-cvc4" />
-        <dependency org="org.sosy_lab" name="javasmt-solver-boolector" rev="3.2.1-30-g95859db8" conf="runtime-boolector->solver-boolector" />
+        <dependency org="org.sosy_lab" name="javasmt-solver-boolector" rev="3.2.2-g0783aa84" conf="runtime-boolector->solver-boolector" />
 
         <!-- additional JavaSMT components with Solver Binaries -->
         <dependency org="org.sosy_lab" name="javasmt-yices2" rev="3.10.0" conf="runtime-yices2->runtime; contrib->sources" />


### PR DESCRIPTION
The Docker image is based on Ubuntu 18.04, with additional software for building Boolector and other solver binaries.
Boolector was then updated to its latest version 3.2.2 from the Git repository.