### PR TITLE
Fixed IllegalArgumentException when extracting free variables from constraint in Z3

### DIFF
--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java
@@ -365,9 +365,9 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
    */
   @Override
   public Map<String, Formula> extractVariables(Formula f) {
-    ImmutableMap.Builder<String, Formula> found = ImmutableMap.builder();
+    Map<String, Formula> found = new LinkedHashMap<>();
     formulaCreator.extractVariablesAndUFs(f, false, found::put);
-    return found.build();
+    return ImmutableMap.copyOf(found);
   }
 
   /**


### PR DESCRIPTION
Extracting free variables from a Z3 context has regularly led to a `java.lang.IllegalArgumentException` exception. 
The exception can be triggered with the following MWE:
```
Configuration config = Configuration.defaultConfiguration();
LogManager logger = BasicLogManager.create(config);
ShutdownManager shutdown = ShutdownManager.create();
SolverContext context = SolverContextFactory.createSolverContext(
        config, logger, shutdown.getNotifier(), SolverContextFactory.Solvers.Z3);

FormulaManager fmgr = context.getFormulaManager();
StringFormulaManager smgr = fmgr.getStringFormulaManager();
BooleanFormula len = smgr.equal(
        smgr.makeString("x"),
        smgr.makeString("xx")
        );
System.out.println(fmgr.dumpFormula(len));
Map<String, Formula> freeVars = fmgr.extractVariables(len);
```
Executing the minimal working example led to:
```
(assert (= "x" "xx"))

java.lang.IllegalArgumentException: Multiple entries with same key: String="x" and String="xx"
	at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:376)
	at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:370)
	at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:153)
	at com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:115)
	at com.google.common.collect.ImmutableMap$Builder.buildOrThrow(ImmutableMap.java:574)
	at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:538)
	at org.sosy_lab.java_smt.basicimpl.AbstractFormulaManager.extractVariables(AbstractFormulaManager.java:370)
	at de.pethmr.knife.janala.Main.err(Main.java:118)
	at de.pethmr.knife.janala.Main.solve(Main.java:195)
	at de.pethmr.swat.tests.StringIf.test(StringIf.java:46)
	at de.pethmr.swat.tests.StringIf.main(StringIf.java:121)
```

The issue was already discussed in [AbstractFormulaManager::extractVariablesAndUFs](https://github.dev/sosy-lab/java-smt/blob/master/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java#L379) and more generally on [StackOverflow](https://stackoverflow.com/questions/41195885/multiple-entries-with-same-key-immutable-map-error).

Using the same code from  `extractVariablesAndUFs` in `extractVariables` fixes the issue.
