### PR TITLE
#301: support for enum types

### DIFF
--- a/src/org/sosy_lab/java_smt/api/EnumerationFormula.java
+++ b/src/org/sosy_lab/java_smt/api/EnumerationFormula.java
@@ -1,0 +1,15 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.api;
+
+import com.google.errorprone.annotations.Immutable;
+
+/** A formula of the enumeration sort. */
+@Immutable
+public interface EnumerationFormula extends Formula {}

--- a/src/org/sosy_lab/java_smt/api/EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/EnumerationFormulaManager.java
@@ -1,0 +1,57 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.api;
+
+import java.util.List;
+import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
+
+/**
+ * This interface represents the theory of enumeration, i.e., datatype of limited domain sort (as
+ * defined in the SMTLIB2 standard)
+ */
+public interface EnumerationFormulaManager {
+
+  /**
+   * Declare an enumeration.
+   *
+   * @param name the name of the enumeration type.
+   * @param elementNames names for all individual elements of this enumeration type.
+   */
+  EnumerationFormulaType declareEnumeration(String name, List<String> elementNames);
+
+  /**
+   * @see #declareEnumeration(String, List)
+   */
+  EnumerationFormulaType declareEnumeration(String name, String... elementNames);
+
+  /**
+   * Creates a constant of given enumeration type with exactly the given name. This constant
+   * (symbol) needs to be an element from the given enumeration type.
+   */
+  EnumerationFormula makeConstant(String pVar, EnumerationFormulaType pType);
+
+  /**
+   * Creates a variable of given enumeration type with exactly the given name.
+   *
+   * <p>This variable (symbol) represents a "String" for which the SMT solver needs to find a model.
+   *
+   * <p>Please make sure that the given name is valid in SMT-LIB2. Take a look at {@link
+   * FormulaManager#isValidName} for further information.
+   *
+   * <p>This method does not quote or unquote the given name, but uses the plain name "AS IS".
+   * {@link Formula#toString} can return a different String than the given one.
+   */
+  EnumerationFormula makeVariable(String pVar, EnumerationFormulaType pType);
+
+  /**
+   * Make a {@link BooleanFormula} that represents the equality of two {@link EnumerationFormula} of
+   * identical enumeration type.
+   */
+  BooleanFormula equivalence(EnumerationFormula pEnumeration1, EnumerationFormula pEnumeration2);
+}

--- a/src/org/sosy_lab/java_smt/api/EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/EnumerationFormulaManager.java
@@ -8,7 +8,10 @@
 
 package org.sosy_lab.java_smt.api;
 
-import java.util.List;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
 
 /**
@@ -20,21 +23,29 @@ public interface EnumerationFormulaManager {
   /**
    * Declare an enumeration.
    *
-   * @param name the name of the enumeration type.
-   * @param elementNames names for all individual elements of this enumeration type.
+   * @param pName the name of the enumeration type.
+   * @param ppElementNames names for all individual elements of this enumeration type.
    */
-  EnumerationFormulaType declareEnumeration(String name, List<String> elementNames);
+  EnumerationFormulaType declareEnumeration(String pName, Set<String> ppElementNames);
 
   /**
-   * @see #declareEnumeration(String, List)
+   * @see #declareEnumeration(String, Set)
    */
-  EnumerationFormulaType declareEnumeration(String name, String... elementNames);
+  default EnumerationFormulaType declareEnumeration(String pName, String... pElementNames) {
+    final Set<String> elements = ImmutableSet.copyOf(pElementNames);
+    Preconditions.checkArgument(
+        pElementNames.length == elements.size(),
+        "An enumeration type requires pairwise distinct elements. "
+            + "The following elements were given multiple times: %s",
+        FluentIterable.from(pElementNames).filter(e -> !elements.contains(e)));
+    return declareEnumeration(pName, elements);
+  }
 
   /**
    * Creates a constant of given enumeration type with exactly the given name. This constant
    * (symbol) needs to be an element from the given enumeration type.
    */
-  EnumerationFormula makeConstant(String pVar, EnumerationFormulaType pType);
+  EnumerationFormula makeConstant(String pName, EnumerationFormulaType pType);
 
   /**
    * Creates a variable of given enumeration type with exactly the given name.

--- a/src/org/sosy_lab/java_smt/api/EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/EnumerationFormulaManager.java
@@ -16,7 +16,7 @@ import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
 
 /**
  * This interface represents the theory of enumeration, i.e., datatype of limited domain sort (as
- * defined in the SMTLIB2 standard)
+ * defined in the SMTLIB2 standard).
  */
 public interface EnumerationFormulaManager {
 

--- a/src/org/sosy_lab/java_smt/api/EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/EnumerationFormulaManager.java
@@ -23,7 +23,7 @@ public interface EnumerationFormulaManager {
   /**
    * Declare an enumeration.
    *
-   * @param pName the name of the enumeration type.
+   * @param pName the unique name to identify the new enumeration type.
    * @param ppElementNames names for all individual elements of this enumeration type.
    */
   EnumerationFormulaType declareEnumeration(String pName, Set<String> ppElementNames);

--- a/src/org/sosy_lab/java_smt/api/Evaluator.java
+++ b/src/org/sosy_lab/java_smt/api/Evaluator.java
@@ -100,6 +100,13 @@ public interface Evaluator extends AutoCloseable {
   @Nullable String evaluate(StringFormula formula);
 
   /**
+   * Type-safe evaluation for enumeration formulas.
+   *
+   * <p>The formula does not need to be a variable, we also allow complex expression.
+   */
+  @Nullable String evaluate(EnumerationFormula formula);
+
+  /**
    * Free resources associated with this evaluator (existing {@link Formula} instances stay valid,
    * but {@link #evaluate(Formula)} etc. must not be called again).
    */

--- a/src/org/sosy_lab/java_smt/api/FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/FormulaManager.java
@@ -87,6 +87,13 @@ public interface FormulaManager {
   StringFormulaManager getStringFormulaManager();
 
   /**
+   * Returns the Enumeration Theory, e.g., also known as 'limited domain'.
+   *
+   * @throws UnsupportedOperationException If the theory is not supported by the solver.
+   */
+  EnumerationFormulaManager getEnumerationFormulaManager();
+
+  /**
    * Create variable of the type equal to {@code formulaType}.
    *
    * @param formulaType the type of the variable.

--- a/src/org/sosy_lab/java_smt/api/FormulaType.java
+++ b/src/org/sosy_lab/java_smt/api/FormulaType.java
@@ -8,8 +8,10 @@
 
 package org.sosy_lab.java_smt.api;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import java.util.List;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
@@ -67,6 +69,10 @@ public abstract class FormulaType<T extends Formula> {
   }
 
   public boolean isRegexType() {
+    return false;
+  }
+
+  public boolean isEnumerationType() {
     return false;
   }
 
@@ -342,6 +348,61 @@ public abstract class FormulaType<T extends Formula> {
     @Override
     public String toSMTLIBString() {
       return "(Array " + indexType.toSMTLIBString() + " " + elementType.toSMTLIBString() + ")";
+    }
+  }
+
+  public static final class EnumerationFormulaType extends FormulaType<EnumerationFormula> {
+
+    private final String name;
+    private final ImmutableSet<String> elements;
+
+    public EnumerationFormulaType(String pName, ImmutableSet<String> pElements) {
+      this.name = Preconditions.checkNotNull(pName);
+      this.elements = pElements;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public ImmutableSet<String> getElements() {
+      return elements;
+    }
+
+    public int getCardinality() {
+      return elements.size();
+    }
+
+    @Override
+    public boolean isEnumerationType() {
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s (%s)", name, Joiner.on(", ").join(elements));
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * name.hashCode() + elements.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof EnumerationFormulaType)) {
+        return false;
+      }
+      EnumerationFormulaType other = (EnumerationFormulaType) obj;
+      return name.equals(other.name) && elements.equals(other.elements);
+    }
+
+    @Override
+    public String toSMTLIBString() {
+      return "(" + this + ")";
     }
   }
 

--- a/src/org/sosy_lab/java_smt/api/FormulaType.java
+++ b/src/org/sosy_lab/java_smt/api/FormulaType.java
@@ -306,7 +306,7 @@ public abstract class FormulaType<T extends Formula> {
     private final FormulaType<TE> elementType;
     private final FormulaType<TI> indexType;
 
-    public ArrayFormulaType(FormulaType<TI> pIndexType, FormulaType<TE> pElementType) {
+    private ArrayFormulaType(FormulaType<TI> pIndexType, FormulaType<TE> pElementType) {
       this.indexType = Preconditions.checkNotNull(pIndexType);
       this.elementType = Preconditions.checkNotNull(pElementType);
     }

--- a/src/org/sosy_lab/java_smt/api/FormulaType.java
+++ b/src/org/sosy_lab/java_smt/api/FormulaType.java
@@ -14,6 +14,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import java.util.List;
+import java.util.Set;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 
@@ -356,9 +357,9 @@ public abstract class FormulaType<T extends Formula> {
     private final String name;
     private final ImmutableSet<String> elements;
 
-    public EnumerationFormulaType(String pName, ImmutableSet<String> pElements) {
+    public EnumerationFormulaType(String pName, Set<String> pElements) {
       this.name = Preconditions.checkNotNull(pName);
-      this.elements = pElements;
+      this.elements = ImmutableSet.copyOf(pElements);
     }
 
     public String getName() {
@@ -470,6 +471,12 @@ public abstract class FormulaType<T extends Formula> {
       // Bitvector<32>
       return FormulaType.getBitvectorTypeWithSize(
           Integer.parseInt(t.substring(10, t.length() - 1)));
+    } else if (t.matches(".*\\(.*\\)")) {
+      // Color (Red, Green, Blue)
+      String name = t.substring(0, t.indexOf("(") - 1);
+      String elementsStr = t.substring(t.indexOf("(") + 1, t.length() - 1);
+      Set<String> elements = ImmutableSet.copyOf(Splitter.on(", ").split(elementsStr));
+      return new EnumerationFormulaType(name, elements);
     } else {
       throw new AssertionError("unknown type:" + t);
     }

--- a/src/org/sosy_lab/java_smt/api/FormulaType.java
+++ b/src/org/sosy_lab/java_smt/api/FormulaType.java
@@ -352,12 +352,16 @@ public abstract class FormulaType<T extends Formula> {
     }
   }
 
+  public static EnumerationFormulaType getEnumerationType(String pName, Set<String> pElements) {
+    return new EnumerationFormulaType(pName, pElements);
+  }
+
   public static final class EnumerationFormulaType extends FormulaType<EnumerationFormula> {
 
     private final String name;
     private final ImmutableSet<String> elements;
 
-    public EnumerationFormulaType(String pName, Set<String> pElements) {
+    private EnumerationFormulaType(String pName, Set<String> pElements) {
       this.name = Preconditions.checkNotNull(pName);
       this.elements = ImmutableSet.copyOf(pElements);
     }

--- a/src/org/sosy_lab/java_smt/api/visitors/FormulaVisitor.java
+++ b/src/org/sosy_lab/java_smt/api/visitors/FormulaVisitor.java
@@ -45,11 +45,13 @@ public interface FormulaVisitor<R> {
   R visitBoundVariable(Formula f, int deBruijnIdx);
 
   /**
-   * Visit a constant, such as "true"/"false" or a numeric constant like "1" or "1.0".
+   * Visit a constant, such as "true"/"false", a numeric constant like "1" or "1.0", a String
+   * constant like 2hello world" or enumeration constant like "Blue".
    *
    * @param f Formula representing the constant.
-   * @param value The value of the constant. It is either of type {@link Boolean} or of a subtype of
-   *     {@link Number}, mostly a {@link BigInteger}, a {@link BigDecimal}, or a {@link Rational}.
+   * @param value The value of the constant. It is either of type {@link Boolean}, of a subtype of
+   *     {@link Number} (mostly a {@link BigInteger}, a {@link BigDecimal}, or a {@link Rational}),
+   *     or {@link String}.
    * @return An arbitrary return value that is passed to the caller.
    */
   R visitConstant(Formula f, Object value);

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractEnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractEnumerationFormulaManager.java
@@ -1,0 +1,83 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.basicimpl;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.sosy_lab.java_smt.basicimpl.AbstractFormulaManager.checkVariableName;
+
+import com.google.common.base.Preconditions;
+import java.util.Set;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormulaManager;
+import org.sosy_lab.java_smt.api.FormulaType;
+import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
+
+public abstract class AbstractEnumerationFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl>
+    extends AbstractBaseFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl>
+    implements EnumerationFormulaManager {
+
+  AbstractEnumerationFormulaManager(
+      FormulaCreator<TFormulaInfo, TType, TEnv, TFuncDecl> pFormulaCreator) {
+    super(pFormulaCreator);
+  }
+
+  private EnumerationFormula wrap(TFormulaInfo pTerm) {
+    return getFormulaCreator().encapsulateEnumeration(pTerm);
+  }
+
+  private void checkSameEnumerationType(EnumerationFormula pF1, EnumerationFormula pF2) {
+    final FormulaType<?> type1 = formulaCreator.getFormulaType(pF1);
+    final FormulaType<?> type2 = formulaCreator.getFormulaType(pF2);
+    checkArgument(type1 instanceof EnumerationFormulaType);
+    checkArgument(type2 instanceof EnumerationFormulaType);
+    checkArgument(
+        type1.equals(type2),
+        "Can't compare element of type %s with element of type %s.",
+        type1,
+        type2);
+  }
+
+  @Override
+  public EnumerationFormulaType declareEnumeration(String pName, Set<String> pElementNames) {
+    checkVariableName(pName);
+    return declareEnumerationImpl(pName, pElementNames);
+  }
+
+  protected abstract EnumerationFormulaType declareEnumerationImpl(
+      String pName, Set<String> pElementNames);
+
+  @Override
+  public EnumerationFormula makeConstant(String pName, EnumerationFormulaType pType) {
+    Preconditions.checkArgument(
+        pType.getElements().contains(pName),
+        "Constant '%s' is not available in the enumeration type '%s'",
+        pName,
+        pType);
+    return wrap(makeConstantImpl(pName, pType));
+  }
+
+  protected abstract TFormulaInfo makeConstantImpl(String pName, EnumerationFormulaType pType);
+
+  @Override
+  public EnumerationFormula makeVariable(String pVar, EnumerationFormulaType pType) {
+    checkVariableName(pVar);
+    return wrap(makeVariableImpl(pVar, pType));
+  }
+
+  protected abstract TFormulaInfo makeVariableImpl(String pVar, EnumerationFormulaType pType);
+
+  @Override
+  public BooleanFormula equivalence(EnumerationFormula pF1, EnumerationFormula pF2) {
+    this.checkSameEnumerationType(pF1, pF2);
+    return wrapBool(equivalenceImpl(extractInfo(pF1), extractInfo(pF2)));
+  }
+
+  protected abstract TFormulaInfo equivalenceImpl(TFormulaInfo f1, TFormulaInfo f2);
+}

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractEnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractEnumerationFormulaManager.java
@@ -24,7 +24,7 @@ public abstract class AbstractEnumerationFormulaManager<TFormulaInfo, TType, TEn
     extends AbstractBaseFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl>
     implements EnumerationFormulaManager {
 
-  AbstractEnumerationFormulaManager(
+  protected AbstractEnumerationFormulaManager(
       FormulaCreator<TFormulaInfo, TType, TEnv, TFuncDecl> pFormulaCreator) {
     super(pFormulaCreator);
   }
@@ -80,5 +80,5 @@ public abstract class AbstractEnumerationFormulaManager<TFormulaInfo, TType, TEn
     return wrapBool(equivalenceImpl(extractInfo(pF1), extractInfo(pF2)));
   }
 
-  protected abstract TFormulaInfo equivalenceImpl(TFormulaInfo f1, TFormulaInfo f2);
+  protected abstract TFormulaInfo equivalenceImpl(TFormulaInfo pF1, TFormulaInfo pF2);
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractEnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractEnumerationFormulaManager.java
@@ -30,9 +30,9 @@ public abstract class AbstractEnumerationFormulaManager<TFormulaInfo, TType, TEn
 
   /** The class 'EnumType' is just a plain internal value-holding class. */
   protected class EnumType {
-    public final EnumerationFormulaType enumerationFormulaType;
-    public final TType nativeType;
-    public final ImmutableMap<String, TFormulaInfo> constants;
+    private final EnumerationFormulaType enumerationFormulaType;
+    private final TType nativeType;
+    private final ImmutableMap<String, TFormulaInfo> constants;
 
     public EnumType(
         EnumerationFormulaType pEnumerationFormulaType,
@@ -41,6 +41,14 @@ public abstract class AbstractEnumerationFormulaManager<TFormulaInfo, TType, TEn
       enumerationFormulaType = pEnumerationFormulaType;
       nativeType = pNativeType;
       constants = pConstants;
+    }
+
+    public EnumerationFormulaType getEnumerationFormulaType() {
+      return enumerationFormulaType;
+    }
+
+    public boolean hasConstants(String name) {
+      return constants.containsKey(name);
     }
   }
 
@@ -80,10 +88,10 @@ public abstract class AbstractEnumerationFormulaManager<TFormulaInfo, TType, TEn
       enumerations.put(pName, declareEnumeration0(type));
     } else {
       Preconditions.checkArgument(
-          type.equals(existingType.enumerationFormulaType),
+          type.equals(existingType.getEnumerationFormulaType()),
           "Enumeration type '%s' is already declared as '%s'.",
           type,
-          existingType.enumerationFormulaType);
+          existingType.getEnumerationFormulaType());
     }
     return type;
   }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractEnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractEnumerationFormulaManager.java
@@ -19,6 +19,7 @@ import org.sosy_lab.java_smt.api.EnumerationFormulaManager;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
 
+@SuppressWarnings("ClassTypeParameterName")
 public abstract class AbstractEnumerationFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl>
     extends AbstractBaseFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl>
     implements EnumerationFormulaManager {

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractEvaluator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractEvaluator.java
@@ -15,6 +15,7 @@ import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.Evaluator;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
@@ -72,6 +73,13 @@ public abstract class AbstractEvaluator<TFormulaInfo, TType, TEnv> implements Ev
   @Nullable
   @Override
   public final String evaluate(StringFormula f) {
+    Preconditions.checkState(!isClosed());
+    return (String) evaluateImpl(creator.extractInfo(f));
+  }
+
+  @Nullable
+  @Override
+  public final String evaluate(EnumerationFormula f) {
     Preconditions.checkState(!isClosed());
     return (String) evaluateImpl(creator.extractInfo(f));
   }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractFormula.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractFormula.java
@@ -15,6 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingModeFormula;
 import org.sosy_lab.java_smt.api.Formula;
@@ -147,6 +148,14 @@ abstract class AbstractFormula<TFormulaInfo> implements Formula {
   static final class RegexFormulaImpl<TFormulaInfo> extends AbstractFormula<TFormulaInfo>
       implements RegexFormula {
     RegexFormulaImpl(TFormulaInfo pT) {
+      super(pT);
+    }
+  }
+
+  /** Simple EnumerationFormula implementation. */
+  static final class EnumerationFormulaImpl<TFormulaInfo> extends AbstractFormula<TFormulaInfo>
+      implements EnumerationFormula {
+    EnumerationFormulaImpl(TFormulaInfo pT) {
       super(pT);
     }
   }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java
@@ -24,6 +24,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.common.Appender;
 import org.sosy_lab.java_smt.api.ArrayFormulaManager;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormulaManager;
 import org.sosy_lab.java_smt.api.FloatingPointFormulaManager;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaManager;
@@ -120,6 +121,9 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
   private final @Nullable AbstractStringFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl>
       strManager;
 
+  private final @Nullable AbstractEnumerationFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl>
+      enumManager;
+
   private final FormulaCreator<TFormulaInfo, TType, TEnv, TFuncDecl> formulaCreator;
 
   /** Builds a solver from the given theory implementations. */
@@ -138,7 +142,9 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
           quantifiedManager,
       @Nullable AbstractArrayFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl> arrayManager,
       @Nullable AbstractSLFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl> slManager,
-      @Nullable AbstractStringFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl> strManager) {
+      @Nullable AbstractStringFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl> strManager,
+      @Nullable AbstractEnumerationFormulaManager<TFormulaInfo, TType, TEnv, TFuncDecl>
+          enumManager) {
 
     this.arrayManager = arrayManager;
     this.quantifiedManager = quantifiedManager;
@@ -150,6 +156,7 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
     this.floatingPointManager = floatingPointManager;
     this.slManager = slManager;
     this.strManager = strManager;
+    this.enumManager = enumManager;
     this.formulaCreator = pFormulaCreator;
 
     checkArgument(
@@ -157,7 +164,9 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
             && functionManager.getFormulaCreator() == formulaCreator
             && !(bitvectorManager != null && bitvectorManager.getFormulaCreator() != formulaCreator)
             && !(floatingPointManager != null
-                && floatingPointManager.getFormulaCreator() != formulaCreator),
+                && floatingPointManager.getFormulaCreator() != formulaCreator)
+            && !(quantifiedManager != null
+                && quantifiedManager.getFormulaCreator() != formulaCreator),
         "The creator instances must match across the managers!");
   }
 
@@ -212,7 +221,7 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
   @Override
   public SLFormulaManager getSLFormulaManager() {
     if (slManager == null) {
-      throw new UnsupportedOperationException("Solver does not support seperation logic theory");
+      throw new UnsupportedOperationException("Solver does not support separation logic theory");
     }
     return slManager;
   }
@@ -240,6 +249,14 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
       throw new UnsupportedOperationException("Solver does not support string theory");
     }
     return strManager;
+  }
+
+  @Override
+  public EnumerationFormulaManager getEnumerationFormulaManager() {
+    if (enumManager == null) {
+      throw new UnsupportedOperationException("Solver does not support enumeration theory");
+    }
+    return enumManager;
   }
 
   public abstract Appender dumpFormula(TFormulaInfo t);

--- a/src/org/sosy_lab/java_smt/basicimpl/CachingModel.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/CachingModel.java
@@ -15,6 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
@@ -76,6 +77,11 @@ public class CachingModel implements Model {
 
   @Override
   public @Nullable String evaluate(StringFormula formula) {
+    return delegate.evaluate(formula);
+  }
+
+  @Override
+  public @Nullable String evaluate(EnumerationFormula formula) {
     return delegate.evaluate(formula);
   }
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/FormulaCreator.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingModeFormula;
 import org.sosy_lab.java_smt.api.Formula;
@@ -48,6 +49,7 @@ import org.sosy_lab.java_smt.api.visitors.TraversalProcess;
 import org.sosy_lab.java_smt.basicimpl.AbstractFormula.ArrayFormulaImpl;
 import org.sosy_lab.java_smt.basicimpl.AbstractFormula.BitvectorFormulaImpl;
 import org.sosy_lab.java_smt.basicimpl.AbstractFormula.BooleanFormulaImpl;
+import org.sosy_lab.java_smt.basicimpl.AbstractFormula.EnumerationFormulaImpl;
 import org.sosy_lab.java_smt.basicimpl.AbstractFormula.FloatingPointFormulaImpl;
 import org.sosy_lab.java_smt.basicimpl.AbstractFormula.FloatingPointRoundingModeFormulaImpl;
 import org.sosy_lab.java_smt.basicimpl.AbstractFormula.IntegerFormulaImpl;
@@ -170,6 +172,11 @@ public abstract class FormulaCreator<TFormulaInfo, TType, TEnv, TFuncDecl> {
     return new RegexFormulaImpl<>(pTerm);
   }
 
+  protected EnumerationFormula encapsulateEnumeration(TFormulaInfo pTerm) {
+    assert getFormulaType(pTerm).isEnumerationType();
+    return new EnumerationFormulaImpl<>(pTerm);
+  }
+
   public Formula encapsulateWithTypeOf(TFormulaInfo pTerm) {
     return encapsulate(getFormulaType(pTerm), pTerm);
   }
@@ -199,6 +206,8 @@ public abstract class FormulaCreator<TFormulaInfo, TType, TEnv, TFuncDecl> {
     } else if (pType.isArrayType()) {
       ArrayFormulaType<?, ?> arrayType = (ArrayFormulaType<?, ?>) pType;
       return (T) encapsulateArray(pTerm, arrayType.getIndexType(), arrayType.getElementType());
+    } else if (pType.isEnumerationType()) {
+      return (T) new EnumerationFormulaImpl<>(pTerm);
     }
     throw new IllegalArgumentException(
         "Cannot create formulas of type " + pType + " in the Solver!");
@@ -249,6 +258,10 @@ public abstract class FormulaCreator<TFormulaInfo, TType, TEnv, TFuncDecl> {
       throw new UnsupportedOperationException(
           "SMT solvers with support for bitvectors "
               + "need to overwrite FormulaCreator.getFormulaType()");
+    } else if (formula instanceof EnumerationFormula) {
+      throw new UnsupportedOperationException(
+          "SMT solvers with support for enumerations need to overwrite FormulaCreator"
+              + ".getFormulaType()");
     } else {
       throw new IllegalArgumentException("Formula with unexpected type " + formula.getClass());
     }

--- a/src/org/sosy_lab/java_smt/delegate/statistics/SolverStatistics.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/SolverStatistics.java
@@ -38,6 +38,8 @@ public class SolverStatistics {
   final AtomicInteger fpOperations = new AtomicInteger();
   final AtomicInteger typeOperations = new AtomicInteger();
   final AtomicInteger stringOperations = new AtomicInteger();
+  final AtomicInteger enumerationDeclarations = new AtomicInteger();
+  final AtomicInteger enumerationOperations = new AtomicInteger();
 
   // model operations
   final AtomicInteger modelEvaluations = new AtomicInteger();

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsEnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsEnumerationFormulaManager.java
@@ -1,0 +1,54 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.delegate.statistics;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Set;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormulaManager;
+import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
+
+public class StatisticsEnumerationFormulaManager implements EnumerationFormulaManager {
+
+  private final EnumerationFormulaManager delegate;
+  private final SolverStatistics stats;
+
+  StatisticsEnumerationFormulaManager(
+      EnumerationFormulaManager pDelegate, SolverStatistics pStats) {
+    delegate = checkNotNull(pDelegate);
+    stats = checkNotNull(pStats);
+  }
+
+  @Override
+  public EnumerationFormulaType declareEnumeration(String name, Set<String> elementNames) {
+    stats.enumerationDeclarations.getAndIncrement();
+    return delegate.declareEnumeration(name, elementNames);
+  }
+
+  @Override
+  public EnumerationFormula makeConstant(String pName, EnumerationFormulaType pType) {
+    stats.enumerationOperations.getAndIncrement();
+    return delegate.makeConstant(pName, pType);
+  }
+
+  @Override
+  public EnumerationFormula makeVariable(String pVar, EnumerationFormulaType pType) {
+    stats.enumerationOperations.getAndIncrement();
+    return delegate.makeVariable(pVar, pType);
+  }
+
+  @Override
+  public BooleanFormula equivalence(
+      EnumerationFormula pEnumeration1, EnumerationFormula pEnumeration2) {
+    stats.enumerationOperations.getAndIncrement();
+    return delegate.equivalence(pEnumeration1, pEnumeration2);
+  }
+}

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsFormulaManager.java
@@ -20,6 +20,7 @@ import org.sosy_lab.java_smt.api.ArrayFormulaManager;
 import org.sosy_lab.java_smt.api.BitvectorFormulaManager;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.EnumerationFormulaManager;
 import org.sosy_lab.java_smt.api.FloatingPointFormulaManager;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaManager;
@@ -95,6 +96,11 @@ class StatisticsFormulaManager implements FormulaManager {
   @Override
   public StringFormulaManager getStringFormulaManager() {
     return new StatisticsStringFormulaManager(delegate.getStringFormulaManager(), stats);
+  }
+
+  @Override
+  public EnumerationFormulaManager getEnumerationFormulaManager() {
+    return new StatisticsEnumerationFormulaManager(delegate.getEnumerationFormulaManager(), stats);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsModel.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsModel.java
@@ -16,6 +16,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
@@ -70,6 +71,12 @@ class StatisticsModel implements Model {
 
   @Override
   public @Nullable String evaluate(StringFormula pF) {
+    stats.modelEvaluations.getAndIncrement();
+    return delegate.evaluate(pF);
+  }
+
+  @Override
+  public @Nullable String evaluate(EnumerationFormula pF) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.evaluate(pF);
   }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedEnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedEnumerationFormulaManager.java
@@ -1,0 +1,58 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.delegate.synchronize;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Set;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormulaManager;
+import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
+import org.sosy_lab.java_smt.api.SolverContext;
+
+public class SynchronizedEnumerationFormulaManager implements EnumerationFormulaManager {
+
+  private final EnumerationFormulaManager delegate;
+  private final SolverContext sync;
+
+  SynchronizedEnumerationFormulaManager(EnumerationFormulaManager pDelegate, SolverContext pSync) {
+    delegate = checkNotNull(pDelegate);
+    sync = checkNotNull(pSync);
+  }
+
+  @Override
+  public EnumerationFormulaType declareEnumeration(String name, Set<String> elementNames) {
+    synchronized (sync) {
+      return delegate.declareEnumeration(name, elementNames);
+    }
+  }
+
+  @Override
+  public EnumerationFormula makeConstant(String pName, EnumerationFormulaType pType) {
+    synchronized (sync) {
+      return delegate.makeConstant(pName, pType);
+    }
+  }
+
+  @Override
+  public EnumerationFormula makeVariable(String pVar, EnumerationFormulaType pType) {
+    synchronized (sync) {
+      return delegate.makeVariable(pVar, pType);
+    }
+  }
+
+  @Override
+  public BooleanFormula equivalence(
+      EnumerationFormula pEnumeration1, EnumerationFormula pEnumeration2) {
+    synchronized (sync) {
+      return delegate.equivalence(pEnumeration1, pEnumeration2);
+    }
+  }
+}

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedFormulaManager.java
@@ -20,6 +20,7 @@ import org.sosy_lab.java_smt.api.ArrayFormulaManager;
 import org.sosy_lab.java_smt.api.BitvectorFormulaManager;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.EnumerationFormulaManager;
 import org.sosy_lab.java_smt.api.FloatingPointFormulaManager;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaManager;
@@ -115,6 +116,14 @@ class SynchronizedFormulaManager implements FormulaManager {
   public StringFormulaManager getStringFormulaManager() {
     synchronized (sync) {
       return new SynchronizedStringFormulaManager(delegate.getStringFormulaManager(), sync);
+    }
+  }
+
+  @Override
+  public EnumerationFormulaManager getEnumerationFormulaManager() {
+    synchronized (sync) {
+      return new SynchronizedEnumerationFormulaManager(
+          delegate.getEnumerationFormulaManager(), sync);
     }
   }
 

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModel.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModel.java
@@ -16,6 +16,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
@@ -77,6 +78,13 @@ class SynchronizedModel implements Model {
 
   @Override
   public @Nullable String evaluate(StringFormula pF) {
+    synchronized (sync) {
+      return delegate.evaluate(pF);
+    }
+  }
+
+  @Override
+  public @Nullable String evaluate(EnumerationFormula pF) {
     synchronized (sync) {
       return delegate.evaluate(pF);
     }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModelWithContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModelWithContext.java
@@ -16,6 +16,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaManager;
 import org.sosy_lab.java_smt.api.Model;
@@ -78,6 +79,11 @@ class SynchronizedModelWithContext implements Model {
 
   @Override
   public @Nullable String evaluate(StringFormula pF) {
+    throw new UnsupportedOperationException(UNSUPPORTED_OPERATION);
+  }
+
+  @Override
+  public @Nullable String evaluate(EnumerationFormula pF) {
     throw new UnsupportedOperationException(UNSUPPORTED_OPERATION);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorFormulaManager.java
@@ -35,6 +35,7 @@ final class BoolectorFormulaManager extends AbstractFormulaManager<Long, Long, L
         pQuantifierManager,
         pArrayManager,
         null,
+        null,
         null);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaManager.java
@@ -53,7 +53,8 @@ class CVC4FormulaManager extends AbstractFormulaManager<Expr, Type, ExprManager,
         pQfmgr,
         pAfmgr,
         pSLfmgr,
-        pStrmgr);
+        pStrmgr,
+        null);
     creator = pFormulaCreator;
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5EnumerationFormulaManager.java
@@ -8,17 +8,12 @@
 
 package org.sosy_lab.java_smt.solvers.cvc5;
 
-import com.google.common.base.Preconditions;
-import io.github.cvc5.Datatype;
+import com.google.common.collect.ImmutableMap;
 import io.github.cvc5.DatatypeConstructorDecl;
 import io.github.cvc5.Kind;
 import io.github.cvc5.Solver;
 import io.github.cvc5.Sort;
 import io.github.cvc5.Term;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
 import org.sosy_lab.java_smt.basicimpl.AbstractEnumerationFormulaManager;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
@@ -26,20 +21,7 @@ import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
 public class CVC5EnumerationFormulaManager
     extends AbstractEnumerationFormulaManager<Term, Sort, Solver, Term> {
 
-  /** The class 'EnumType' is just a plain internal value-holding class. */
-  private static class EnumType {
-    private final EnumerationFormulaType eType;
-    private final Sort sort;
-
-    private EnumType(EnumerationFormulaType pEType, Sort pSort) {
-      eType = pEType;
-      sort = pSort;
-    }
-  }
-
   private final Solver solver;
-
-  private final Map<String, EnumType> enumerations = new LinkedHashMap<>();
 
   protected CVC5EnumerationFormulaManager(FormulaCreator<Term, Sort, Solver, Term> pCreator) {
     super(pCreator);
@@ -47,40 +29,20 @@ public class CVC5EnumerationFormulaManager
   }
 
   @Override
-  protected EnumerationFormulaType declareEnumerationImpl(String pName, Set<String> pElementNames) {
-    final EnumerationFormulaType type = FormulaType.getEnumerationType(pName, pElementNames);
-    EnumType existingType = enumerations.get(pName);
-    if (existingType == null) {
-      enumerations.put(pName, declareEnumeration0(type));
-    } else {
-      Preconditions.checkArgument(
-          type.equals(existingType.eType),
-          "Enumeration type '%s' is already declared as '%s'.",
-          type,
-          existingType.eType);
-    }
-    return type;
-  }
-
-  private EnumType declareEnumeration0(EnumerationFormulaType pType) {
+  protected EnumType declareEnumeration0(EnumerationFormulaType pType) {
     DatatypeConstructorDecl[] constructors =
         pType.getElements().stream()
             .map(solver::mkDatatypeConstructorDecl)
             .toArray(DatatypeConstructorDecl[]::new);
     Sort enumType = solver.declareDatatype(pType.getName(), constructors);
-    return new EnumType(pType, enumType);
-  }
 
-  @Override
-  protected Term makeConstantImpl(String pName, EnumerationFormulaType pType) {
-    Datatype enumType = enumerations.get(pType.getName()).sort.getDatatype();
-    return solver.mkTerm(Kind.APPLY_CONSTRUCTOR, enumType.getConstructor(pName).getTerm());
-  }
-
-  @Override
-  protected Term makeVariableImpl(String pVar, EnumerationFormulaType pType) {
-    Sort enumType = enumerations.get(pType.getName()).sort;
-    return getFormulaCreator().makeVariable(enumType, pVar);
+    // we store the constants for later access
+    ImmutableMap.Builder<String, Term> constantsMapping = ImmutableMap.builder();
+    for (String element : pType.getElements()) {
+      Term decl = enumType.getDatatype().getConstructor(element).getTerm();
+      constantsMapping.put(element, solver.mkTerm(Kind.APPLY_CONSTRUCTOR, decl));
+    }
+    return new EnumType(pType, enumType, constantsMapping.buildOrThrow());
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5EnumerationFormulaManager.java
@@ -1,0 +1,90 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.solvers.cvc5;
+
+import com.google.common.base.Preconditions;
+import io.github.cvc5.Datatype;
+import io.github.cvc5.DatatypeConstructorDecl;
+import io.github.cvc5.Kind;
+import io.github.cvc5.Solver;
+import io.github.cvc5.Sort;
+import io.github.cvc5.Term;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.sosy_lab.java_smt.api.FormulaType;
+import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
+import org.sosy_lab.java_smt.basicimpl.AbstractEnumerationFormulaManager;
+import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
+
+public class CVC5EnumerationFormulaManager
+    extends AbstractEnumerationFormulaManager<Term, Sort, Solver, Term> {
+
+  /** The class 'EnumType' is just a plain internal value-holding class. */
+  private static class EnumType {
+    private final EnumerationFormulaType eType;
+    private final Sort sort;
+
+    private EnumType(EnumerationFormulaType pEType, Sort pSort) {
+      eType = pEType;
+      sort = pSort;
+    }
+  }
+
+  private final Solver solver;
+
+  private final Map<String, EnumType> enumerations = new LinkedHashMap<>();
+
+  protected CVC5EnumerationFormulaManager(FormulaCreator<Term, Sort, Solver, Term> pCreator) {
+    super(pCreator);
+    solver = pCreator.getEnv();
+  }
+
+  @Override
+  protected EnumerationFormulaType declareEnumerationImpl(String pName, Set<String> pElementNames) {
+    final EnumerationFormulaType type = FormulaType.getEnumerationType(pName, pElementNames);
+    EnumType existingType = enumerations.get(pName);
+    if (existingType == null) {
+      enumerations.put(pName, declareEnumeration0(type));
+    } else {
+      Preconditions.checkArgument(
+          type.equals(existingType.eType),
+          "Enumeration type '%s' is already declared as '%s'.",
+          type,
+          existingType.eType);
+    }
+    return type;
+  }
+
+  private EnumType declareEnumeration0(EnumerationFormulaType pType) {
+    DatatypeConstructorDecl[] constructors =
+        pType.getElements().stream()
+            .map(solver::mkDatatypeConstructorDecl)
+            .toArray(DatatypeConstructorDecl[]::new);
+    Sort enumType = solver.declareDatatype(pType.getName(), constructors);
+    return new EnumType(pType, enumType);
+  }
+
+  @Override
+  protected Term makeConstantImpl(String pName, EnumerationFormulaType pType) {
+    Datatype enumType = enumerations.get(pType.getName()).sort.getDatatype();
+    return solver.mkTerm(Kind.APPLY_CONSTRUCTOR, enumType.getConstructor(pName).getTerm());
+  }
+
+  @Override
+  protected Term makeVariableImpl(String pVar, EnumerationFormulaType pType) {
+    Sort enumType = enumerations.get(pType.getName()).sort;
+    return getFormulaCreator().makeVariable(enumType, pVar);
+  }
+
+  @Override
+  protected Term equivalenceImpl(Term pF1, Term pF2) {
+    return solver.mkTerm(Kind.EQUAL, pF1, pF2);
+  }
+}

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Formula.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Formula.java
@@ -13,6 +13,7 @@ import io.github.cvc5.Term;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingModeFormula;
 import org.sosy_lab.java_smt.api.Formula;
@@ -133,6 +134,13 @@ public class CVC5Formula implements Formula {
   @Immutable
   static final class CVC5RegexFormula extends CVC5Formula implements RegexFormula {
     CVC5RegexFormula(Term pTerm) {
+      super(pTerm);
+    }
+  }
+
+  @Immutable
+  static final class CVC5EnumerationFormula extends CVC5Formula implements EnumerationFormula {
+    CVC5EnumerationFormula(Term pTerm) {
       super(pTerm);
     }
   }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
@@ -54,7 +54,8 @@ class CVC5FormulaManager extends AbstractFormulaManager<Term, Sort, Solver, Term
         pQfmgr,
         pAfmgr,
         pSLfmgr,
-        pStrmgr);
+        pStrmgr,
+        null);
     creator = pFormulaCreator;
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
@@ -42,7 +42,8 @@ class CVC5FormulaManager extends AbstractFormulaManager<Term, Sort, Solver, Term
       CVC5QuantifiedFormulaManager pQfmgr,
       CVC5ArrayFormulaManager pAfmgr,
       CVC5SLFormulaManager pSLfmgr,
-      CVC5StringFormulaManager pStrmgr) {
+      CVC5StringFormulaManager pStrmgr,
+      CVC5EnumerationFormulaManager pEfmgr) {
     super(
         pFormulaCreator,
         pFfmgr,
@@ -55,7 +56,7 @@ class CVC5FormulaManager extends AbstractFormulaManager<Term, Sort, Solver, Term
         pAfmgr,
         pSLfmgr,
         pStrmgr,
-        null);
+        pEfmgr);
     creator = pFormulaCreator;
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
@@ -89,6 +89,7 @@ public final class CVC5SolverContext extends AbstractSolverContext {
     CVC5ArrayFormulaManager arrayTheory = new CVC5ArrayFormulaManager(pCreator);
     CVC5SLFormulaManager slTheory = new CVC5SLFormulaManager(pCreator);
     CVC5StringFormulaManager strTheory = new CVC5StringFormulaManager(pCreator);
+    CVC5EnumerationFormulaManager enumTheory = new CVC5EnumerationFormulaManager(pCreator);
     CVC5FormulaManager manager =
         new CVC5FormulaManager(
             pCreator,
@@ -101,7 +102,8 @@ public final class CVC5SolverContext extends AbstractSolverContext {
             qfTheory,
             arrayTheory,
             slTheory,
-            strTheory);
+            strTheory,
+            enumTheory);
 
     return new CVC5SolverContext(pCreator, manager, pShutdownNotifier, newSolver, randomSeed);
   }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5EnumerationFormulaManager.java
@@ -8,7 +8,6 @@
 
 package org.sosy_lab.java_smt.solvers.mathsat5;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_get_enum_constants;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_get_enum_type;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_equal;
@@ -17,10 +16,6 @@ import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
 import org.sosy_lab.java_smt.basicimpl.AbstractEnumerationFormulaManager;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
@@ -28,23 +23,7 @@ import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
 public class Mathsat5EnumerationFormulaManager
     extends AbstractEnumerationFormulaManager<Long, Long, Long, Long> {
 
-  /** The class 'EnumType' is just a plain internal value-holding class. */
-  private static class EnumType {
-    private final EnumerationFormulaType eType;
-    private final long type;
-    private final ImmutableMap<String, Long> constants;
-
-    private EnumType(
-        EnumerationFormulaType pEType, long pType, ImmutableMap<String, Long> pConstants) {
-      eType = pEType;
-      type = pType;
-      constants = pConstants;
-    }
-  }
-
   private final long mathsatEnv;
-
-  private final Map<String, EnumType> enumerations = new LinkedHashMap<>();
 
   protected Mathsat5EnumerationFormulaManager(FormulaCreator<Long, Long, Long, Long> pCreator) {
     super(pCreator);
@@ -52,22 +31,7 @@ public class Mathsat5EnumerationFormulaManager
   }
 
   @Override
-  protected EnumerationFormulaType declareEnumerationImpl(String pName, Set<String> pElementNames) {
-    final EnumerationFormulaType type = FormulaType.getEnumerationType(pName, pElementNames);
-    EnumType existingType = enumerations.get(pName);
-    if (existingType == null) {
-      enumerations.put(pName, declareEnumeration0(type));
-    } else {
-      Preconditions.checkArgument(
-          type.equals(existingType.eType),
-          "Enumeration type '%s' is already declared as '%s'.",
-          type,
-          existingType.eType);
-    }
-    return type;
-  }
-
-  private EnumType declareEnumeration0(EnumerationFormulaType pType) {
+  protected EnumType declareEnumeration0(EnumerationFormulaType pType) {
 
     // MathSAT does not support equal-named enumeration elements in distinct enumeration types.
     for (EnumType existingType : enumerations.values()) {
@@ -75,7 +39,7 @@ public class Mathsat5EnumerationFormulaManager
           Iterables.all(pType.getElements(), e -> !existingType.constants.containsKey(e)),
           "Enumeration type '%s' has elements that already appear in enumeration type '%s'.",
           pType,
-          existingType.eType);
+          existingType.enumerationFormulaType);
     }
 
     String[] elements = pType.getElements().toArray(new String[] {});
@@ -89,16 +53,6 @@ public class Mathsat5EnumerationFormulaManager
       constantsMapping.put(elements[i], constant);
     }
     return new EnumType(pType, enumType, constantsMapping.buildOrThrow());
-  }
-
-  @Override
-  protected Long makeConstantImpl(String pName, EnumerationFormulaType pType) {
-    return checkNotNull(enumerations.get(pType.getName()).constants.get(pName));
-  }
-
-  @Override
-  protected Long makeVariableImpl(String pVar, EnumerationFormulaType pType) {
-    return getFormulaCreator().makeVariable(enumerations.get(pType.getName()).type, pVar);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5EnumerationFormulaManager.java
@@ -1,0 +1,108 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.solvers.mathsat5;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_get_enum_constants;
+import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_get_enum_type;
+import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_equal;
+import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_term;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.sosy_lab.java_smt.api.FormulaType;
+import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
+import org.sosy_lab.java_smt.basicimpl.AbstractEnumerationFormulaManager;
+import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
+
+public class Mathsat5EnumerationFormulaManager
+    extends AbstractEnumerationFormulaManager<Long, Long, Long, Long> {
+
+  /** The class 'EnumType' is just a plain internal value-holding class. */
+  private static class EnumType {
+    private final EnumerationFormulaType eType;
+    private final long type;
+    private final ImmutableMap<String, Long> constants;
+
+    private EnumType(
+        EnumerationFormulaType pEType, long pType, ImmutableMap<String, Long> pConstants) {
+      eType = pEType;
+      type = pType;
+      constants = pConstants;
+    }
+  }
+
+  private final long mathsatEnv;
+
+  private final Map<String, EnumType> enumerations = new LinkedHashMap<>();
+
+  protected Mathsat5EnumerationFormulaManager(FormulaCreator<Long, Long, Long, Long> pCreator) {
+    super(pCreator);
+    this.mathsatEnv = pCreator.getEnv();
+  }
+
+  @Override
+  protected EnumerationFormulaType declareEnumerationImpl(String pName, Set<String> pElementNames) {
+    final EnumerationFormulaType type = FormulaType.getEnumerationType(pName, pElementNames);
+    EnumType existingType = enumerations.get(pName);
+    if (existingType == null) {
+      enumerations.put(pName, declareEnumeration0(type));
+    } else {
+      Preconditions.checkArgument(
+          type.equals(existingType.eType),
+          "Enumeration type '%s' is already declared as '%s'.",
+          type,
+          existingType.eType);
+    }
+    return type;
+  }
+
+  private EnumType declareEnumeration0(EnumerationFormulaType pType) {
+
+    // MathSAT does not support equal-named enumeration elements in distinct enumeration types.
+    for (EnumType existingType : enumerations.values()) {
+      Preconditions.checkArgument(
+          Iterables.all(pType.getElements(), e -> !existingType.constants.containsKey(e)),
+          "Enumeration type '%s' has elements that already appear in enumeration type '%s'.",
+          pType,
+          existingType.eType);
+    }
+
+    String[] elements = pType.getElements().toArray(new String[] {});
+    long enumType = msat_get_enum_type(mathsatEnv, pType.getName(), elements.length, elements);
+
+    // we store the constants for later access
+    long[] constantDecls = msat_get_enum_constants(mathsatEnv, enumType);
+    ImmutableMap.Builder<String, Long> constantsMapping = ImmutableMap.builder();
+    for (int i = 0; i < elements.length; i++) {
+      long constant = msat_make_term(mathsatEnv, constantDecls[i], new long[] {});
+      constantsMapping.put(elements[i], constant);
+    }
+    return new EnumType(pType, enumType, constantsMapping.buildOrThrow());
+  }
+
+  @Override
+  protected Long makeConstantImpl(String pName, EnumerationFormulaType pType) {
+    return checkNotNull(enumerations.get(pType.getName()).constants.get(pName));
+  }
+
+  @Override
+  protected Long makeVariableImpl(String pVar, EnumerationFormulaType pType) {
+    return getFormulaCreator().makeVariable(enumerations.get(pType.getName()).type, pVar);
+  }
+
+  @Override
+  protected Long equivalenceImpl(Long pF1, Long pF2) {
+    return msat_make_equal(mathsatEnv, pF1, pF2);
+  }
+}

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5EnumerationFormulaManager.java
@@ -36,10 +36,10 @@ public class Mathsat5EnumerationFormulaManager
     // MathSAT does not support equal-named enumeration elements in distinct enumeration types.
     for (EnumType existingType : enumerations.values()) {
       Preconditions.checkArgument(
-          Iterables.all(pType.getElements(), e -> !existingType.constants.containsKey(e)),
+          Iterables.all(pType.getElements(), e -> !existingType.hasConstants(e)),
           "Enumeration type '%s' has elements that already appear in enumeration type '%s'.",
           pType,
-          existingType.enumerationFormulaType);
+          existingType.getEnumerationFormulaType());
     }
 
     String[] elements = pType.getElements().toArray(new String[] {});

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5Formula.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5Formula.java
@@ -12,6 +12,7 @@ import com.google.errorprone.annotations.Immutable;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingModeFormula;
 import org.sosy_lab.java_smt.api.Formula;
@@ -116,6 +117,14 @@ abstract class Mathsat5Formula implements Formula {
   @Immutable
   static final class Mathsat5BooleanFormula extends Mathsat5Formula implements BooleanFormula {
     Mathsat5BooleanFormula(long pTerm) {
+      super(pTerm);
+    }
+  }
+
+  @Immutable
+  static final class Mathsat5EnumerationFormula extends Mathsat5Formula
+      implements EnumerationFormula {
+    Mathsat5EnumerationFormula(long pTerm) {
       super(pTerm);
     }
   }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5FormulaManager.java
@@ -39,7 +39,8 @@ final class Mathsat5FormulaManager extends AbstractFormulaManager<Long, Long, Lo
       Mathsat5RationalFormulaManager pRationalManager,
       Mathsat5BitvectorFormulaManager pBitpreciseManager,
       Mathsat5FloatingPointFormulaManager pFloatingPointManager,
-      Mathsat5ArrayFormulaManager pArrayManager) {
+      Mathsat5ArrayFormulaManager pArrayManager,
+      Mathsat5EnumerationFormulaManager pEnumerationManager) {
     super(
         creator,
         pFunctionManager,
@@ -52,7 +53,7 @@ final class Mathsat5FormulaManager extends AbstractFormulaManager<Long, Long, Lo
         pArrayManager,
         null,
         null,
-        null);
+        pEnumerationManager);
   }
 
   static long getMsatTerm(Formula pT) {

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5FormulaManager.java
@@ -51,6 +51,7 @@ final class Mathsat5FormulaManager extends AbstractFormulaManager<Long, Long, Lo
         null,
         pArrayManager,
         null,
+        null,
         null);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApi.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApi.java
@@ -254,6 +254,8 @@ class Mathsat5NativeApi {
   public static native long msat_get_function_type(
       long e, long[] paramTypes, int size, long returnType);
 
+  public static native long msat_get_enum_type(long e, String name, int size, String[] elements);
+
   public static native boolean msat_is_bool_type(long e, long t);
 
   public static native boolean msat_is_rational_type(long e, long t);
@@ -273,6 +275,10 @@ class Mathsat5NativeApi {
   public static native int msat_get_fp_type_mant_width(long e, long t);
 
   public static native boolean msat_is_fp_roundingmode_type(long e, long t);
+
+  public static native boolean msat_is_enum_type(long e, long t);
+
+  public static native long[] msat_get_enum_constants(long e, long t);
 
   public static native boolean msat_type_equals(long t1, long t2);
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApi.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApi.java
@@ -276,7 +276,11 @@ class Mathsat5NativeApi {
 
   public static native boolean msat_is_fp_roundingmode_type(long e, long t);
 
-  public static native boolean msat_is_enum_type(long e, long t);
+  // disable this method until we get a proper MathSAT 5.6.9 or later.
+  // public static native boolean msat_is_enum_type(long e, long t);
+  public static boolean msat_is_enum_type(long e, long t) {
+    return false;
+  }
 
   public static native long[] msat_get_enum_constants(long e, long t);
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApiTest.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApiTest.java
@@ -482,6 +482,7 @@ public class Mathsat5NativeApiTest extends Mathsat5AbstractNativeApiTest {
   }
 
   @Test
+  @Ignore // disable until we have MathSAT 5.6.9 or later
   public void enumTypeTest() throws SolverException, InterruptedException {
     String[] colors = {"blue", "red", "green"};
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
@@ -195,6 +195,8 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
     Mathsat5FloatingPointFormulaManager floatingPointTheory =
         new Mathsat5FloatingPointFormulaManager(creator, pFloatingPointRoundingMode);
     Mathsat5ArrayFormulaManager arrayTheory = new Mathsat5ArrayFormulaManager(creator);
+    Mathsat5EnumerationFormulaManager enumerationTheory =
+        new Mathsat5EnumerationFormulaManager(creator);
     Mathsat5FormulaManager manager =
         new Mathsat5FormulaManager(
             creator,
@@ -204,7 +206,8 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
             rationalTheory,
             bitvectorTheory,
             floatingPointTheory,
-            arrayTheory);
+            arrayTheory,
+            enumerationTheory);
     return new Mathsat5SolverContext(
         logger, msatConf, settings, randomSeed, pShutdownNotifier, manager, creator);
   }

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
@@ -71,7 +71,6 @@ import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
 import org.sosy_lab.common.io.PathCounterTemplate;
 import org.sosy_lab.java_smt.api.FormulaType;
-import org.sosy_lab.java_smt.api.FormulaType.ArrayFormulaType;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import scala.Tuple2;
 import scala.Tuple4;
@@ -536,7 +535,7 @@ class PrincessEnvironment {
       Sort elementSort = ((ExtArray.ArraySort) sort).theory().objSort();
       assert indexSorts.iterator().size() == 1 : "unexpected index type in Array type:" + sort;
       // assert indexSorts.size() == 1; // TODO Eclipse does not like simpler code.
-      return new ArrayFormulaType<>(
+      return FormulaType.getArrayType(
           getFormulaTypeFromSort(indexSorts.iterator().next()), // get single index-sort
           getFormulaTypeFromSort(elementSort));
     } else if (sort instanceof MultipleValueBool$) {

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaCreator.java
@@ -56,7 +56,6 @@ import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
-import org.sosy_lab.java_smt.api.FormulaType.ArrayFormulaType;
 import org.sosy_lab.java_smt.api.FunctionDeclarationKind;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
@@ -193,7 +192,7 @@ class PrincessFormulaCreator
       final FormulaType<?> arrayIndexType = getArrayFormulaIndexType((ArrayFormula<?, ?>) pFormula);
       final FormulaType<?> arrayElementType =
           getArrayFormulaElementType((ArrayFormula<?, ?>) pFormula);
-      return (FormulaType<T>) new ArrayFormulaType<>(arrayIndexType, arrayElementType);
+      return (FormulaType<T>) FormulaType.getArrayType(arrayIndexType, arrayElementType);
     }
 
     return super.getFormulaType(pFormula);

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaManager.java
@@ -44,6 +44,7 @@ final class PrincessFormulaManager
         pQuantifierManager,
         pArrayManager,
         null,
+        null,
         null);
     creator = pCreator;
   }

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaCreator.java
@@ -29,7 +29,6 @@ import java.util.List;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
-import org.sosy_lab.java_smt.api.FormulaType.ArrayFormulaType;
 import org.sosy_lab.java_smt.api.FunctionDeclarationKind;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
@@ -64,7 +63,7 @@ class SmtInterpolFormulaCreator extends FormulaCreator<Term, Sort, Script, Funct
     } else if (pSort == getBoolType()) {
       return FormulaType.BooleanType;
     } else if (pSort.isArraySort()) {
-      return new FormulaType.ArrayFormulaType<>(
+      return FormulaType.getArrayType(
           getFormulaTypeOfSort(pSort.getArguments()[0]),
           getFormulaTypeOfSort(pSort.getArguments()[1]));
     } else {
@@ -79,7 +78,7 @@ class SmtInterpolFormulaCreator extends FormulaCreator<Term, Sort, Script, Funct
       final FormulaType<?> arrayIndexType = getArrayFormulaIndexType((ArrayFormula<?, ?>) pFormula);
       final FormulaType<?> arrayElementType =
           getArrayFormulaElementType((ArrayFormula<?, ?>) pFormula);
-      return (FormulaType<T>) new ArrayFormulaType<>(arrayIndexType, arrayElementType);
+      return (FormulaType<T>) FormulaType.getArrayType(arrayIndexType, arrayElementType);
     }
 
     return super.getFormulaType(pFormula);

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaManager.java
@@ -62,6 +62,7 @@ public class SmtInterpolFormulaManager
         null,
         pArrayFormulaManager,
         null,
+        null,
         null);
     logger = pLogger;
   }

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2FormulaManager.java
@@ -59,6 +59,7 @@ public class Yices2FormulaManager extends AbstractFormulaManager<Integer, Intege
         null,
         null,
         null,
+        null,
         null);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3EnumerationFormulaManager.java
@@ -1,0 +1,105 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.solvers.z3;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.z3.Native;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.sosy_lab.java_smt.api.FormulaType;
+import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
+import org.sosy_lab.java_smt.basicimpl.AbstractEnumerationFormulaManager;
+
+class Z3EnumerationFormulaManager
+    extends AbstractEnumerationFormulaManager<Long, Long, Long, Long> {
+
+  private static class EnumType {
+    private final EnumerationFormulaType eType;
+    private final long type;
+    private final ImmutableMap<String, Long> constants;
+
+    private EnumType(
+        EnumerationFormulaType pEType, long pType, ImmutableMap<String, Long> pConstants) {
+      eType = pEType;
+      type = pType;
+      constants = pConstants;
+    }
+  }
+
+  private final long z3context;
+
+  private final Map<String, EnumType> enumConstants = new LinkedHashMap<>();
+
+  Z3EnumerationFormulaManager(Z3FormulaCreator creator) {
+    super(creator);
+    this.z3context = creator.getEnv();
+  }
+
+  @Override
+  protected EnumerationFormulaType declareEnumerationImpl(String pName, Set<String> pElementNames) {
+    final EnumerationFormulaType type = FormulaType.getEnumerationType(pName, pElementNames);
+    EnumType existingType = enumConstants.get(pName);
+    if (existingType == null) {
+      enumConstants.put(pName, declareEnumeration0(type));
+    } else {
+      Preconditions.checkArgument(
+          type.equals(existingType.eType),
+          "Enumeration type '%s' is already declared as '%s'.",
+          type,
+          existingType.eType);
+    }
+    return type;
+  }
+
+  private EnumType declareEnumeration0(EnumerationFormulaType pType) {
+    long symbol = Native.mkStringSymbol(z3context, pType.getName());
+
+    String[] elements = pType.getElements().toArray(new String[] {});
+    long[] elementSymbols = new long[elements.length];
+    for (int i = 0; i < elements.length; i++) {
+      elementSymbols[i] = Native.mkStringSymbol(z3context, elements[i]);
+    }
+
+    long[] constants = new long[pType.getElements().size()];
+    long[] predicates = new long[pType.getElements().size()]; // unused later
+
+    long enumType =
+        Native.mkEnumerationSort(
+            z3context, symbol, elements.length, elementSymbols, constants, predicates);
+    Native.incRef(z3context, enumType);
+
+    // we store the constants for later access
+    ImmutableMap.Builder<String, Long> constantsMapping = ImmutableMap.builder();
+    for (int i = 0; i < elements.length; i++) {
+      long constantApp = Native.mkApp(z3context, constants[i], 0, null);
+      Native.incRef(z3context, constantApp);
+      constantsMapping.put(elements[i], constantApp);
+    }
+    return new EnumType(pType, enumType, constantsMapping.build());
+  }
+
+  @Override
+  protected Long makeConstantImpl(String pName, EnumerationFormulaType pType) {
+    return checkNotNull(enumConstants.get(pType.getName()).constants.get(pName));
+  }
+
+  @Override
+  protected Long makeVariableImpl(String pVar, EnumerationFormulaType pType) {
+    return getFormulaCreator().makeVariable(enumConstants.get(pType.getName()).type, pVar);
+  }
+
+  @Override
+  protected Long equivalenceImpl(Long pF1, Long pF2) {
+    return Native.mkEq(z3context, pF1, pF2);
+  }
+}

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3EnumerationFormulaManager.java
@@ -85,7 +85,7 @@ class Z3EnumerationFormulaManager
       Native.incRef(z3context, constantApp);
       constantsMapping.put(elements[i], constantApp);
     }
-    return new EnumType(pType, enumType, constantsMapping.build());
+    return new EnumType(pType, enumType, constantsMapping.buildOrThrow());
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3EnumerationFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3EnumerationFormulaManager.java
@@ -23,6 +23,7 @@ import org.sosy_lab.java_smt.basicimpl.AbstractEnumerationFormulaManager;
 class Z3EnumerationFormulaManager
     extends AbstractEnumerationFormulaManager<Long, Long, Long, Long> {
 
+  /** The class 'EnumType' is just a plain internal value-holding class. */
   private static class EnumType {
     private final EnumerationFormulaType eType;
     private final long type;
@@ -38,7 +39,7 @@ class Z3EnumerationFormulaManager
 
   private final long z3context;
 
-  private final Map<String, EnumType> enumConstants = new LinkedHashMap<>();
+  private final Map<String, EnumType> enumerations = new LinkedHashMap<>();
 
   Z3EnumerationFormulaManager(Z3FormulaCreator creator) {
     super(creator);
@@ -48,9 +49,9 @@ class Z3EnumerationFormulaManager
   @Override
   protected EnumerationFormulaType declareEnumerationImpl(String pName, Set<String> pElementNames) {
     final EnumerationFormulaType type = FormulaType.getEnumerationType(pName, pElementNames);
-    EnumType existingType = enumConstants.get(pName);
+    EnumType existingType = enumerations.get(pName);
     if (existingType == null) {
-      enumConstants.put(pName, declareEnumeration0(type));
+      enumerations.put(pName, declareEnumeration0(type));
     } else {
       Preconditions.checkArgument(
           type.equals(existingType.eType),
@@ -90,12 +91,12 @@ class Z3EnumerationFormulaManager
 
   @Override
   protected Long makeConstantImpl(String pName, EnumerationFormulaType pType) {
-    return checkNotNull(enumConstants.get(pType.getName()).constants.get(pName));
+    return checkNotNull(enumerations.get(pType.getName()).constants.get(pName));
   }
 
   @Override
   protected Long makeVariableImpl(String pVar, EnumerationFormulaType pType) {
-    return getFormulaCreator().makeVariable(enumConstants.get(pType.getName()).type, pVar);
+    return getFormulaCreator().makeVariable(enumerations.get(pType.getName()).type, pVar);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3Formula.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3Formula.java
@@ -16,6 +16,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingModeFormula;
 import org.sosy_lab.java_smt.api.Formula;
@@ -149,6 +150,13 @@ abstract class Z3Formula implements Formula {
   @Immutable
   static final class Z3RegexFormula extends Z3Formula implements RegexFormula {
     Z3RegexFormula(long z3context, long z3expr) {
+      super(z3context, z3expr);
+    }
+  }
+
+  @Immutable
+  static final class Z3EnumerationFormula extends Z3Formula implements EnumerationFormula {
+    Z3EnumerationFormula(long z3context, long z3expr) {
       super(z3context, z3expr);
     }
   }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
@@ -10,7 +10,6 @@ package org.sosy_lab.java_smt.solvers.z3;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -509,15 +508,10 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
 
   private FunctionDeclarationKind getDeclarationKind(long f) {
     final int arity = Native.getArity(environment, Native.getAppDecl(environment, f));
-    Preconditions.checkArgument(
-        arity > 0,
-        "Unexpected arity '%s' for formula '%s' for handling a function application.",
-        arity,
-        new Object() {
-          public String toString() {
-            return Native.astToString(environment, f);
-          }
-        });
+    assert arity > 0
+        : String.format(
+            "Unexpected arity '%s' for formula '%s' for handling a function application.",
+            arity, Native.astToString(environment, f));
     if (getAppName(f).equals("div0")) {
       // Z3 segfaults in getDeclKind for this term (cf. https://github.com/Z3Prover/z3/issues/669)
       return FunctionDeclarationKind.OTHER;

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
@@ -10,6 +10,7 @@ package org.sosy_lab.java_smt.solvers.z3;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -42,6 +43,7 @@ import org.sosy_lab.common.time.Timer;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingMode;
 import org.sosy_lab.java_smt.api.Formula;
@@ -58,6 +60,7 @@ import org.sosy_lab.java_smt.basicimpl.FunctionDeclarationImpl;
 import org.sosy_lab.java_smt.solvers.z3.Z3Formula.Z3ArrayFormula;
 import org.sosy_lab.java_smt.solvers.z3.Z3Formula.Z3BitvectorFormula;
 import org.sosy_lab.java_smt.solvers.z3.Z3Formula.Z3BooleanFormula;
+import org.sosy_lab.java_smt.solvers.z3.Z3Formula.Z3EnumerationFormula;
 import org.sosy_lab.java_smt.solvers.z3.Z3Formula.Z3FloatingPointFormula;
 import org.sosy_lab.java_smt.solvers.z3.Z3Formula.Z3FloatingPointRoundingModeFormula;
 import org.sosy_lab.java_smt.solvers.z3.Z3Formula.Z3IntegerFormula;
@@ -151,6 +154,7 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
     long z3context = getEnv();
     long symbol = Native.mkStringSymbol(z3context, varName);
     long var = Native.mkConst(z3context, symbol, type);
+    Native.incRef(z3context, var);
     symbolsToDeclarations.put(varName, Native.getAppDecl(z3context, var));
     return var;
   }
@@ -196,6 +200,14 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
       case Z3_RE_SORT:
         return FormulaType.RegexType;
       case Z3_DATATYPE_SORT:
+        int n = Native.getDatatypeSortNumConstructors(z3context, pSort);
+        ImmutableSet.Builder<String> elements = ImmutableSet.builder();
+        for (int i = 0; i < n; i++) {
+          long decl = Native.getDatatypeSortConstructor(z3context, pSort, i);
+          elements.add(symbolToString(Native.getDeclName(z3context, decl)));
+        }
+        return FormulaType.getEnumerationType(
+            Native.sortToString(z3context, pSort), elements.build());
       case Z3_RELATION_SORT:
       case Z3_FINITE_DOMAIN_SORT:
       case Z3_SEQ_SORT:
@@ -286,6 +298,8 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
           storePhantomReference(
               new Z3ArrayFormula<>(getEnv(), pTerm, arrFt.getIndexType(), arrFt.getElementType()),
               pTerm);
+    } else if (pType.isEnumerationType()) {
+      return (T) storePhantomReference(new Z3EnumerationFormula(getEnv(), pTerm), pTerm);
     }
 
     throw new IllegalArgumentException("Cannot create formulas of type " + pType + " in Z3");
@@ -332,6 +346,17 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
             Native.sortToString(getEnv(), Native.getSort(getEnv(), pTerm)));
     cleanupReferences();
     return storePhantomReference(new Z3RegexFormula(getEnv(), pTerm), pTerm);
+  }
+
+  @Override
+  protected EnumerationFormula encapsulateEnumeration(Long pTerm) {
+    assert getFormulaType(pTerm).isEnumerationType()
+        : String.format(
+            "Term %s has unexpected type %s.",
+            Native.astToString(getEnv(), pTerm),
+            Native.sortToString(getEnv(), Native.getSort(getEnv(), pTerm)));
+    cleanupReferences();
+    return storePhantomReference(new Z3EnumerationFormula(getEnv(), pTerm), pTerm);
   }
 
   @Override
@@ -413,6 +438,10 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
           } else if (declKind == Z3_decl_kind.Z3_OP_UNINTERPRETED.toInt()
               || declKind == Z3_decl_kind.Z3_OP_INTERNAL.toInt()) {
             return visitor.visitFreeVariable(formula, getAppName(f));
+
+            // enumeration constant
+          } else if (declKind == Z3_decl_kind.Z3_OP_DT_CONSTRUCTOR.toInt()) {
+            return visitor.visitConstant(formula, convertValue(f));
           } // else: fall-through with a function application
         }
 
@@ -479,8 +508,16 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
   }
 
   private FunctionDeclarationKind getDeclarationKind(long f) {
-    assert Native.getArity(environment, Native.getAppDecl(environment, f)) > 0
-        : "Variables should be handled in other branch.";
+    final int arity = Native.getArity(environment, Native.getAppDecl(environment, f));
+    Preconditions.checkArgument(
+        arity > 0,
+        "Unexpected arity '%s' for formula '%s' for handling a function application.",
+        arity,
+        new Object() {
+          public String toString() {
+            return Native.astToString(environment, f);
+          }
+        });
     if (getAppName(f).equals("div0")) {
       // Z3 segfaults in getDeclKind for this term (cf. https://github.com/Z3Prover/z3/issues/669)
       return FunctionDeclarationKind.OTHER;
@@ -776,9 +813,10 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
       } else if (type.isBitvectorType()) {
         return new BigInteger(Native.getNumeralString(environment, value));
       } else if (type.isFloatingPointType()) {
-
         // Converting to Rational first.
         return convertValue(Native.simplify(environment, Native.mkFpaToReal(environment, value)));
+      } else if (type.isEnumerationType()) {
+        return Native.astToString(environment, value);
       } else {
 
         // Explicitly crash on unknown type.

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaManager.java
@@ -41,7 +41,8 @@ final class Z3FormulaManager extends AbstractFormulaManager<Long, Long, Long, Lo
       Z3FloatingPointFormulaManager pFloatingPointManager,
       Z3QuantifiedFormulaManager pQuantifiedManager,
       Z3ArrayFormulaManager pArrayManager,
-      Z3StringFormulaManager pStringManager) {
+      Z3StringFormulaManager pStringManager,
+      Z3EnumerationFormulaManager pEnumerationManager) {
     super(
         pFormulaCreator,
         pFunctionManager,
@@ -54,7 +55,7 @@ final class Z3FormulaManager extends AbstractFormulaManager<Long, Long, Long, Lo
         pArrayManager,
         null,
         pStringManager,
-        null);
+        pEnumerationManager);
     formulaCreator = pFormulaCreator;
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaManager.java
@@ -53,7 +53,8 @@ final class Z3FormulaManager extends AbstractFormulaManager<Long, Long, Long, Lo
         pQuantifiedManager,
         pArrayManager,
         null,
-        pStringManager);
+        pStringManager,
+        null);
     formulaCreator = pFormulaCreator;
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3SolverContext.java
@@ -190,6 +190,7 @@ public final class Z3SolverContext extends AbstractSolverContext {
     Z3QuantifiedFormulaManager quantifierManager = new Z3QuantifiedFormulaManager(creator);
     Z3ArrayFormulaManager arrayManager = new Z3ArrayFormulaManager(creator);
     Z3StringFormulaManager stringTheory = new Z3StringFormulaManager(creator);
+    Z3EnumerationFormulaManager enumTheory = new Z3EnumerationFormulaManager(creator);
 
     // Set the custom error handling
     // which will throw Z3Exception
@@ -207,7 +208,8 @@ public final class Z3SolverContext extends AbstractSolverContext {
             floatingPointTheory,
             quantifierManager,
             arrayManager,
-            stringTheory);
+            stringTheory,
+            enumTheory);
     return new Z3SolverContext(creator, pShutdownNotifier, logger, manager, extraOptions);
   }
 

--- a/src/org/sosy_lab/java_smt/test/ArrayFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/ArrayFormulaManagerTest.java
@@ -16,11 +16,6 @@ import static org.sosy_lab.java_smt.api.FormulaType.getSinglePrecisionFloatingPo
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -33,21 +28,7 @@ import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.StringFormula;
 
 /** Tests Arrays for all solvers that support it. */
-@RunWith(Parameterized.class)
-public class ArrayFormulaManagerTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class ArrayFormulaManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Before
   public void init() {

--- a/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
@@ -23,8 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
@@ -41,22 +39,9 @@ import org.sosy_lab.java_smt.api.SolverException;
  * theory or bitvectors length 1.
  */
 @RunWith(Parameterized.class)
-public class BitvectorFormulaManagerTest extends SolverBasedTest0 {
+public class BitvectorFormulaManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   private static final BitvectorType bvType4 = FormulaType.getBitvectorTypeWithSize(4);
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
 
   @Before
   public void init() {

--- a/src/org/sosy_lab/java_smt/test/BooleanFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/BooleanFormulaManagerTest.java
@@ -16,10 +16,6 @@ import com.google.common.truth.Truth;
 import java.util.List;
 import org.junit.AssumptionViolatedException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.SolverException;
@@ -28,21 +24,7 @@ import org.sosy_lab.java_smt.api.SolverException;
  * Uses bitvector theory if there is no integer theory available. Notice: Boolector does not support
  * bitvectors length 1.
  */
-@RunWith(Parameterized.class)
-public class BooleanFormulaManagerTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class BooleanFormulaManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Test
   public void testVariableNamedTrue() throws SolverException, InterruptedException {

--- a/src/org/sosy_lab/java_smt/test/BooleanFormulaSubjectTest.java
+++ b/src/org/sosy_lab/java_smt/test/BooleanFormulaSubjectTest.java
@@ -18,10 +18,6 @@ import com.google.common.truth.ExpectFailure.SimpleSubjectBuilderCallback;
 import com.google.common.truth.SimpleSubjectBuilder;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.SolverException;
@@ -30,20 +26,7 @@ import org.sosy_lab.java_smt.api.SolverException;
  * Uses bitvector theory if there is no integer theory available. Notice: Boolector does not support
  * bitvectors length 1.
  */
-@RunWith(Parameterized.class)
-public class BooleanFormulaSubjectTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class BooleanFormulaSubjectTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   private BooleanFormula simpleFormula;
   private BooleanFormula contradiction;

--- a/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
@@ -12,6 +12,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.HashSet;
 import java.util.List;
@@ -225,5 +226,41 @@ public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
     mgr.visitRecursively(eq, visitor2);
     assertThat(visitor2.functions).containsExactly(FunctionDeclarationKind.EQ);
     assertThat(visitor2.constants).containsExactly("Blue");
+  }
+
+  @Test
+  public void testModel() throws SolverException, InterruptedException {
+    EnumerationFormulaType colorType = emgr.declareEnumeration("ColorM", "Blue", "White");
+    EnumerationFormula blue = emgr.makeConstant("Blue", colorType);
+    EnumerationFormula varColor = emgr.makeVariable("varColor", colorType);
+
+    EnumerationFormulaType shapeType =
+        emgr.declareEnumeration("ShapeM", "Circle", "Reactangle", "Triangle");
+    EnumerationFormula triangle = emgr.makeConstant("Triangle", shapeType);
+    EnumerationFormula varShape = emgr.makeVariable("varShape", shapeType);
+
+    evaluateInModel(
+        emgr.equivalence(blue, varColor),
+        varColor,
+        Lists.newArrayList("Blue"),
+        Lists.newArrayList(blue));
+
+    evaluateInModel(
+        bmgr.not(emgr.equivalence(blue, varColor)),
+        varColor,
+        Lists.newArrayList("White"),
+        Lists.newArrayList(blue));
+
+    evaluateInModel(
+        bmgr.and(emgr.equivalence(blue, varColor), emgr.equivalence(triangle, varShape)),
+        varColor,
+        Lists.newArrayList("Blue"),
+        Lists.newArrayList(blue));
+
+    evaluateInModel(
+        bmgr.and(emgr.equivalence(blue, varColor), emgr.equivalence(triangle, varShape)),
+        varShape,
+        Lists.newArrayList("Triangle"),
+        Lists.newArrayList(triangle));
   }
 }

--- a/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
@@ -9,6 +9,7 @@
 package org.sosy_lab.java_smt.test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -53,6 +54,16 @@ public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
   @Before
   public void init() {
     requireEnumeration();
+
+    if (solverToUse() == Solvers.MATHSAT5) {
+      System.out.println(context.getVersion());
+      assume()
+          .withMessage(
+              "Solver %s in version 5.6.8 does not yet support the theory of enumerations",
+              solverToUse())
+          .that(context.getVersion())
+          .doesNotContain("MathSAT5 version 5.6.8");
+    }
   }
 
   @Test
@@ -96,15 +107,20 @@ public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
     assertThrows(
         IllegalArgumentException.class, () -> emgr.declareEnumeration("Color", otherColors));
 
-    // different type with same elements is allowed
-    EnumerationFormulaType sameColorType = emgr.declareEnumeration("SameColor", colors);
-    assertEquals("SameColor", sameColorType.getName());
-    assertEquals(colors, sameColorType.getElements());
+    if (solverToUse() == Solvers.MATHSAT5) {
+      assertThrows(
+          IllegalArgumentException.class, () -> emgr.declareEnumeration("SameColor", colors));
+    } else {
+      // different type with same elements is allowed
+      EnumerationFormulaType sameColorType = emgr.declareEnumeration("SameColor", colors);
+      assertEquals("SameColor", sameColorType.getName());
+      assertEquals(colors, sameColorType.getElements());
 
-    // different type with same elements is allowed
-    EnumerationFormulaType otherColorType = emgr.declareEnumeration("OtherColor", otherColors);
-    assertThat(otherColorType.getName()).isEqualTo("OtherColor");
-    assertThat(otherColorType.getElements()).isEqualTo(otherColors);
+      // different type with same elements is allowed
+      EnumerationFormulaType otherColorType = emgr.declareEnumeration("OtherColor", otherColors);
+      assertThat(otherColorType.getName()).isEqualTo("OtherColor");
+      assertThat(otherColorType.getElements()).isEqualTo(otherColors);
+    }
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
@@ -232,6 +232,7 @@ public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
   public void testModel() throws SolverException, InterruptedException {
     EnumerationFormulaType colorType = emgr.declareEnumeration("ColorM", "Blue", "White");
     EnumerationFormula blue = emgr.makeConstant("Blue", colorType);
+    EnumerationFormula white = emgr.makeConstant("White", colorType);
     EnumerationFormula varColor = emgr.makeVariable("varColor", colorType);
 
     EnumerationFormulaType shapeType =
@@ -249,7 +250,7 @@ public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
         bmgr.not(emgr.equivalence(blue, varColor)),
         varColor,
         Lists.newArrayList("White"),
-        Lists.newArrayList(blue));
+        Lists.newArrayList(white));
 
     evaluateInModel(
         bmgr.and(emgr.equivalence(blue, varColor), emgr.equivalence(triangle, varShape)),

--- a/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
@@ -20,10 +20,6 @@ import java.util.List;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.EnumerationFormula;
@@ -35,21 +31,7 @@ import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.visitors.DefaultFormulaVisitor;
 import org.sosy_lab.java_smt.api.visitors.TraversalProcess;
 
-@RunWith(Parameterized.class)
-public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class EnumerationFormulaManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Before
   public void init() {

--- a/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
@@ -1,0 +1,135 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.Sets;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
+import org.sosy_lab.java_smt.api.EnumerationFormula;
+import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
+import org.sosy_lab.java_smt.api.SolverException;
+
+@RunWith(Parameterized.class)
+public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
+
+  @Parameters(name = "{0}")
+  public static Object[] getAllSolvers() {
+    return Solvers.values();
+  }
+
+  @Parameter(0)
+  public Solvers solver;
+
+  @Override
+  protected Solvers solverToUse() {
+    return solver;
+  }
+
+  @Before
+  public void init() {
+    requireEnumeration();
+  }
+
+  @Test
+  public void testEnumerationDeclaration() {
+    Set<String> colors = Sets.newHashSet("Blue", "White");
+    EnumerationFormulaType colorType = emgr.declareEnumeration("Color", "Blue", "White");
+    assertThat(colorType.getName()).isEqualTo("Color");
+    assertThat(colorType.getElements()).isEqualTo(colors);
+
+    Set<String> shapes = Sets.newHashSet("Circle", "Square", "Triangle");
+    EnumerationFormulaType shapeType = emgr.declareEnumeration("Shape", shapes);
+    assertThat(shapeType.getName()).isEqualTo("Shape");
+    assertThat(shapeType.getElements()).isEqualTo(shapes);
+
+    assertThat(colors).isNotEqualTo(shapes);
+  }
+
+  @Test
+  public void testTooManyDistinctValues() throws SolverException, InterruptedException {
+    EnumerationFormulaType colorType = emgr.declareEnumeration("ColorA", "Blue", "White");
+    EnumerationFormula color1 = emgr.makeVariable("first", colorType);
+    EnumerationFormula color2 = emgr.makeVariable("second", colorType);
+    EnumerationFormula color3 = emgr.makeVariable("third", colorType);
+
+    // there are two colors, so there can be two distinct assignments.
+    assertThatFormula(bmgr.not(emgr.equivalence(color1, color2))).isSatisfiable();
+    assertThatFormula(bmgr.not(emgr.equivalence(color2, color3))).isSatisfiable();
+    assertThatFormula(bmgr.not(emgr.equivalence(color3, color1))).isSatisfiable();
+
+    // there are only two colors, so there can not be three distinct assignments.
+    assertThatFormula(
+            bmgr.and(
+                bmgr.not(emgr.equivalence(color1, color2)),
+                bmgr.not(emgr.equivalence(color2, color3)),
+                bmgr.not(emgr.equivalence(color3, color1))))
+        .isUnsatisfiable();
+  }
+
+  @Test
+  public void testConstants() throws SolverException, InterruptedException {
+    EnumerationFormulaType colorType = emgr.declareEnumeration("ColorB", "Blue", "White");
+    EnumerationFormula blue = emgr.makeConstant("Blue", colorType);
+    EnumerationFormula white = emgr.makeConstant("White", colorType);
+    EnumerationFormula var = emgr.makeVariable("var", colorType);
+
+    assertThatFormula(emgr.equivalence(blue, var)).isSatisfiable();
+    assertThatFormula(emgr.equivalence(white, var)).isSatisfiable();
+    assertThatFormula(bmgr.not(emgr.equivalence(blue, var))).isSatisfiable();
+    assertThatFormula(bmgr.not(emgr.equivalence(white, var))).isSatisfiable();
+    assertThatFormula(bmgr.not(emgr.equivalence(blue, white))).isSatisfiable();
+
+    // there are only two colors, so is no third option.
+    assertThatFormula(
+            bmgr.or(bmgr.not(emgr.equivalence(blue, var)), bmgr.not(emgr.equivalence(white, var))))
+        .isUnsatisfiable();
+    assertThatFormula(bmgr.or(emgr.equivalence(blue, var), emgr.equivalence(white, var)))
+        .isUnsatisfiable();
+    assertThatFormula(
+            bmgr.and(bmgr.not(emgr.equivalence(blue, var)), bmgr.not(emgr.equivalence(white, var))))
+        .isUnsatisfiable();
+    assertThatFormula(bmgr.and(emgr.equivalence(blue, var), emgr.equivalence(white, var)))
+        .isUnsatisfiable();
+  }
+
+  @Test
+  public void testIncompatibleEnumeration() {
+    EnumerationFormulaType colorType = emgr.declareEnumeration("ColorC", "Blue", "White");
+    EnumerationFormulaType shapeType =
+        emgr.declareEnumeration("ShapeC", "Circle", "Rectangle", "Triangle");
+
+    EnumerationFormula blue = emgr.makeConstant("Blue", colorType);
+    EnumerationFormula varColor = emgr.makeVariable("varColor", colorType);
+
+    EnumerationFormula circle = emgr.makeConstant("Circle", shapeType);
+    EnumerationFormula varShape = emgr.makeVariable("varShape", shapeType);
+
+    Assert.assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(blue, varShape));
+    Assert.assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(circle, varColor));
+    Assert.assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(varColor, varShape));
+    Assert.assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(blue, circle));
+  }
+
+  @Test
+  public void testInvalidName() {
+    Assert.assertThrows(
+        IllegalArgumentException.class, () -> emgr.declareEnumeration("true", "X", "Y"));
+    EnumerationFormulaType colorType = emgr.declareEnumeration("ColorE", "Blue", "White");
+    Assert.assertThrows(IllegalArgumentException.class, () -> emgr.makeVariable("true", colorType));
+  }
+}

--- a/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
@@ -9,10 +9,13 @@
 package org.sosy_lab.java_smt.test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.Sets;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,9 +23,15 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
+import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.EnumerationFormula;
+import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType.EnumerationFormulaType;
+import org.sosy_lab.java_smt.api.FunctionDeclaration;
+import org.sosy_lab.java_smt.api.FunctionDeclarationKind;
 import org.sosy_lab.java_smt.api.SolverException;
+import org.sosy_lab.java_smt.api.visitors.DefaultFormulaVisitor;
+import org.sosy_lab.java_smt.api.visitors.TraversalProcess;
 
 @RunWith(Parameterized.class)
 public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
@@ -49,15 +58,52 @@ public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
   public void testEnumerationDeclaration() {
     Set<String> colors = Sets.newHashSet("Blue", "White");
     EnumerationFormulaType colorType = emgr.declareEnumeration("Color", "Blue", "White");
-    assertThat(colorType.getName()).isEqualTo("Color");
-    assertThat(colorType.getElements()).isEqualTo(colors);
+    assertEquals("Color", colorType.getName());
+    assertEquals(colors, colorType.getElements());
 
     Set<String> shapes = Sets.newHashSet("Circle", "Square", "Triangle");
     EnumerationFormulaType shapeType = emgr.declareEnumeration("Shape", shapes);
-    assertThat(shapeType.getName()).isEqualTo("Shape");
-    assertThat(shapeType.getElements()).isEqualTo(shapes);
+    assertEquals("Shape", shapeType.getName());
+    assertEquals(shapes, shapeType.getElements());
 
     assertThat(colors).isNotEqualTo(shapes);
+  }
+
+  @Test
+  public void testType() {
+    EnumerationFormulaType colorType = emgr.declareEnumeration("ColorM", "Blue", "White");
+    EnumerationFormula blue = emgr.makeConstant("Blue", colorType);
+    EnumerationFormula varColor = emgr.makeVariable("varColor", colorType);
+
+    assertEquals(colorType, mgr.getFormulaType(blue));
+    assertEquals(colorType, mgr.getFormulaType(varColor));
+  }
+
+  @Test
+  public void testRepeatedEnumerationDeclaration() {
+    Set<String> colors = Sets.newHashSet("Blue", "White");
+    Set<String> otherColors = Sets.newHashSet("Blue", "White", "Red");
+    EnumerationFormulaType colorType = emgr.declareEnumeration("Color", colors);
+
+    // same type again is allowed
+    EnumerationFormulaType identicalColorType = emgr.declareEnumeration("Color", colors);
+    assertEquals("Color", identicalColorType.getName());
+    assertEquals(colors, identicalColorType.getElements());
+    assertEquals(colorType, identicalColorType);
+
+    // distinct type with same name is not allowed
+    assertThrows(
+        IllegalArgumentException.class, () -> emgr.declareEnumeration("Color", otherColors));
+
+    // different type with same elements is allowed
+    EnumerationFormulaType sameColorType = emgr.declareEnumeration("SameColor", colors);
+    assertEquals("SameColor", sameColorType.getName());
+    assertEquals(colors, sameColorType.getElements());
+
+    // different type with same elements is allowed
+    EnumerationFormulaType otherColorType = emgr.declareEnumeration("OtherColor", otherColors);
+    assertThat(otherColorType.getName()).isEqualTo("OtherColor");
+    assertThat(otherColorType.getElements()).isEqualTo(otherColors);
   }
 
   @Test
@@ -97,9 +143,9 @@ public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
     // there are only two colors, so is no third option.
     assertThatFormula(
             bmgr.or(bmgr.not(emgr.equivalence(blue, var)), bmgr.not(emgr.equivalence(white, var))))
-        .isUnsatisfiable();
+        .isSatisfiable();
     assertThatFormula(bmgr.or(emgr.equivalence(blue, var), emgr.equivalence(white, var)))
-        .isUnsatisfiable();
+        .isSatisfiable();
     assertThatFormula(
             bmgr.and(bmgr.not(emgr.equivalence(blue, var)), bmgr.not(emgr.equivalence(white, var))))
         .isUnsatisfiable();
@@ -119,17 +165,65 @@ public class EnumerationFormulaManagerTest extends SolverBasedTest0 {
     EnumerationFormula circle = emgr.makeConstant("Circle", shapeType);
     EnumerationFormula varShape = emgr.makeVariable("varShape", shapeType);
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(blue, varShape));
-    Assert.assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(circle, varColor));
-    Assert.assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(varColor, varShape));
-    Assert.assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(blue, circle));
+    assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(blue, varShape));
+    assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(circle, varColor));
+    assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(varColor, varShape));
+    assertThrows(IllegalArgumentException.class, () -> emgr.equivalence(blue, circle));
   }
 
   @Test
   public void testInvalidName() {
-    Assert.assertThrows(
-        IllegalArgumentException.class, () -> emgr.declareEnumeration("true", "X", "Y"));
+    assertThrows(IllegalArgumentException.class, () -> emgr.declareEnumeration("true", "X", "Y"));
     EnumerationFormulaType colorType = emgr.declareEnumeration("ColorE", "Blue", "White");
-    Assert.assertThrows(IllegalArgumentException.class, () -> emgr.makeVariable("true", colorType));
+    assertThrows(IllegalArgumentException.class, () -> emgr.makeVariable("true", colorType));
+  }
+
+  private static class ConstantsVisitor extends DefaultFormulaVisitor<TraversalProcess> {
+
+    final Set<String> constants = new HashSet<>();
+    final Set<FunctionDeclarationKind> functions = new HashSet<>();
+
+    @Override
+    protected TraversalProcess visitDefault(Formula f) {
+      return TraversalProcess.CONTINUE;
+    }
+
+    @Override
+    public TraversalProcess visitConstant(Formula f, Object value) {
+      constants.add((String) value);
+      return visitDefault(f);
+    }
+
+    @Override
+    public TraversalProcess visitFunction(
+        Formula f, List<Formula> args, FunctionDeclaration<?> functionDeclaration) {
+      functions.add(functionDeclaration.getKind());
+      return visitDefault(f);
+    }
+  }
+
+  @Test
+  public void testVisitor() {
+    requireVisitor();
+
+    EnumerationFormulaType colorType = emgr.declareEnumeration("ColorC", "Blue", "White");
+    EnumerationFormula blue = emgr.makeConstant("Blue", colorType);
+    EnumerationFormula varColor = emgr.makeVariable("varColor", colorType);
+    BooleanFormula eq = emgr.equivalence(blue, varColor);
+
+    assertThat(mgr.extractVariables(varColor)).containsExactly("varColor", varColor);
+    assertThat(mgr.extractVariables(eq)).containsExactly("varColor", varColor);
+    assertThat(mgr.extractVariablesAndUFs(varColor)).containsExactly("varColor", varColor);
+    assertThat(mgr.extractVariablesAndUFs(eq)).containsExactly("varColor", varColor);
+
+    ConstantsVisitor visitor1 = new ConstantsVisitor();
+    mgr.visitRecursively(blue, visitor1);
+    assertThat(visitor1.functions).isEmpty();
+    assertThat(visitor1.constants).containsExactly("Blue");
+
+    ConstantsVisitor visitor2 = new ConstantsVisitor();
+    mgr.visitRecursively(eq, visitor2);
+    assertThat(visitor2.functions).containsExactly(FunctionDeclarationKind.EQ);
+    assertThat(visitor2.constants).containsExactly("Blue");
   }
 }

--- a/src/org/sosy_lab/java_smt/test/ExceptionHandlerTest.java
+++ b/src/org/sosy_lab/java_smt/test/ExceptionHandlerTest.java
@@ -2,34 +2,16 @@
 // an API wrapper for a collection of SMT solvers:
 // https://github.com/sosy-lab/java-smt
 //
-// SPDX-FileCopyrightText: 2020 Dirk Beyer <https://www.sosy-lab.org>
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package org.sosy_lab.java_smt.test;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 
 /** Test that exception handling is set up properly. */
-@RunWith(Parameterized.class)
-public class ExceptionHandlerTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class ExceptionHandlerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Test(expected = Exception.class)
   @SuppressWarnings("CheckReturnValue")

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -23,10 +23,6 @@ import java.util.List;
 import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.common.rationals.ExtendedRational;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
@@ -44,26 +40,13 @@ import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 
-@RunWith(Parameterized.class)
-public class FloatingPointFormulaManagerTest extends SolverBasedTest0 {
+public class FloatingPointFormulaManagerTest
+    extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   // numbers are small enough to be precise with single precision
   private static final int[] SINGLE_PREC_INTS = new int[] {0, 1, 2, 5, 10, 20, 50, 100, 200, 500};
 
   private static final int NUM_RANDOM_TESTS = 100;
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
 
   private FloatingPointType singlePrecType;
   private FloatingPointType doublePrecType;

--- a/src/org/sosy_lab/java_smt/test/FormulaClassifierTest.java
+++ b/src/org/sosy_lab/java_smt/test/FormulaClassifierTest.java
@@ -13,15 +13,10 @@ import static com.google.common.truth.TruthJUnit.assume;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.example.FormulaClassifier;
 
-@RunWith(Parameterized.class)
-public class FormulaClassifierTest extends SolverBasedTest0 {
+public class FormulaClassifierTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   private FormulaClassifier classifier;
 
@@ -37,18 +32,6 @@ public class FormulaClassifierTest extends SolverBasedTest0 {
 
   private static final String BVS =
       "(declare-fun bv () (_ BitVec 4))" + "(declare-fun bv2 () (_ BitVec 4))";
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
 
   @Before
   public void init() {

--- a/src/org/sosy_lab/java_smt/test/FormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FormulaManagerTest.java
@@ -29,7 +29,6 @@ import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FormulaType;
-import org.sosy_lab.java_smt.api.FormulaType.ArrayFormulaType;
 import org.sosy_lab.java_smt.api.FunctionDeclaration;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.SolverException;
@@ -332,7 +331,7 @@ public class FormulaManagerTest extends SolverBasedTest0 {
     requireArrays();
     // exists arr : (arr[0]=5 && x=arr[0]) --> simplified: x=5
     ArrayFormula<IntegerFormula, IntegerFormula> arr =
-        amgr.makeArray("arr", new ArrayFormulaType<>(IntegerType, IntegerType));
+        amgr.makeArray("arr", FormulaType.getArrayType(IntegerType, IntegerType));
     IntegerFormula index = imgr.makeNumber(0);
     IntegerFormula value = imgr.makeNumber(5);
     IntegerFormula x = imgr.makeVariable("x");

--- a/src/org/sosy_lab/java_smt/test/FormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FormulaManagerTest.java
@@ -20,10 +20,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Map;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
@@ -33,21 +29,7 @@ import org.sosy_lab.java_smt.api.FunctionDeclaration;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.SolverException;
 
-@RunWith(Parameterized.class)
-public class FormulaManagerTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class FormulaManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Test
   public void testEmptySubstitution() throws SolverException, InterruptedException {

--- a/src/org/sosy_lab/java_smt/test/InterpolatingProverTest.java
+++ b/src/org/sosy_lab/java_smt/test/InterpolatingProverTest.java
@@ -21,10 +21,6 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.common.UniqueIdGenerator;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
@@ -34,22 +30,8 @@ import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.SolverException;
 
 /** This class contains some simple Junit-tests to check the interpolation-API of our solvers. */
-@RunWith(Parameterized.class)
 @SuppressWarnings({"resource", "LocalVariableName"})
-public class InterpolatingProverTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Solvers[] getAllCombinations() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class InterpolatingProverTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   /** Generate a prover environment depending on the parameter above. */
   @SuppressWarnings("unchecked")

--- a/src/org/sosy_lab/java_smt/test/ModelEvaluationTest.java
+++ b/src/org/sosy_lab/java_smt/test/ModelEvaluationTest.java
@@ -2,19 +2,17 @@
 // an API wrapper for a collection of SMT solvers:
 // https://github.com/sosy-lab/java-smt
 //
-// SPDX-FileCopyrightText: 2020 Dirk Beyer <https://www.sosy-lab.org>
+// SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package org.sosy_lab.java_smt.test;
 
-import static com.google.common.truth.Truth.assertThat;
 import static org.sosy_lab.java_smt.test.ProverEnvironmentSubject.assertThat;
 
 import com.google.common.collect.Lists;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.Test;
@@ -27,14 +25,10 @@ import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Evaluator;
-import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.Model;
-import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
-import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
-import org.sosy_lab.java_smt.api.StringFormula;
 
 /** Test that we can request evaluations from models. */
 @RunWith(Parameterized.class)
@@ -80,53 +74,6 @@ public class ModelEvaluationTest extends SolverBasedTest0 {
       builder.setOption("solver.mathsat5.furtherOptions", "model_generation=true");
     }
     return builder;
-  }
-
-  private void evaluateInModel(
-      BooleanFormula constraint,
-      Formula formula,
-      Collection<Object> possibleExpectedValues,
-      Collection<Formula> possibleExpectedFormulas)
-      throws SolverException, InterruptedException {
-
-    try (ProverEnvironment prover = context.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
-      prover.push(constraint);
-      assertThat(prover).isSatisfiable();
-
-      try (Model m = prover.getModel()) {
-        if (formula instanceof BooleanFormula) {
-          assertThat(m.evaluate((BooleanFormula) formula)).isIn(possibleExpectedValues);
-          assertThat(m.evaluate(formula)).isIn(possibleExpectedValues);
-        } else if (formula instanceof IntegerFormula) {
-          assertThat(m.evaluate((IntegerFormula) formula)).isIn(possibleExpectedValues);
-          assertThat(m.evaluate(formula)).isIn(possibleExpectedValues);
-        } else if (formula instanceof RationalFormula) {
-          assertThat(m.evaluate((RationalFormula) formula)).isIn(possibleExpectedValues);
-          // assertThat(m.evaluate(formula)).isIn(possibleExpectedValues);
-        } else if (formula instanceof StringFormula) {
-          assertThat(m.evaluate((StringFormula) formula)).isIn(possibleExpectedValues);
-          assertThat(m.evaluate(formula)).isIn(possibleExpectedValues);
-        } else {
-          assertThat(m.evaluate(formula)).isIn(possibleExpectedValues);
-        }
-
-        // let's try to check evaluations. Actually the whole method is based on some default values
-        // in the solvers, because we do not use constraints for the evaluated formulas.
-        Formula eval = m.eval(formula);
-        if (eval != null) {
-          switch (solver) {
-            case Z3:
-              // ignore, Z3 provides arbitrary values
-              break;
-            case BOOLECTOR:
-              // ignore, Boolector provides no useful values
-              break;
-            default:
-              assertThat(eval).isIn(possibleExpectedFormulas);
-          }
-        }
-      }
-    }
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/test/ModelEvaluationTest.java
+++ b/src/org/sosy_lab/java_smt/test/ModelEvaluationTest.java
@@ -16,10 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.common.configuration.ConfigurationBuilder;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
@@ -31,8 +27,7 @@ import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 
 /** Test that we can request evaluations from models. */
-@RunWith(Parameterized.class)
-public class ModelEvaluationTest extends SolverBasedTest0 {
+public class ModelEvaluationTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   /**
    * This is the default boolean value for unknown model evaluations. For unknown model evaluation
@@ -53,18 +48,6 @@ public class ModelEvaluationTest extends SolverBasedTest0 {
   private static final String DEFAULT_MODEL_STRING = "";
 
   private static int problemSize;
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
 
   @Override
   protected ConfigurationBuilder createTestConfigBuilder() {

--- a/src/org/sosy_lab/java_smt/test/ModelTest.java
+++ b/src/org/sosy_lab/java_smt/test/ModelTest.java
@@ -28,10 +28,6 @@ import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.ArrayFormula;
@@ -53,8 +49,7 @@ import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 
 /** Test that values from models are appropriately parsed. */
-@RunWith(Parameterized.class)
-public class ModelTest extends SolverBasedTest0 {
+public class ModelTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   // A list of variables to test that model variable names are correctly applied
   private static final ImmutableList<String> VARIABLE_NAMES =
@@ -85,18 +80,6 @@ public class ModelTest extends SolverBasedTest0 {
 
   private static final ImmutableList<Solvers> SOLVERS_WITH_PARTIAL_MODEL =
       ImmutableList.of(Solvers.Z3, Solvers.PRINCESS);
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
 
   @Before
   public void setup() {

--- a/src/org/sosy_lab/java_smt/test/NonLinearArithmeticTest.java
+++ b/src/org/sosy_lab/java_smt/test/NonLinearArithmeticTest.java
@@ -43,7 +43,7 @@ public class NonLinearArithmeticTest<T extends NumeralFormula> extends SolverBas
           Solvers.SMTINTERPOL, Solvers.MATHSAT5, Solvers.BOOLECTOR, Solvers.CVC4, Solvers.YICES2);
 
   @Parameters(name = "{0} {1} {2}")
-  public static Iterable<Object[]> getAllSolvers() {
+  public static Iterable<Object[]> getAllSolversAndTheories() {
     return Lists.cartesianProduct(
             Arrays.asList(Solvers.values()),
             ImmutableList.of(FormulaType.IntegerType, FormulaType.RationalType),

--- a/src/org/sosy_lab/java_smt/test/NonLinearArithmeticWithModuloTest.java
+++ b/src/org/sosy_lab/java_smt/test/NonLinearArithmeticWithModuloTest.java
@@ -32,7 +32,7 @@ import org.sosy_lab.java_smt.basicimpl.AbstractNumeralFormulaManager.NonLinearAr
 public class NonLinearArithmeticWithModuloTest extends SolverBasedTest0 {
 
   @Parameters(name = "{0} {1}")
-  public static Iterable<Object[]> getAllSolvers() {
+  public static Iterable<Object[]> getAllSolversAndTheories() {
     return Lists.cartesianProduct(
             Arrays.asList(Solvers.values()), Arrays.asList(NonLinearArithmetic.values()))
         .stream()

--- a/src/org/sosy_lab/java_smt/test/NumeralFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/NumeralFormulaManagerTest.java
@@ -15,11 +15,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
@@ -29,21 +24,7 @@ import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.visitors.DefaultFormulaVisitor;
 
-@RunWith(Parameterized.class)
-public class NumeralFormulaManagerTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class NumeralFormulaManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Test
   public void distinctTest() throws SolverException, InterruptedException {

--- a/src/org/sosy_lab/java_smt/test/OptimizationTest.java
+++ b/src/org/sosy_lab/java_smt/test/OptimizationTest.java
@@ -16,10 +16,6 @@ import com.google.common.collect.Range;
 import java.math.BigInteger;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.common.configuration.ConfigurationBuilder;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
@@ -31,21 +27,7 @@ import org.sosy_lab.java_smt.api.OptimizationProverEnvironment.OptStatus;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 
-@RunWith(Parameterized.class)
-public class OptimizationTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class OptimizationTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Override
   protected ConfigurationBuilder createTestConfigBuilder() {

--- a/src/org/sosy_lab/java_smt/test/PrettyPrinterTest.java
+++ b/src/org/sosy_lab/java_smt/test/PrettyPrinterTest.java
@@ -12,16 +12,10 @@ import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.utils.PrettyPrinter;
 import org.sosy_lab.java_smt.utils.PrettyPrinter.PrinterOption;
 
-@RunWith(Parameterized.class)
-public class PrettyPrinterTest extends SolverBasedTest0 {
+public class PrettyPrinterTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   private PrettyPrinter pp;
 
@@ -36,18 +30,6 @@ public class PrettyPrinterTest extends SolverBasedTest0 {
           + "(declare-fun bar (Real) Real)";
 
   private static final String QUERY_1 = "(assert (and (= (select arr x) (foo 3)) (< x xx)))";
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
 
   @Before
   public void init() {

--- a/src/org/sosy_lab/java_smt/test/ProverEnvironmentSubjectTest.java
+++ b/src/org/sosy_lab/java_smt/test/ProverEnvironmentSubjectTest.java
@@ -17,31 +17,13 @@ import com.google.common.truth.ExpectFailure.SimpleSubjectBuilderCallback;
 import com.google.common.truth.SimpleSubjectBuilder;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 
-@RunWith(Parameterized.class)
-public class ProverEnvironmentSubjectTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class ProverEnvironmentSubjectTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   private BooleanFormula simpleFormula;
   private BooleanFormula contradiction;

--- a/src/org/sosy_lab/java_smt/test/ProverEnvironmentTest.java
+++ b/src/org/sosy_lab/java_smt/test/ProverEnvironmentTest.java
@@ -26,10 +26,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -38,21 +34,7 @@ import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 
-@RunWith(Parameterized.class)
-public class ProverEnvironmentTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Solvers[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class ProverEnvironmentTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Test
   public void assumptionsTest() throws SolverException, InterruptedException {

--- a/src/org/sosy_lab/java_smt/test/QuantifierManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/QuantifierManagerTest.java
@@ -20,10 +20,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.common.UniqueIdGenerator;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.ArrayFormula;
@@ -39,21 +35,7 @@ import org.sosy_lab.java_smt.api.Tactic;
 import org.sosy_lab.java_smt.api.visitors.DefaultFormulaVisitor;
 
 @SuppressFBWarnings(value = "DLS_DEAD_LOCAL_STORE", justification = "test code")
-@RunWith(Parameterized.class)
-public class QuantifierManagerTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solverUnderTest;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solverUnderTest;
-  }
+public class QuantifierManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   private IntegerFormula x;
   private ArrayFormula<IntegerFormula, IntegerFormula> a;
@@ -124,7 +106,7 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // The tests in this class use quantifiers and thus solver failures are expected.
     // We do not ignore all SolverExceptions in order to not hide bugs,
     // but only for Princess and CVC4 which are known to not be able to solve all tests here.
-    if (solverUnderTest == Solvers.PRINCESS || solverUnderTest == Solvers.CVC4) {
+    if (solverToUse() == Solvers.PRINCESS || solverToUse() == Solvers.CVC4) {
       assume().withMessage(e.getMessage()).fail();
     }
     throw e;
@@ -159,9 +141,9 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // (forall x . b[x] = 0) AND (b[123] = 1) is UNSAT
     requireBitvectors();
     // Princess does not support bitvectors in arrays
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.PRINCESS);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.PRINCESS);
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     BooleanFormula f =
         bmgr.and(
@@ -204,9 +186,9 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // (forall x . b[x] = 0) AND (b[123] = 0) is SAT
     requireBitvectors();
     // Princess does not support bitvectors in arrays
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.PRINCESS);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.PRINCESS);
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     BooleanFormula f =
         bmgr.and(
@@ -380,9 +362,9 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // (exists x . b[x] = 0) AND (b[123] = 1) is SAT
     requireBitvectors();
     // Princess does not support bitvectors in arrays
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.PRINCESS);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.PRINCESS);
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     BooleanFormula f =
         bmgr.and(
@@ -418,9 +400,9 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // (exists x . b[x] = 1) AND (forall x . b[x] = 0) is UNSAT
     requireBitvectors();
     // Princess does not support bitvectors in arrays
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.PRINCESS);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.PRINCESS);
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     BooleanFormula f =
         bmgr.and(qmgr.exists(ImmutableList.of(xbv), bvArray_at_x_eq_1), bv_forall_x_a_at_x_eq_0);
@@ -485,9 +467,9 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // (exists x . b[x] = 0) OR (forall x . b[x] = 1) is SAT
     requireBitvectors();
     // Princess does not support bitvectors in arrays
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.PRINCESS);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.PRINCESS);
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     BooleanFormula f =
         bmgr.or(
@@ -513,9 +495,9 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // (exists x . b[x] = 1) OR (exists x . b[x] = 1) is SAT
     requireBitvectors();
     // Princess does not support bitvectors in arrays
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.PRINCESS);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.PRINCESS);
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     BooleanFormula f =
         bmgr.or(
@@ -539,7 +521,7 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // forall x . x = x+1 is UNSAT
     requireBitvectors();
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     int width = 16;
     BitvectorFormula z = bvmgr.makeVariable(width, "z");
@@ -568,7 +550,7 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // forall z . z+2 = z+1+1 is SAT
     requireBitvectors();
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     int width = 16;
     BitvectorFormula z = bvmgr.makeVariable(width, "z");
@@ -598,7 +580,7 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
   public void testBVEquality() throws SolverException, InterruptedException {
     requireBitvectors();
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     BitvectorFormula z = bvmgr.makeVariable(bvWidth, "z");
     BitvectorFormula y = bvmgr.makeVariable(bvWidth, "y");
@@ -611,7 +593,7 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
   public void testBVEquality2() throws SolverException, InterruptedException {
     requireBitvectors();
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     BitvectorFormula z = bvmgr.makeVariable(bvWidth, "z");
     BitvectorFormula y = bvmgr.makeVariable(bvWidth, "y");
@@ -625,7 +607,7 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // UNSAT because of bv behaviour
     requireBitvectors();
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     BitvectorFormula z = bvmgr.makeVariable(bvWidth, "z");
     BitvectorFormula zPlusTwo =
@@ -657,7 +639,7 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     // If the free and bound vars are equal, this will be UNSAT
     requireBitvectors();
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
 
     int width = 2;
     BitvectorFormula aa = bvmgr.makeVariable(width, "aa");
@@ -848,7 +830,7 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     //                      or     extract_0_0 x = 1
 
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
     int i = index.getFreshId();
     int width = 2;
 
@@ -874,9 +856,9 @@ public class QuantifierManagerTest extends SolverBasedTest0 {
     //                                  (= a3 #x00000000))
 
     // Boolector quants need to be reworked
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.BOOLECTOR);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.BOOLECTOR);
     // Z3 fails this currently. Remove once thats not longer the case!
-    assume().that(solverUnderTest).isNotEqualTo(Solvers.Z3);
+    assume().that(solverToUse()).isNotEqualTo(Solvers.Z3);
     int width = 32;
 
     BitvectorFormula a2 = bvmgr.makeVariable(width, "a2");

--- a/src/org/sosy_lab/java_smt/test/RationalFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/RationalFormulaManagerTest.java
@@ -16,11 +16,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FunctionDeclaration;
@@ -30,26 +25,12 @@ import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.visitors.DefaultFormulaVisitor;
 
-@RunWith(Parameterized.class)
-public class RationalFormulaManagerTest extends SolverBasedTest0 {
+public class RationalFormulaManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   private static final double[] SOME_DOUBLES =
       new double[] {
         0, 0.1, 0.25, 0.5, 1, 1.5, 1.9, 2.1, 2.5, -0.1, -0.5, -1, -1.5, -1.9, -2.1, -2.5,
       };
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
 
   @Test
   public void rationalToIntTest() throws SolverException, InterruptedException {

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -29,6 +29,7 @@ import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BitvectorFormulaManager;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.EnumerationFormulaManager;
 import org.sosy_lab.java_smt.api.FloatingPointFormulaManager;
 import org.sosy_lab.java_smt.api.FormulaManager;
 import org.sosy_lab.java_smt.api.IntegerFormulaManager;
@@ -86,6 +87,7 @@ public abstract class SolverBasedTest0 {
   protected @Nullable ArrayFormulaManager amgr;
   protected @Nullable FloatingPointFormulaManager fpmgr;
   protected @Nullable StringFormulaManager smgr;
+  protected @Nullable EnumerationFormulaManager emgr;
   protected ShutdownManager shutdownManager = ShutdownManager.create();
 
   protected ShutdownNotifier shutdownNotifierToUse() {
@@ -159,6 +161,11 @@ public abstract class SolverBasedTest0 {
     } catch (UnsupportedOperationException e) {
       smgr = null;
     }
+    try {
+      emgr = mgr.getEnumerationFormulaManager();
+    } catch (UnsupportedOperationException e) {
+      emgr = null;
+    }
   }
 
   @After
@@ -229,6 +236,14 @@ public abstract class SolverBasedTest0 {
     assume()
         .withMessage("Solver %s does not support the theory of strings", solverToUse())
         .that(smgr)
+        .isNotNull();
+  }
+
+  /** Skip test if the solver does not support enumeration theory. */
+  protected final void requireEnumeration() {
+    assume()
+        .withMessage("Solver %s does not support the theory of enumerations", solverToUse())
+        .that(emgr)
         .isNotNull();
   }
 

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -18,6 +18,10 @@ import java.util.Collection;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.common.configuration.Configuration;
@@ -371,6 +375,23 @@ public abstract class SolverBasedTest0 {
           }
         }
       }
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public abstract static class ParameterizedSolverBasedTest0 extends SolverBasedTest0 {
+
+    @Parameters(name = "{0}")
+    public static Object[] getAllSolvers() {
+      return Solvers.values();
+    }
+
+    @Parameter(0)
+    public Solvers solver;
+
+    @Override
+    protected Solvers solverToUse() {
+      return solver;
     }
   }
 }

--- a/src/org/sosy_lab/java_smt/test/SolverContextTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverContextTest.java
@@ -12,28 +12,10 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.TruthJUnit.assume;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 
-@RunWith(Parameterized.class)
-public class SolverContextTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class SolverContextTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Test
   public void testMultipleContextClose() {

--- a/src/org/sosy_lab/java_smt/test/SolverFormulaIODeclarationsTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverFormulaIODeclarationsTest.java
@@ -17,30 +17,13 @@ import com.google.common.truth.Truth;
 import java.util.EnumSet;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.SolverException;
 
-@RunWith(Parameterized.class)
-public class SolverFormulaIODeclarationsTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class SolverFormulaIODeclarationsTest
+    extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Before
   public void checkThatSolverIsAvailable() {

--- a/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
@@ -20,10 +20,6 @@ import com.google.common.collect.Multiset;
 import com.google.common.truth.TruthJUnit;
 import java.util.function.Supplier;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -32,9 +28,8 @@ import org.sosy_lab.java_smt.api.FunctionDeclaration;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.SolverException;
 
-@RunWith(Parameterized.class)
 @SuppressWarnings("checkstyle:linelength")
-public class SolverFormulaIOTest extends SolverBasedTest0 {
+public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
   private static final String MATHSAT_DUMP1 =
       "(set-info :source |printed by MathSAT|)\n"
           + "(declare-fun a () Bool)\n"
@@ -99,19 +94,6 @@ public class SolverFormulaIOTest extends SolverBasedTest0 {
           + "(declare-fun u () Bool)\n"
           + "(assert  (let (($x35 (and (xor q (= (+ a b) c)) (>= a b)))) (let (($x9 (= a b))) (and"
           + " (and (or $x35 u) q) (and $x9 $x35)))))";
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
 
   @Test
   public void varDumpTest() {

--- a/src/org/sosy_lab/java_smt/test/SolverFormulaWithAssumptionsTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverFormulaWithAssumptionsTest.java
@@ -18,33 +18,15 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
-import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.InterpolatingProverEnvironment;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverException;
 
-@RunWith(Parameterized.class)
-public class SolverFormulaWithAssumptionsTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class SolverFormulaWithAssumptionsTest
+    extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   /**
    * Generate a prover environment depending on the parameter above. Can be overridden to

--- a/src/org/sosy_lab/java_smt/test/SolverTacticsTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverTacticsTest.java
@@ -19,10 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
@@ -35,21 +31,8 @@ import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.Tactic;
 import org.sosy_lab.java_smt.api.visitors.BooleanFormulaVisitor;
 
-@RunWith(Parameterized.class)
 @SuppressWarnings("LocalVariableName")
-public class SolverTacticsTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class SolverTacticsTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Test
   public void nnfTacticDefaultTest1() throws SolverException, InterruptedException {

--- a/src/org/sosy_lab/java_smt/test/SolverTheoriesTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverTheoriesTest.java
@@ -23,10 +23,6 @@ import java.util.Random;
 import org.junit.AssumptionViolatedException;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
@@ -41,22 +37,8 @@ import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 
-@RunWith(Parameterized.class)
 @SuppressWarnings("LocalVariableName")
-public class SolverTheoriesTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class SolverTheoriesTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   @Test
   public void basicBoolTest() throws SolverException, InterruptedException {

--- a/src/org/sosy_lab/java_smt/test/SolverVisitorTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverVisitorTest.java
@@ -25,10 +25,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
@@ -53,8 +49,7 @@ import org.sosy_lab.java_smt.api.visitors.FormulaTransformationVisitor;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.api.visitors.TraversalProcess;
 
-@RunWith(Parameterized.class)
-public class SolverVisitorTest extends SolverBasedTest0 {
+public class SolverVisitorTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   /** visit a formula and fail on OTHER, i.e., unexpected function declaration type. */
   private final class FunctionDeclarationVisitorNoOther extends DefaultFormulaVisitor<Formula> {
@@ -125,18 +120,6 @@ public class SolverVisitorTest extends SolverBasedTest0 {
     protected Formula visitDefault(Formula pF) {
       return pF;
     }
-  }
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
   }
 
   @Before

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -19,10 +19,6 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Formula;
@@ -33,8 +29,7 @@ import org.sosy_lab.java_smt.api.StringFormula;
 
 @SuppressWarnings("ConstantConditions")
 @SuppressFBWarnings(value = "DLS_DEAD_LOCAL_STORE", justification = "test code")
-@RunWith(Parameterized.class)
-public class StringFormulaManagerTest extends SolverBasedTest0 {
+public class StringFormulaManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   private static final ImmutableList<String> WORDS =
       ImmutableList.of(
@@ -71,18 +66,6 @@ public class StringFormulaManagerTest extends SolverBasedTest0 {
 
   private StringFormula hello;
   private RegexFormula a2z;
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter public Solvers solverUnderTest;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solverUnderTest;
-  }
 
   @Before
   public void setup() {
@@ -157,7 +140,7 @@ public class StringFormulaManagerTest extends SolverBasedTest0 {
     assertThatFormula(smgr.in(smgr.makeString("a\\u0336"), regexAllChar)).isUnsatisfiable();
     assertThatFormula(smgr.in(smgr.makeString("\\n"), regexAllChar)).isUnsatisfiable();
 
-    if (ImmutableList.of(Solvers.CVC4, Solvers.CVC5).contains(solverUnderTest)) {
+    if (ImmutableList.of(Solvers.CVC4, Solvers.CVC5).contains(solverToUse())) {
       // CVC4 and CVC5 do not support Unicode characters.
       assertThrows(Exception.class, () -> smgr.range('a', 'Δ'));
     } else {

--- a/src/org/sosy_lab/java_smt/test/TimeoutTest.java
+++ b/src/org/sosy_lab/java_smt/test/TimeoutTest.java
@@ -34,7 +34,7 @@ public class TimeoutTest extends SolverBasedTest0 {
   private static final int[] DELAYS = {1, 5, 10, 20, 50, 100};
 
   @Parameters(name = "{0} with delay {1}")
-  public static List<Object[]> getAllSolvers() {
+  public static List<Object[]> getAllSolversAndDelays() {
     List<Object[]> lst = new ArrayList<>();
     for (Solvers solver : Solvers.values()) {
       for (int delay : DELAYS) {

--- a/src/org/sosy_lab/java_smt/test/UFManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/UFManagerTest.java
@@ -15,10 +15,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Truth;
 import java.util.List;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
@@ -29,23 +25,9 @@ import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.visitors.ExpectedFormulaVisitor;
 
-@RunWith(Parameterized.class)
-public class UFManagerTest extends SolverBasedTest0 {
+public class UFManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   private static final ImmutableList<String> VALID_NAMES = ImmutableList.of("Func", "(Func)");
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
 
   @Test
   public void testDeclareAndCallUFWithInt() throws SolverException, InterruptedException {

--- a/src/org/sosy_lab/java_smt/test/UfEliminationTest.java
+++ b/src/org/sosy_lab/java_smt/test/UfEliminationTest.java
@@ -20,10 +20,6 @@ import com.google.common.truth.Truth;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Formula;
@@ -34,21 +30,7 @@ import org.sosy_lab.java_smt.utils.SolverUtils;
 import org.sosy_lab.java_smt.utils.UfElimination;
 import org.sosy_lab.java_smt.utils.UfElimination.Result;
 
-@RunWith(Parameterized.class)
-public class UfEliminationTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getAllSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class UfEliminationTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   private UfElimination ackermannization;
 

--- a/src/org/sosy_lab/java_smt/test/VariableNamesInvalidTest.java
+++ b/src/org/sosy_lab/java_smt/test/VariableNamesInvalidTest.java
@@ -10,30 +10,11 @@ package org.sosy_lab.java_smt.test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
 
-@RunWith(Parameterized.class)
 @SuppressFBWarnings(value = "DLS_DEAD_LOCAL_STORE")
-public class VariableNamesInvalidTest extends SolverBasedTest0 {
-
-  @Parameters(name = "{0}")
-  public static Object[] getSolvers() {
-    return Solvers.values();
-  }
-
-  @Parameter(0)
-  public Solvers solver;
-
-  @Override
-  protected Solvers solverToUse() {
-    return solver;
-  }
+public class VariableNamesInvalidTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
   // currently the only invalid String is the empty String
 


### PR DESCRIPTION
We use a new FormulaManager for Enumeration logic.

Enumeration logic is supported by MathSAT (v5.6.9 required), Z3 and CVC5.

CVC4 does not nicely transfer datatype formulas between solvers, and is already out of support.

Yices2 requires new bindings, because several methods are missing in our bindings.

SMTInterpol and Princess do not support this logic, for now.