### PR TITLE
Fix bug in regex intersection and difference

### DIFF
--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
@@ -242,7 +242,7 @@ public abstract class AbstractStringFormulaManager<TFormulaInfo, TType, TEnv, TF
 
   @Override
   public RegexFormula intersection(RegexFormula regex1, RegexFormula regex2) {
-    return wrapRegex(union(extractInfo(regex1), extractInfo(regex2)));
+    return wrapRegex(intersection(extractInfo(regex1), extractInfo(regex2)));
   }
 
   protected abstract TFormulaInfo intersection(TFormulaInfo pParam1, TFormulaInfo pParam2);
@@ -267,7 +267,7 @@ public abstract class AbstractStringFormulaManager<TFormulaInfo, TType, TEnv, TF
   }
 
   protected TFormulaInfo difference(TFormulaInfo pParam1, TFormulaInfo pParam2) {
-    return union(pParam1, complement(pParam2));
+    return intersection(pParam1, complement(pParam2));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -161,7 +161,7 @@ public class StringFormulaManagerTest extends SolverBasedTest0 {
       // Z3 and other solvers support Unicode characters in the theory of strings.
       assertThatFormula(
               smgr.in(
-                  smgr.makeVariable("x"), smgr.intersection(smgr.range('a', 'Δ'), regexAllChar)))
+                  smgr.makeVariable("x"), smgr.union(smgr.range('a', 'Δ'), regexAllChar)))
           .isSatisfiable();
       // Combining characters are not matched as one character.
       // Non-ascii non-printable characters should use the codepoint representation
@@ -185,6 +185,35 @@ public class StringFormulaManagerTest extends SolverBasedTest0 {
   public void testEmptyRegex() throws SolverException, InterruptedException {
     RegexFormula regex = smgr.none();
     assertThatFormula(smgr.in(hello, regex)).isUnsatisfiable();
+  }
+
+  @Test
+  public void testRegexUnion() throws  SolverException, InterruptedException {
+    RegexFormula regex = smgr.union(smgr.makeRegex("a"), smgr.makeRegex("b"));
+    assertThatFormula(smgr.in(smgr.makeString("a"), regex)).isSatisfiable();
+    assertThatFormula(smgr.in(smgr.makeString("b"), regex)).isSatisfiable();
+    assertThatFormula(smgr.in(smgr.makeString("c"), regex)).isUnsatisfiable();
+  }
+
+  @Test
+  public void testRegexIntersection() throws  SolverException, InterruptedException {
+    RegexFormula regex = smgr.intersection(smgr.makeRegex("a"), smgr.makeRegex("b"));
+    StringFormula variable = smgr.makeVariable("var");
+    assertThatFormula(smgr.in(variable, regex)).isUnsatisfiable();
+
+    regex = smgr.intersection(
+        smgr.union(smgr.makeRegex("a"), smgr.makeRegex("b")),
+        smgr.union(smgr.makeRegex("b"), smgr.makeRegex("c")));
+    assertThatFormula(smgr.in(smgr.makeString("a"), regex)).isUnsatisfiable();
+    assertThatFormula(smgr.in(smgr.makeString("b"), regex)).isSatisfiable();
+  }
+
+  @Test
+  public void testRegexDifference() throws  SolverException, InterruptedException {
+    RegexFormula regex = smgr.difference(
+        smgr.union(smgr.makeRegex("a"), smgr.makeRegex("b")), smgr.makeRegex("b"));
+    assertThatFormula(smgr.in(smgr.makeString("a"), regex)).isSatisfiable();
+    assertThatFormula(smgr.in(smgr.makeString("b"), regex)).isUnsatisfiable();
   }
 
   @Test


### PR DESCRIPTION
While working with the theory of strings, I saw unexpected behavior when using regex intersection or difference. It turns out that union was used for those operations instead of intersection. I made the correction and added 3 unit tests. I also made a fix to `testRegexAllCharUnicode()`, which was only passing because of this bug.