### PR TITLE
More theories for Princess

### DIFF
--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractBaseFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractBaseFormulaManager.java
@@ -30,7 +30,7 @@ abstract class AbstractBaseFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl> 
     return formulaCreator;
   }
 
-  final TFormulaInfo extractInfo(Formula pBits) {
+  protected final TFormulaInfo extractInfo(Formula pBits) {
     return getFormulaCreator().extractInfo(pBits);
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
@@ -32,11 +32,11 @@ public abstract class AbstractStringFormulaManager<TFormulaInfo, TType, TEnv, TF
     super(pCreator);
   }
 
-  private StringFormula wrapString(TFormulaInfo formulaInfo) {
+  protected StringFormula wrapString(TFormulaInfo formulaInfo) {
     return getFormulaCreator().encapsulateString(formulaInfo);
   }
 
-  private RegexFormula wrapRegex(TFormulaInfo formulaInfo) {
+  protected RegexFormula wrapRegex(TFormulaInfo formulaInfo) {
     return getFormulaCreator().encapsulateRegex(formulaInfo);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
@@ -31,6 +31,8 @@ import ap.terfor.ConstantTerm;
 import ap.terfor.preds.Predicate;
 import ap.theories.ExtArray;
 import ap.theories.bitvectors.ModuloArithmetic;
+import ap.theories.strings.SeqStringTheory;
+import ap.theories.strings.SeqStringTheoryBuilder;
 import ap.types.Sort;
 import ap.types.Sort$;
 import ap.types.Sort.MultipleValueBool$;
@@ -100,6 +102,18 @@ class PrincessEnvironment {
 
   public static final Sort BOOL_SORT = Sort$.MODULE$.Bool();
   public static final Sort INTEGER_SORT = Sort.Integer$.MODULE$;
+  public static final Sort NAT_SORT = Sort.Nat$.MODULE$;
+
+  static int STRING_ALPHABET_SIZE = 500;
+  static SeqStringTheory stringTheory;
+  static {
+    SeqStringTheoryBuilder builder = new SeqStringTheoryBuilder();
+    builder.setAlphabetSize(STRING_ALPHABET_SIZE);
+    stringTheory = builder.theory();
+  }
+
+  public static final Sort STRING_SORT = stringTheory.StringSort();
+  public static final Sort REGEX_SORT = stringTheory.RegexSort();
 
   @Option(secure = true, description = "log all queries as Princess-specific Scala code")
   private boolean logAllQueriesAsScala = false;
@@ -512,7 +526,8 @@ class PrincessEnvironment {
         // add more info about the formula, then rethrow
         throw new IllegalArgumentException(
             String.format(
-                "Unknown formula type '%s' for formula '%s'.", pFormula.getClass(), pFormula),
+                "Unknown formula type '%s' of sort '%s' for formula '%s'.",
+                pFormula.getClass(), sort.toString(), pFormula),
             e);
       }
     }
@@ -524,8 +539,12 @@ class PrincessEnvironment {
   private static FormulaType<?> getFormulaTypeFromSort(final Sort sort) {
     if (sort == PrincessEnvironment.BOOL_SORT) {
       return FormulaType.BooleanType;
-    } else if (sort == PrincessEnvironment.INTEGER_SORT) {
+    } else if (sort == PrincessEnvironment.INTEGER_SORT || sort == PrincessEnvironment.NAT_SORT) {
       return FormulaType.IntegerType;
+    } else if (sort == PrincessEnvironment.STRING_SORT) {
+      return FormulaType.StringType;
+    } else if (sort == PrincessEnvironment.REGEX_SORT) {
+      return FormulaType.RegexType;
     } else if (sort instanceof ExtArray.ArraySort) {
       Seq<Sort> indexSorts = ((ExtArray.ArraySort) sort).theory().indexSorts();
       Sort elementSort = ((ExtArray.ArraySort) sort).theory().objSort();

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaCreator.java
@@ -42,6 +42,8 @@ import ap.terfor.preds.Predicate;
 import ap.theories.ExtArray;
 import ap.theories.bitvectors.ModuloArithmetic;
 import ap.theories.nia.GroebnerMultiplication$;
+import ap.theories.strings.SeqStringTheory;
+import ap.theories.strings.SeqStringTheoryBuilder;
 import ap.types.Sort;
 import ap.types.Sort$;
 import com.google.common.collect.HashBasedTable;
@@ -108,6 +110,54 @@ class PrincessFormulaCreator
     theoryPredKind.put(ModuloArithmetic.bv_sle(), FunctionDeclarationKind.BV_SLE);
 
     theoryFunctionKind.put(GroebnerMultiplication$.MODULE$.mul(), FunctionDeclarationKind.MUL);
+
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.str_$plus$plus(),
+        FunctionDeclarationKind.STR_CONCAT);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.str_len(),
+        FunctionDeclarationKind.STR_LENGTH);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.str_indexof(),
+        FunctionDeclarationKind.STR_INDEX_OF);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.str_char(),
+        FunctionDeclarationKind.STR_CHAR_AT);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.str_substr(),
+        FunctionDeclarationKind.STR_SUBSTRING);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.str_replace(),
+        FunctionDeclarationKind.STR_REPLACE);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.str_replaceall(),
+        FunctionDeclarationKind.STR_REPLACE_ALL);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.str_to_re(),
+        FunctionDeclarationKind.STR_TO_RE);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.str_to_int(),
+        FunctionDeclarationKind.STR_TO_INT);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.re_range(),
+        FunctionDeclarationKind.RE_RANGE);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.re_$plus$plus(),
+        FunctionDeclarationKind.RE_CONCAT);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.re_union(),
+        FunctionDeclarationKind.RE_UNION);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.re_inter(),
+        FunctionDeclarationKind.RE_INTERSECT);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.re_$times(),
+        FunctionDeclarationKind.RE_STAR);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.re_$plus(),
+        FunctionDeclarationKind.RE_PLUS);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.re_diff(),
+        FunctionDeclarationKind.RE_DIFFERENCE);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.re_opt(),
+        FunctionDeclarationKind.RE_OPTIONAL);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.re_comp(),
+        FunctionDeclarationKind.RE_COMPLEMENT);
+    theoryFunctionKind.put(PrincessEnvironment.stringTheory.int_to_str(),
+        FunctionDeclarationKind.INT_TO_STR);
+
+    theoryPredKind.put(PrincessEnvironment.stringTheory.str_prefixof(),
+        FunctionDeclarationKind.STR_PREFIX);
+    theoryPredKind.put(PrincessEnvironment.stringTheory.str_suffixof(),
+        FunctionDeclarationKind.STR_SUFFIX);
+    theoryPredKind.put(PrincessEnvironment.stringTheory.str_contains(),
+        FunctionDeclarationKind.STR_CONTAINS);
+    theoryPredKind.put(PrincessEnvironment.stringTheory.str_in_re(),
+        FunctionDeclarationKind.STR_IN_RE);
   }
 
   /**
@@ -121,7 +171,9 @@ class PrincessFormulaCreator
   private final Table<Sort, Sort, Sort> arraySortCache = HashBasedTable.create();
 
   PrincessFormulaCreator(PrincessEnvironment pEnv) {
-    super(pEnv, PrincessEnvironment.BOOL_SORT, PrincessEnvironment.INTEGER_SORT, null, null, null);
+    super(pEnv, PrincessEnvironment.BOOL_SORT, PrincessEnvironment.INTEGER_SORT,
+        null,
+        PrincessEnvironment.STRING_SORT, PrincessEnvironment.REGEX_SORT);
   }
 
   @Override
@@ -177,6 +229,7 @@ class PrincessFormulaCreator
     }
     return result;
   }
+
 
   @SuppressWarnings("unchecked")
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaManager.java
@@ -32,7 +32,8 @@ final class PrincessFormulaManager
       PrincessIntegerFormulaManager pIntegerManager,
       PrincessBitvectorFormulaManager pBitpreciseManager,
       PrincessArrayFormulaManager pArrayManager,
-      PrincessQuantifiedFormulaManager pQuantifierManager) {
+      PrincessQuantifiedFormulaManager pQuantifierManager,
+      PrincessStringFormulaManager pStringManager) {
     super(
         pCreator,
         pFunctionManager,
@@ -44,7 +45,7 @@ final class PrincessFormulaManager
         pQuantifierManager,
         pArrayManager,
         null,
-        null);
+        pStringManager);
     creator = pCreator;
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessSolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessSolverContext.java
@@ -56,6 +56,8 @@ public final class PrincessSolverContext extends AbstractSolverContext {
     PrincessArrayFormulaManager arrayTheory = new PrincessArrayFormulaManager(creator);
     PrincessQuantifiedFormulaManager quantifierTheory =
         new PrincessQuantifiedFormulaManager(creator);
+    PrincessStringFormulaManager stringTheory =
+        new PrincessStringFormulaManager(creator);
     PrincessFormulaManager manager =
         new PrincessFormulaManager(
             creator,
@@ -64,7 +66,8 @@ public final class PrincessSolverContext extends AbstractSolverContext {
             integerTheory,
             bitvectorTheory,
             arrayTheory,
-            quantifierTheory);
+            quantifierTheory,
+            stringTheory);
     return new PrincessSolverContext(manager, creator);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessStringFormulaManager.java
@@ -1,0 +1,216 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2021 Alejandro SerranoMena
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.solvers.princess;
+
+import ap.parser.IAtom;
+import ap.parser.IBinFormula;
+import ap.parser.IBinJunctor;
+import ap.parser.IExpression;
+import ap.parser.IFormula;
+import ap.parser.IFunApp;
+import ap.parser.INot;
+import ap.parser.ITerm;
+import ap.types.Sort;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.sosy_lab.java_smt.api.RegexFormula;
+import org.sosy_lab.java_smt.basicimpl.AbstractStringFormulaManager;
+import scala.collection.immutable.Seq;
+
+public class PrincessStringFormulaManager
+    extends AbstractStringFormulaManager<
+        IExpression, Sort, PrincessEnvironment, PrincessFunctionDeclaration> {
+
+  PrincessStringFormulaManager(PrincessFormulaCreator pCreator) {
+    super(pCreator);
+  }
+
+  static Seq<ITerm> toSeq(List<IExpression> exprs) {
+    ArrayList<ITerm> result = new ArrayList<ITerm>();
+    for (IExpression expr : exprs) result.add((ITerm)expr);
+    return PrincessEnvironment.toSeq(result);
+  }
+
+  static Seq<ITerm> toSeq(IExpression... exprs) {
+    return toSeq(Arrays.asList(exprs));
+  }
+
+  @Override
+  protected IExpression makeStringImpl(String value) {
+    return PrincessEnvironment.stringTheory.string2Term(value);
+  }
+
+  @Override
+  protected IExpression makeVariableImpl(String pVar) {
+    Sort t = getFormulaCreator().getStringType();
+    return getFormulaCreator().makeVariable(t, pVar);
+  }
+
+  @Override
+  protected IFormula equal(IExpression pParam1, IExpression pParam2) {
+    return ((ITerm) pParam1).$eq$eq$eq((ITerm) pParam2);
+  }
+
+  @Override
+  protected IFormula greaterThan(IExpression pParam1, IExpression pParam2) {
+    IFormula leq = greaterOrEquals(pParam1, pParam2);
+    IFormula eq = equal(pParam1, pParam2);
+    return new IBinFormula(IBinJunctor.And(), leq, new INot(eq));
+  }
+
+  @Override
+  protected IFormula lessOrEquals(IExpression pParam1, IExpression pParam2) {
+    return new IAtom(PrincessEnvironment.stringTheory.str_$less$eq(), toSeq(pParam1, pParam2));
+  }
+
+  @Override
+  protected IFormula greaterOrEquals(IExpression pParam1, IExpression pParam2) {
+    // just reverse the order
+    return lessOrEquals(pParam2, pParam1);
+  }
+
+  @Override
+  protected IFormula lessThan(IExpression pParam1, IExpression pParam2) {
+    IFormula leq = lessOrEquals(pParam1, pParam2);
+    IFormula eq = equal(pParam1, pParam2);
+    return new IBinFormula(IBinJunctor.And(), leq, new INot(eq));
+  }
+
+  @Override
+  protected ITerm length(IExpression pParam) {
+    return new IFunApp(PrincessEnvironment.stringTheory.str_len(), toSeq(pParam));
+  }
+
+  @Override
+  protected ITerm concatImpl(List<IExpression> parts) {
+    return new IFunApp(PrincessEnvironment.stringTheory.str_$plus$plus(), toSeq(parts));
+  }
+
+  @Override
+  protected IFormula prefix(IExpression prefix, IExpression str) {
+    return new IAtom(PrincessEnvironment.stringTheory.str_prefixof(), toSeq(prefix, str));
+  }
+
+  @Override
+  protected IFormula suffix(IExpression suffix, IExpression str) {
+    return new IAtom(PrincessEnvironment.stringTheory.str_suffixof(), toSeq(suffix, str));
+  }
+
+  @Override
+  protected IFormula in(IExpression str, IExpression regex) {
+    return new IAtom(PrincessEnvironment.stringTheory.str_in_re(), toSeq(str, regex));
+  }
+
+  @Override
+  protected IFormula contains(IExpression str, IExpression part) {
+    return new IAtom(PrincessEnvironment.stringTheory.str_contains(), toSeq(str, part));
+  }
+
+  @Override
+  protected ITerm indexOf(IExpression str, IExpression part, IExpression startIndex) {
+    return new IFunApp(PrincessEnvironment.stringTheory.str_indexof(), toSeq(str, part, startIndex));
+  }
+
+  @Override
+  protected ITerm charAt(IExpression str, IExpression index) {
+    return new IFunApp(PrincessEnvironment.stringTheory.str_char(), toSeq(str, index));
+  }
+
+  @Override
+  protected ITerm substring(IExpression str, IExpression index, IExpression length) {
+    return new IFunApp(PrincessEnvironment.stringTheory.str_substr(), toSeq(str, index, length));
+  }
+
+  @Override
+  protected ITerm replace(
+      IExpression fullStr, IExpression target, IExpression replacement) {
+    return new IFunApp(PrincessEnvironment.stringTheory.str_replace(), toSeq(fullStr, target, replacement));
+  }
+
+  @Override
+  protected ITerm replaceAll(
+      IExpression fullStr, IExpression target, IExpression replacement) {
+    return new IFunApp(PrincessEnvironment.stringTheory.str_replaceall(), toSeq(fullStr, target,
+        replacement));
+  }
+
+  @Override
+  protected ITerm makeRegexImpl(String value) {
+    return new IFunApp(PrincessEnvironment.stringTheory.str_to_re(), toSeq(makeStringImpl(value)));
+  }
+
+  @Override
+  protected ITerm noneImpl() {
+    return new IFunApp(PrincessEnvironment.stringTheory.re_none(), toSeq());
+  }
+
+  @Override
+  protected ITerm allImpl() {
+    return new IFunApp(PrincessEnvironment.stringTheory.re_all(), toSeq());
+  }
+
+  @Override
+  protected ITerm range(IExpression start, IExpression end) {
+    return new IFunApp(PrincessEnvironment.stringTheory.re_range(), toSeq());
+  }
+
+  @Override
+  public RegexFormula cross(RegexFormula regex) {
+    return wrapRegex(new IFunApp(PrincessEnvironment.stringTheory.re_$plus(),
+        toSeq(extractInfo(regex))));
+  }
+
+  @Override
+  public RegexFormula optional(RegexFormula regex) {
+    return wrapRegex(new IFunApp(PrincessEnvironment.stringTheory.re_opt(),
+        toSeq(extractInfo(regex))));
+  }
+
+  @Override
+  public RegexFormula difference(RegexFormula regex1, RegexFormula regex2) {
+    return wrapRegex(new IFunApp(PrincessEnvironment.stringTheory.re_diff(),
+        toSeq(extractInfo(regex1), extractInfo(regex2))));
+  }
+
+  @Override
+  protected ITerm concatRegexImpl(List<IExpression> parts) {
+    return new IFunApp(PrincessEnvironment.stringTheory.re_$plus$plus(), toSeq(parts));
+  }
+
+  @Override
+  protected ITerm union(IExpression pParam1, IExpression pParam2) {
+    return new IFunApp(PrincessEnvironment.stringTheory.re_union(), toSeq(pParam1, pParam2));
+  }
+
+  @Override
+  protected ITerm intersection(IExpression pParam1, IExpression pParam2) {
+    return new IFunApp(PrincessEnvironment.stringTheory.re_inter(), toSeq(pParam1, pParam2));
+  }
+
+  @Override
+  protected ITerm closure(IExpression pParam) {
+    return new IFunApp(PrincessEnvironment.stringTheory.re_$times(), toSeq(pParam));
+  }
+
+  @Override
+  protected ITerm complement(IExpression pParam) {
+    return new IFunApp(PrincessEnvironment.stringTheory.re_comp(), toSeq(pParam));
+  }
+
+  @Override
+  protected ITerm toIntegerFormula(IExpression pParam) {
+    return new IFunApp(PrincessEnvironment.stringTheory.str_to_int(), toSeq(pParam));
+  }
+
+  @Override
+  protected ITerm toStringFormula(IExpression pParam) {
+    return new IFunApp(PrincessEnvironment.stringTheory.int_to_str(), toSeq(pParam));
+  }
+}


### PR DESCRIPTION
Princess supports more theories than the ones currently announced in `java-smt`. The goal of this PR is to support them:

- [X] String theory via naïve theory
- [ ] String theory via [Ostrich](https://github.com/uuverifiers/ostrich/), an extension to Princess
- [ ] Rational theory

For the second goal a release of [Ostrich](https://github.com/uuverifiers/ostrich/) must be added to the [Sosy Lab Ivy repository](https://www.sosy-lab.org/ivy/io.github.uuverifiers/). Until them, most of the tests return _Inconclusive_ (and thus fail).