### PR TITLE
Add allChar function, fix #281

### DIFF
--- a/src/org/sosy_lab/java_smt/api/StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/StringFormulaManager.java
@@ -128,6 +128,12 @@ public interface StringFormulaManager {
    */
   RegexFormula all();
 
+ /**
+   * @return formula denoting the set of all strings of length 1, also known as DOT operator which
+   *     represents an arbitrary char. .
+   */
+  RegexFormula allChar();
+
   /**
    * @return formula denoting the range regular expression over two sequences of length 1.
    */

--- a/src/org/sosy_lab/java_smt/api/StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/StringFormulaManager.java
@@ -124,13 +124,17 @@ public interface StringFormulaManager {
   RegexFormula none();
 
   /**
+   * Note: The size of the used alphabet depends on the underlying SMT solver.
+   *
    * @return formula denoting the set of all strings, also known as Regex <code>".*"</code>.
    */
   RegexFormula all();
 
- /**
+  /**
+   * Note: The size of the used alphabet depends on the underlying SMT solver.
+   *
    * @return formula denoting the set of all strings of length 1, also known as DOT operator which
-   *     represents an arbitrary char. .
+   *     represents one arbitrary char, or as Regex <code>"."</code>.
    */
   RegexFormula allChar();
 

--- a/src/org/sosy_lab/java_smt/api/StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/StringFormulaManager.java
@@ -8,6 +8,7 @@
 
 package org.sosy_lab.java_smt.api;
 
+import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.List;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
@@ -148,6 +149,13 @@ public interface StringFormulaManager {
    * @see #range(StringFormula, StringFormula)
    */
   default RegexFormula range(char start, char end) {
+    Preconditions.checkArgument(
+        start <= end,
+        "Range from start '%s' (%s) to end '%s' (%s) is empty.",
+        start,
+        (int) start,
+        end,
+        (int) end);
     return range(makeString(String.valueOf(start)), makeString(String.valueOf(end)));
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
@@ -206,6 +206,13 @@ public abstract class AbstractStringFormulaManager<TFormulaInfo, TType, TEnv, TF
   protected abstract TFormulaInfo allImpl();
 
   @Override
+  public RegexFormula allChar() {
+    return wrapRegex(allCharImpl());
+  }
+
+  protected abstract TFormulaInfo allCharImpl();
+
+  @Override
   public RegexFormula range(StringFormula start, StringFormula end) {
     return wrapRegex(range(extractInfo(start), extractInfo(end)));
   }

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsStringFormulaManager.java
@@ -157,6 +157,12 @@ class StatisticsStringFormulaManager implements StringFormulaManager {
   }
 
   @Override
+  public RegexFormula allChar() {
+    stats.stringOperations.getAndIncrement();
+    return delegate.allChar();
+  }
+
+  @Override
   public RegexFormula range(StringFormula start, StringFormula end) {
     stats.stringOperations.getAndIncrement();
     return delegate.range(start, end);

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedStringFormulaManager.java
@@ -179,6 +179,13 @@ class SynchronizedStringFormulaManager implements StringFormulaManager {
   }
 
   @Override
+  public RegexFormula allChar() {
+    synchronized (sync) {
+      return delegate.allChar();
+    }
+  }
+
+  @Override
   public RegexFormula range(StringFormula start, StringFormula end) {
     synchronized (sync) {
       return delegate.range(start, end);

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4StringFormulaManager.java
@@ -139,6 +139,11 @@ class CVC4StringFormulaManager extends AbstractStringFormulaManager<Expr, Type, 
   }
 
   @Override
+  protected Expr allCharImpl() {
+    return exprManager.mkExpr(Kind.REGEXP_SIGMA, noneImpl());
+  }
+
+  @Override
   protected Expr range(Expr start, Expr end) {
     return exprManager.mkExpr(Kind.REGEXP_RANGE, start, end);
   }

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4StringFormulaManager.java
@@ -140,7 +140,7 @@ class CVC4StringFormulaManager extends AbstractStringFormulaManager<Expr, Type, 
 
   @Override
   protected Expr allCharImpl() {
-    return exprManager.mkExpr(Kind.REGEXP_SIGMA, noneImpl());
+    return exprManager.mkExpr(Kind.REGEXP_SIGMA, new vectorExpr());
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3StringFormulaManager.java
@@ -132,6 +132,11 @@ class Z3StringFormulaManager extends AbstractStringFormulaManager<Long, Long, Lo
   }
 
   @Override
+  protected Long allCharImpl() {
+    return Native.mkReAllchar(z3context, formulaCreator.getRegexType());
+  }
+
+  @Override
   protected Long range(Long start, Long end) {
     return Native.mkReRange(z3context, start, end);
   }

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -131,33 +131,40 @@ public class StringFormulaManagerTest extends SolverBasedTest0 {
   @Test
   public void testRegexAllChar() throws SolverException, InterruptedException {
     RegexFormula regexAllChar = smgr.allChar();
-    RegexFormula regexDot = smgr.makeRegex(".");
+
     assertThatFormula(smgr.in(smgr.makeString("a"), regexAllChar)).isSatisfiable();
-    assertThatFormula(smgr.in(smgr.makeString("a"), regexDot)).isUnsatisfiable();
     assertThatFormula(smgr.in(smgr.makeString("ab"), regexAllChar)).isUnsatisfiable();
     assertThatFormula(smgr.in(smgr.makeString(""), regexAllChar)).isUnsatisfiable();
     assertThatFormula(smgr.in(smgr.makeString("ab"), smgr.times(regexAllChar, 2))).isSatisfiable();
-    assertThatFormula(smgr.in(smgr.makeVariable("x"), smgr.intersection(smgr.range('a', '9'),
-        regexAllChar))).isSatisfiable();
+    assertThatFormula(
+            smgr.in(smgr.makeVariable("x"), smgr.intersection(smgr.range('a', '9'), regexAllChar)))
+        .isSatisfiable();
+
+    RegexFormula regexDot = smgr.makeRegex(".");
+    assertThatFormula(smgr.in(smgr.makeString("a"), regexDot)).isUnsatisfiable();
   }
 
   @Test
   public void testRegexAllCharUnicode() throws SolverException, InterruptedException {
     RegexFormula regexAllChar = smgr.allChar();
-    if (solverUnderTest == Solvers.Z3) {
-      // Z3 supports Unicode characters in the theory of strings.
+
+    if (solverUnderTest == Solvers.CVC4) {
+      // CVC4 does not support Unicode characters
+      assertThatFormula(smgr.in(smgr.makeString("\\u0394"), regexAllChar)).isUnsatisfiable();
+
+    } else {
+      // Z3 and other solvers support Unicode characters in the theory of strings.
       assertThatFormula(smgr.in(smgr.makeString("\\u0394"), regexAllChar)).isSatisfiable();
       assertThatFormula(smgr.in(smgr.makeString("\\u{1fa6a}"), regexAllChar)).isSatisfiable();
-      assertThatFormula(smgr.in(smgr.makeVariable("x"), smgr.intersection(smgr.range('a', 'Δ'),
-          regexAllChar))).isSatisfiable();
+      assertThatFormula(
+              smgr.in(
+                  smgr.makeVariable("x"), smgr.intersection(smgr.range('a', 'Δ'), regexAllChar)))
+          .isSatisfiable();
       // Combining characters are not matched as one character.
       assertThatFormula(smgr.in(smgr.makeString("a\\u0336"), regexAllChar)).isUnsatisfiable();
       // Non-ascii non-printable characters should use the codepoint representation
       assertThatFormula(smgr.in(smgr.makeString("Δ"), regexAllChar)).isUnsatisfiable();
       assertThatFormula(smgr.in(smgr.makeString("\\n"), regexAllChar)).isUnsatisfiable();
-    } else if (solverUnderTest == Solvers.CVC4){
-      // CVC4 does not support Unicode characters
-      assertThatFormula(smgr.in(smgr.makeString("\\u0394"), regexAllChar)).isUnsatisfiable();
     }
   }
 

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -129,6 +129,14 @@ public class StringFormulaManagerTest extends SolverBasedTest0 {
   }
 
   @Test
+  public void testRegexAllChar() throws SolverException, InterruptedException {
+    RegexFormula regexAllChar = smgr.allChar();
+    RegexFormula regexDot = smgr.makeRegex(".");
+    assertThatFormula(smgr.in(smgr.makeString("a"), regexAllChar)).isSatisfiable();
+    assertThatFormula(smgr.in(smgr.makeString("a"), regexDot)).isUnsatisfiable();
+  }
+
+  @Test
   public void testStringRegex2() throws SolverException, InterruptedException {
     RegexFormula regex = smgr.concat(smgr.closure(a2z), smgr.makeRegex("ll"), smgr.closure(a2z));
     assertThatFormula(smgr.in(hello, regex)).isSatisfiable();

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -148,23 +148,24 @@ public class StringFormulaManagerTest extends SolverBasedTest0 {
   public void testRegexAllCharUnicode() throws SolverException, InterruptedException {
     RegexFormula regexAllChar = smgr.allChar();
 
-    if (solverUnderTest == Solvers.CVC4) {
-      // CVC4 does not support Unicode characters
-      assertThatFormula(smgr.in(smgr.makeString("\\u0394"), regexAllChar)).isUnsatisfiable();
+    // Single characters.
+    assertThatFormula(smgr.in(smgr.makeString("\\u0394"), regexAllChar)).isSatisfiable();
+    assertThatFormula(smgr.in(smgr.makeString("\\u{1fa6a}"), regexAllChar)).isSatisfiable();
 
-    } else {
+    // Combining characters are not matched as one character.
+    assertThatFormula(smgr.in(smgr.makeString("a\\u0336"), regexAllChar)).isUnsatisfiable();
+    assertThatFormula(smgr.in(smgr.makeString("\\n"), regexAllChar)).isUnsatisfiable();
+
+    if (solverUnderTest != Solvers.CVC4) {
+      // CVC4 does not support Unicode characters.
       // Z3 and other solvers support Unicode characters in the theory of strings.
-      assertThatFormula(smgr.in(smgr.makeString("\\u0394"), regexAllChar)).isSatisfiable();
-      assertThatFormula(smgr.in(smgr.makeString("\\u{1fa6a}"), regexAllChar)).isSatisfiable();
       assertThatFormula(
               smgr.in(
                   smgr.makeVariable("x"), smgr.intersection(smgr.range('a', 'Δ'), regexAllChar)))
           .isSatisfiable();
       // Combining characters are not matched as one character.
-      assertThatFormula(smgr.in(smgr.makeString("a\\u0336"), regexAllChar)).isUnsatisfiable();
       // Non-ascii non-printable characters should use the codepoint representation
       assertThatFormula(smgr.in(smgr.makeString("Δ"), regexAllChar)).isUnsatisfiable();
-      assertThatFormula(smgr.in(smgr.makeString("\\n"), regexAllChar)).isUnsatisfiable();
     }
   }
 

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -134,6 +134,31 @@ public class StringFormulaManagerTest extends SolverBasedTest0 {
     RegexFormula regexDot = smgr.makeRegex(".");
     assertThatFormula(smgr.in(smgr.makeString("a"), regexAllChar)).isSatisfiable();
     assertThatFormula(smgr.in(smgr.makeString("a"), regexDot)).isUnsatisfiable();
+    assertThatFormula(smgr.in(smgr.makeString("ab"), regexAllChar)).isUnsatisfiable();
+    assertThatFormula(smgr.in(smgr.makeString(""), regexAllChar)).isUnsatisfiable();
+    assertThatFormula(smgr.in(smgr.makeString("ab"), smgr.times(regexAllChar, 2))).isSatisfiable();
+    assertThatFormula(smgr.in(smgr.makeVariable("x"), smgr.intersection(smgr.range('a', '9'),
+        regexAllChar))).isSatisfiable();
+  }
+
+  @Test
+  public void testRegexAllCharUnicode() throws SolverException, InterruptedException {
+    RegexFormula regexAllChar = smgr.allChar();
+    if (solverUnderTest == Solvers.Z3) {
+      // Z3 supports Unicode characters in the theory of strings.
+      assertThatFormula(smgr.in(smgr.makeString("\\u0394"), regexAllChar)).isSatisfiable();
+      assertThatFormula(smgr.in(smgr.makeString("\\u{1fa6a}"), regexAllChar)).isSatisfiable();
+      assertThatFormula(smgr.in(smgr.makeVariable("x"), smgr.intersection(smgr.range('a', 'Δ'),
+          regexAllChar))).isSatisfiable();
+      // Combining characters are not matched as one character.
+      assertThatFormula(smgr.in(smgr.makeString("a\\u0336"), regexAllChar)).isUnsatisfiable();
+      // Non-ascii non-printable characters should use the codepoint representation
+      assertThatFormula(smgr.in(smgr.makeString("Δ"), regexAllChar)).isUnsatisfiable();
+      assertThatFormula(smgr.in(smgr.makeString("\\n"), regexAllChar)).isUnsatisfiable();
+    } else if (solverUnderTest == Solvers.CVC4){
+      // CVC4 does not support Unicode characters
+      assertThatFormula(smgr.in(smgr.makeString("\\u0394"), regexAllChar)).isUnsatisfiable();
+    }
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -137,7 +137,7 @@ public class StringFormulaManagerTest extends SolverBasedTest0 {
     assertThatFormula(smgr.in(smgr.makeString(""), regexAllChar)).isUnsatisfiable();
     assertThatFormula(smgr.in(smgr.makeString("ab"), smgr.times(regexAllChar, 2))).isSatisfiable();
     assertThatFormula(
-            smgr.in(smgr.makeVariable("x"), smgr.intersection(smgr.range('a', '9'), regexAllChar)))
+            smgr.in(smgr.makeVariable("x"), smgr.intersection(smgr.range('9', 'a'), regexAllChar)))
         .isSatisfiable();
 
     RegexFormula regexDot = smgr.makeRegex(".");


### PR DESCRIPTION
This function corresponds to `re.allchar` in http://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml. It is implemented by the Z3 and CVC4 solvers. It was previously removed by mistake. Fixes #281.

Running tests with `ant tests` (before or after applying these changes) yields test errors. CVC4 tests all fail and some Z3 tests fail. For Z3 tests, this does not happen when they are run individually. I am unsure if this is expected or if I should change the way I run tests. However, the newly added test case passes with Z3.