### PR TITLE
322 feature request clone proverenvironment with stack

### DIFF
--- a/src/org/sosy_lab/java_smt/api/SolverContext.java
+++ b/src/org/sosy_lab/java_smt/api/SolverContext.java
@@ -66,6 +66,18 @@ public interface SolverContext extends AutoCloseable {
   ProverEnvironment newProverEnvironment(ProverOptions... options);
 
   /**
+   * Create a new {@link ProverEnvironment} which encapsulates an assertion stack and can be used to
+   * check formulas for unsatisfiability, but retains the current assertion stack of the given
+   * {@link ProverEnvironment}.
+   *
+   * @param proverToCopy An existing {@link ProverEnvironment}, whichs assertion stack is to be
+   *     copied into the new one.
+   * @param options Options specified for the prover environment. All the options specified in
+   *     {@link ProverOptions} are turned off by default.
+   */
+  ProverEnvironment copyProverEnvironment(ProverEnvironment proverToCopy, ProverOptions... options);
+
+  /**
    * Create a fresh new {@link InterpolatingProverEnvironment} which encapsulates an assertion stack
    * and allows generating and retrieve interpolants for unsatisfiable formulas. If the SMT solver
    * is able to handle satisfiability tests with assumptions please consider implementing the {@link
@@ -75,6 +87,22 @@ public interface SolverContext extends AutoCloseable {
    *     {@link ProverOptions} are turned off by default.
    */
   InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation(ProverOptions... options);
+
+  /**
+   * Create a fresh new {@link InterpolatingProverEnvironment} which encapsulates an assertion stack
+   * and allows generating and retrieve interpolants for unsatisfiable formulas. The new {@link
+   * ProverEnvironment} retains the current assertion stack of the given {@link ProverEnvironment}.
+   * If the SMT solver is able to handle satisfiability tests with assumptions please consider
+   * implementing the {@link InterpolatingProverEnvironment} interface, and return an Object of this
+   * type here.
+   *
+   * @param proverToCopy An existing {@link ProverEnvironment}, whichs assertion stack is to be
+   *     copied into the new one.
+   * @param options Options specified for the prover environment. All the options specified in
+   *     {@link ProverOptions} are turned off by default.
+   */
+  InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation(
+      ProverEnvironment proverToCopy, ProverOptions... options);
 
   /**
    * Create a fresh new {@link OptimizationProverEnvironment} which encapsulates an assertion stack

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractSolverContext.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractSolverContext.java
@@ -46,7 +46,22 @@ public abstract class AbstractSolverContext implements SolverContext {
     return out;
   }
 
+  @Override
+  public final ProverEnvironment copyProverEnvironment(
+      ProverEnvironment proverToCopy, ProverOptions... options) {
+    ProverEnvironment out = copyProverEnvironment0(proverToCopy, toSet(options));
+    if (!supportsAssumptionSolving()) {
+      // In the case we do not already have a prover environment with assumptions,
+      // we add a wrapper to it
+      out = new ProverWithAssumptionsWrapper(out);
+    }
+    return out;
+  }
+
   protected abstract ProverEnvironment newProverEnvironment0(Set<ProverOptions> options);
+
+  protected abstract ProverEnvironment copyProverEnvironment0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> options);
 
   @SuppressWarnings("resource")
   @Override
@@ -62,8 +77,25 @@ public abstract class AbstractSolverContext implements SolverContext {
     return out;
   }
 
+  @Override
+  public final InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation(
+      ProverEnvironment proverToCopy, ProverOptions... options) {
+
+    InterpolatingProverEnvironment<?> out =
+        copyProverEnvironmentWithInterpolation0(proverToCopy, toSet(options));
+    if (!supportsAssumptionSolving()) {
+      // In the case we do not already have a prover environment with assumptions,
+      // we add a wrapper to it
+      out = new InterpolatingProverWithAssumptionsWrapper<>(out, fmgr);
+    }
+    return out;
+  }
+
   protected abstract InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> pSet);
+
+  protected abstract InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> pSet);
 
   @SuppressWarnings("resource")
   @Override

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractSolverContext.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractSolverContext.java
@@ -77,6 +77,7 @@ public abstract class AbstractSolverContext implements SolverContext {
     return out;
   }
 
+  @SuppressWarnings("resource")
   @Override
   public final InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation(
       ProverEnvironment proverToCopy, ProverOptions... options) {

--- a/src/org/sosy_lab/java_smt/delegate/logging/LoggingSolverContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/logging/LoggingSolverContext.java
@@ -41,6 +41,7 @@ public final class LoggingSolverContext implements SolverContext {
     return new LoggingProverEnvironment(logger, delegate.newProverEnvironment(pOptions));
   }
 
+  @SuppressWarnings("resource")
   @Override
   public ProverEnvironment copyProverEnvironment(
       ProverEnvironment proverToCopy, ProverOptions... options) {
@@ -57,6 +58,7 @@ public final class LoggingSolverContext implements SolverContext {
         logger, delegate.newProverEnvironmentWithInterpolation(options));
   }
 
+  @SuppressWarnings("resource")
   @Override
   public InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation(
       ProverEnvironment proverToCopy, ProverOptions... options) {

--- a/src/org/sosy_lab/java_smt/delegate/logging/LoggingSolverContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/logging/LoggingSolverContext.java
@@ -41,12 +41,28 @@ public final class LoggingSolverContext implements SolverContext {
     return new LoggingProverEnvironment(logger, delegate.newProverEnvironment(pOptions));
   }
 
+  @Override
+  public ProverEnvironment copyProverEnvironment(
+      ProverEnvironment proverToCopy, ProverOptions... options) {
+    // TODO: log this? Because this is not a normal new prover?
+    return new LoggingProverEnvironment(
+        logger, delegate.copyProverEnvironment(proverToCopy, options));
+  }
+
   @SuppressWarnings("resource")
   @Override
   public InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation(
       ProverOptions... options) {
     return new LoggingInterpolatingProverEnvironment<>(
         logger, delegate.newProverEnvironmentWithInterpolation(options));
+  }
+
+  @Override
+  public InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation(
+      ProverEnvironment proverToCopy, ProverOptions... options) {
+    // TODO: log this? Because this is not a normal new prover?
+    return new LoggingInterpolatingProverEnvironment<>(
+        logger, delegate.copyProverEnvironmentWithInterpolation(proverToCopy, options));
   }
 
   @SuppressWarnings("resource")

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsSolverContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsSolverContext.java
@@ -39,12 +39,26 @@ public class StatisticsSolverContext implements SolverContext {
     return new StatisticsProverEnvironment(delegate.newProverEnvironment(pOptions), stats);
   }
 
+  @Override
+  public ProverEnvironment copyProverEnvironment(
+      ProverEnvironment proverToCopy, ProverOptions... options) {
+    return new StatisticsProverEnvironment(
+        delegate.copyProverEnvironment(proverToCopy, options), stats);
+  }
+
   @SuppressWarnings("resource")
   @Override
   public InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation(
       ProverOptions... pOptions) {
     return new StatisticsInterpolatingProverEnvironment<>(
         delegate.newProverEnvironmentWithInterpolation(pOptions), stats);
+  }
+
+  @Override
+  public InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation(
+      ProverEnvironment proverToCopy, ProverOptions... options) {
+    return new StatisticsInterpolatingProverEnvironment<>(
+        delegate.copyProverEnvironmentWithInterpolation(proverToCopy, options), stats);
   }
 
   @SuppressWarnings("resource")

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsSolverContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsSolverContext.java
@@ -39,6 +39,7 @@ public class StatisticsSolverContext implements SolverContext {
     return new StatisticsProverEnvironment(delegate.newProverEnvironment(pOptions), stats);
   }
 
+  @SuppressWarnings("resource")
   @Override
   public ProverEnvironment copyProverEnvironment(
       ProverEnvironment proverToCopy, ProverOptions... options) {
@@ -54,6 +55,7 @@ public class StatisticsSolverContext implements SolverContext {
         delegate.newProverEnvironmentWithInterpolation(pOptions), stats);
   }
 
+  @SuppressWarnings("resource")
   @Override
   public InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation(
       ProverEnvironment proverToCopy, ProverOptions... options) {

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedSolverContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedSolverContext.java
@@ -94,6 +94,24 @@ public class SynchronizedSolverContext implements SolverContext {
     }
   }
 
+  @Override
+  public ProverEnvironment copyProverEnvironment(
+      ProverEnvironment proverToCopy, ProverOptions... options) {
+    synchronized (sync) {
+      if (useSeperateProvers) {
+        SolverContext otherContext = createOtherContext();
+        return new SynchronizedProverEnvironmentWithContext(
+            otherContext.copyProverEnvironment(proverToCopy, options),
+            sync,
+            delegate.getFormulaManager(),
+            otherContext.getFormulaManager());
+      } else {
+        return new SynchronizedProverEnvironment(
+            delegate.copyProverEnvironment(proverToCopy, options), delegate);
+      }
+    }
+  }
+
   @SuppressWarnings("resource")
   @Override
   public InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation(
@@ -109,6 +127,24 @@ public class SynchronizedSolverContext implements SolverContext {
       } else {
         return new SynchronizedInterpolatingProverEnvironment<>(
             delegate.newProverEnvironmentWithInterpolation(pOptions), delegate);
+      }
+    }
+  }
+
+  @Override
+  public InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation(
+      ProverEnvironment proverToCopy, ProverOptions... options) {
+    synchronized (sync) {
+      if (useSeperateProvers) {
+        SolverContext otherContext = createOtherContext();
+        return new SynchronizedInterpolatingProverEnvironmentWithContext<>(
+            otherContext.copyProverEnvironmentWithInterpolation(proverToCopy, options),
+            sync,
+            delegate.getFormulaManager(),
+            otherContext.getFormulaManager());
+      } else {
+        return new SynchronizedInterpolatingProverEnvironment<>(
+            delegate.copyProverEnvironmentWithInterpolation(proverToCopy, options), delegate);
       }
     }
   }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedSolverContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedSolverContext.java
@@ -94,6 +94,7 @@ public class SynchronizedSolverContext implements SolverContext {
     }
   }
 
+  @SuppressWarnings("resource")
   @Override
   public ProverEnvironment copyProverEnvironment(
       ProverEnvironment proverToCopy, ProverOptions... options) {
@@ -131,6 +132,7 @@ public class SynchronizedSolverContext implements SolverContext {
     }
   }
 
+  @SuppressWarnings("resource")
   @Override
   public InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation(
       ProverEnvironment proverToCopy, ProverOptions... options) {

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorSolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorSolverContext.java
@@ -205,9 +205,23 @@ public final class BoolectorSolverContext extends AbstractSolverContext {
   }
 
   @Override
+  protected ProverEnvironment copyProverEnvironment0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> options) {
+    throw new UnsupportedOperationException(
+        "Boolector does not support the copying of " + "ProverEnvironments");
+  }
+
+  @Override
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> pSet) {
     throw new UnsupportedOperationException("Boolector does not support interpolation");
+  }
+
+  @Override
+  protected InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> pSet) {
+    throw new UnsupportedOperationException(
+        "Boolector does not support the copying of " + "ProverEnvironments");
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4SolverContext.java
@@ -138,6 +138,13 @@ public final class CVC4SolverContext extends AbstractSolverContext {
   }
 
   @Override
+  protected ProverEnvironment copyProverEnvironment0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> options) {
+    throw new UnsupportedOperationException(
+        "CVC4 does not support the copying of " + "ProverEnvironments");
+  }
+
+  @Override
   protected boolean supportsAssumptionSolving() {
     return false;
   }
@@ -146,6 +153,13 @@ public final class CVC4SolverContext extends AbstractSolverContext {
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> pSet) {
     throw new UnsupportedOperationException("CVC4 does not support interpolation");
+  }
+
+  @Override
+  protected InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> pSet) {
+    throw new UnsupportedOperationException(
+        "CVC4 does not support the copying of " + "ProverEnvironments");
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
@@ -158,6 +158,13 @@ public final class CVC5SolverContext extends AbstractSolverContext {
   }
 
   @Override
+  protected ProverEnvironment copyProverEnvironment0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> options) {
+    throw new UnsupportedOperationException(
+        "CVC5 does not support the copying of " + "ProverEnvironments");
+  }
+
+  @Override
   protected boolean supportsAssumptionSolving() {
     return false;
   }
@@ -166,6 +173,13 @@ public final class CVC5SolverContext extends AbstractSolverContext {
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> pOptions) {
     throw new UnsupportedOperationException("CVC5 does not support Craig interpolation.");
+  }
+
+  @Override
+  protected InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> pSet) {
+    throw new UnsupportedOperationException(
+        "CVC5 does not support the copying of " + "ProverEnvironments");
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
@@ -267,10 +267,24 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
   }
 
   @Override
+  protected ProverEnvironment copyProverEnvironment0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> options) {
+    throw new UnsupportedOperationException(
+        "MathSAT5 does not support copying of prover " + "environments");
+  }
+
+  @Override
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> options) {
     Preconditions.checkState(!closed, "solver context is already closed");
     return new Mathsat5InterpolatingProver(this, shutdownNotifier, creator, options);
+  }
+
+  @Override
+  protected InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> pSet) {
+    throw new UnsupportedOperationException(
+        "MathSAT5 does not support copying of prover " + "environments");
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessSolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessSolverContext.java
@@ -77,12 +77,26 @@ public final class PrincessSolverContext extends AbstractSolverContext {
     return (PrincessTheoremProver) creator.getEnv().getNewProver(false, manager, creator, options);
   }
 
+  @Override
+  protected ProverEnvironment copyProverEnvironment0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> options) {
+    throw new UnsupportedOperationException(
+        "Princess does not support the copying of " + "ProverEnvironments");
+  }
+
   @SuppressWarnings("resource")
   @Override
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> options) {
     return (PrincessInterpolatingProver)
         creator.getEnv().getNewProver(true, manager, creator, options);
+  }
+
+  @Override
+  protected InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> pSet) {
+    throw new UnsupportedOperationException(
+        "Princess does not support the copying of " + "ProverEnvironments");
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolSolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolSolverContext.java
@@ -231,6 +231,13 @@ public final class SmtInterpolSolverContext extends AbstractSolverContext {
     return new SmtInterpolTheoremProver(manager, newScript, options, shutdownNotifier);
   }
 
+  @Override
+  protected ProverEnvironment copyProverEnvironment0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> options) {
+    throw new UnsupportedOperationException(
+        "SMTInterpol does not support the copying of " + "ProverEnvironments");
+  }
+
   @SuppressWarnings("resource")
   @Override
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
@@ -250,6 +257,13 @@ public final class SmtInterpolSolverContext extends AbstractSolverContext {
               settings.smtLogfile.getFreshPath());
     }
     return prover;
+  }
+
+  @Override
+  protected InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> pSet) {
+    throw new UnsupportedOperationException(
+        "SMTInterpol does not support the copying of " + "ProverEnvironments");
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2SolverContext.java
@@ -108,9 +108,23 @@ public class Yices2SolverContext extends AbstractSolverContext {
   }
 
   @Override
+  protected ProverEnvironment copyProverEnvironment0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> options) {
+    throw new UnsupportedOperationException(
+        "Yices2 does not support the copying of " + "ProverEnvironments");
+  }
+
+  @Override
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> pSet) {
     throw new UnsupportedOperationException("Yices does not support interpolation");
+  }
+
+  @Override
+  protected InterpolatingProverEnvironment<?> copyProverEnvironmentWithInterpolation0(
+      ProverEnvironment proverToCopy, Set<ProverOptions> pSet) {
+    throw new UnsupportedOperationException(
+        "Yices2 does not support the copying of " + "ProverEnvironments");
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3SolverContext.java
@@ -20,7 +20,6 @@ import java.lang.ref.ReferenceQueue;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.IdentityHashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -54,7 +53,7 @@ public final class Z3SolverContext extends AbstractSolverContext {
   private boolean closed = false;
 
   private final ReferenceQueue<Long> referenceQueue = new ReferenceQueue<>();
-  private final Map<PhantomReference<Long>, Long> referenceMap = new IdentityHashMap<>();
+  private final IdentityHashMap<PhantomReference<Long>, Long> referenceMap = new IdentityHashMap<>();
 
   private static final String OPT_ENGINE_CONFIG_KEY = "optsmt_engine";
   private static final String OPT_PRIORITY_CONFIG_KEY = "priority";

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3SolverContext.java
@@ -265,7 +265,7 @@ public final class Z3SolverContext extends AbstractSolverContext {
         shutdownNotifier);
   }
 
-  private final ImmutableMap<String, Object> generateSolverOptions(Set<ProverOptions> options) {
+  private ImmutableMap<String, Object> generateSolverOptions(Set<ProverOptions> options) {
     return ImmutableMap.<String, Object>builder()
         .put(":random-seed", extraOptions.randomSeed)
         .put(

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
@@ -29,6 +29,17 @@ class Z3TheoremProver extends Z3AbstractProver<Void> implements ProverEnvironmen
     super(creator, pMgr, pOptions, pSolverOptions, pLogfile, pShutdownNotifier);
   }
 
+  Z3TheoremProver(
+      Z3FormulaCreator creator,
+      Z3FormulaManager pMgr,
+      final long pZ3solver,
+      Set<ProverOptions> pOptions,
+      ImmutableMap<String, Object> pSolverOptions,
+      @Nullable PathCounterTemplate pLogfile,
+      ShutdownNotifier pShutdownNotifier) {
+    super(creator, pMgr, pOptions, pSolverOptions, pLogfile, pShutdownNotifier);
+  }
+
   @Override
   @Nullable
   public Void addConstraint(BooleanFormula f) throws InterruptedException {

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
@@ -37,7 +37,7 @@ class Z3TheoremProver extends Z3AbstractProver<Void> implements ProverEnvironmen
       ImmutableMap<String, Object> pSolverOptions,
       @Nullable PathCounterTemplate pLogfile,
       ShutdownNotifier pShutdownNotifier) {
-    super(creator, pMgr, pOptions, pSolverOptions, pLogfile, pShutdownNotifier);
+    super(creator, pMgr, pZ3solver, pOptions, pSolverOptions, pLogfile, pShutdownNotifier);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -319,6 +319,20 @@ public abstract class SolverBasedTest0 {
         .isNotEqualTo(Solvers.BOOLECTOR);
   }
 
+  protected void requireProverCopying() {
+    assume()
+        .withMessage("Solver %s does not support copying of ProverEnvironments", solverToUse())
+        .that(solverToUse())
+        .isNoneOf(
+            Solvers.CVC4,
+            Solvers.CVC5,
+            Solvers.YICES2,
+            Solvers.BOOLECTOR,
+            Solvers.MATHSAT5,
+            Solvers.PRINCESS,
+            Solvers.SMTINTERPOL);
+  }
+
   /**
    * Use this for checking assertions about BooleanFormulas with Truth: <code>
    * assertThatFormula(formula).is...()</code>.

--- a/src/org/sosy_lab/java_smt/test/SolverContextTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverContextTest.java
@@ -134,6 +134,7 @@ public class SolverContextTest extends SolverBasedTest0.ParameterizedSolverBased
     }
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void testProverCopyCloseInitialProver() throws SolverException, InterruptedException {
     requireProverCopying();

--- a/src/org/sosy_lab/java_smt/test/SolverContextTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverContextTest.java
@@ -149,6 +149,7 @@ public class SolverContextTest extends SolverBasedTest0.ParameterizedSolverBased
    * Create a prover, push a SAT and an UNSAT formula on 2 levels, copy the prover, check that
    * the stack is copied correctly.
    */
+  @Test
   public void testProverCopyWithStackAndAssertions() throws InterruptedException, SolverException {
     requireProverCopying();
     IntegerFormula x = imgr.makeVariable("x");

--- a/src/org/sosy_lab/java_smt/test/SolverContextTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverContextTest.java
@@ -137,11 +137,10 @@ public class SolverContextTest extends SolverBasedTest0.ParameterizedSolverBased
   @Test
   public void testProverCopyCloseInitialProver() throws SolverException, InterruptedException {
     requireProverCopying();
-    try (ProverEnvironment prover = context.newProverEnvironment()) {
-      try (ProverEnvironment copiedProver = context.copyProverEnvironment(prover)) {
-        prover.close();
-        assertThat(copiedProver.isUnsat()).isFalse();
-      }
+    ProverEnvironment prover = context.newProverEnvironment();
+    try (ProverEnvironment copiedProver = context.copyProverEnvironment(prover)) {
+      prover.close();
+      assertThat(copiedProver.isUnsat()).isFalse();
     }
   }
 

--- a/src/org/sosy_lab/java_smt/test/SolverContextTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverContextTest.java
@@ -126,19 +126,23 @@ public class SolverContextTest extends SolverBasedTest0.ParameterizedSolverBased
   @Test
   public void testProverCopying() throws SolverException, InterruptedException {
     requireProverCopying();
-    ProverEnvironment prover = context.newProverEnvironment();
-    assertThat(prover.isUnsat()).isFalse();
-    ProverEnvironment copiedProver = context.copyProverEnvironment(prover);
-    assertThat(copiedProver.isUnsat()).isFalse();
+    try (ProverEnvironment prover = context.newProverEnvironment()) {
+      assertThat(prover.isUnsat()).isFalse();
+      try (ProverEnvironment copiedProver = context.copyProverEnvironment(prover)) {
+        assertThat(copiedProver.isUnsat()).isFalse();
+      }
+    }
   }
 
   @Test
   public void testProverCopyCloseInitialProver() throws SolverException, InterruptedException {
     requireProverCopying();
-    ProverEnvironment prover = context.newProverEnvironment();
-    ProverEnvironment copiedProver = context.copyProverEnvironment(prover);
-    prover.close();
-    assertThat(copiedProver.isUnsat()).isFalse();
+    try (ProverEnvironment prover = context.newProverEnvironment()) {
+      try (ProverEnvironment copiedProver = context.copyProverEnvironment(prover)) {
+        prover.close();
+        assertThat(copiedProver.isUnsat()).isFalse();
+      }
+    }
   }
 
   /*
@@ -149,24 +153,26 @@ public class SolverContextTest extends SolverBasedTest0.ParameterizedSolverBased
     requireProverCopying();
     IntegerFormula x = imgr.makeVariable("x");
     IntegerFormula one = imgr.makeNumber("1");
-    ProverEnvironment prover = context.newProverEnvironment();
-    BooleanFormula sat = bmgr.and(imgr.equal(x, one), imgr.greaterOrEquals(x, one));
-    BooleanFormula f = bmgr.makeFalse();
-    prover.push();
-    prover.addConstraint(sat);
-    assertThat(prover.isUnsat()).isFalse();
-    prover.push();
-    prover.addConstraint(f);
-    assertThat(prover.isUnsat()).isTrue();
+    try (ProverEnvironment prover = context.newProverEnvironment()) {
+      BooleanFormula sat = bmgr.and(imgr.equal(x, one), imgr.greaterOrEquals(x, one));
+      BooleanFormula f = bmgr.makeFalse();
+      prover.push();
+      prover.addConstraint(sat);
+      assertThat(prover.isUnsat()).isFalse();
+      prover.push();
+      prover.addConstraint(f);
+      assertThat(prover.isUnsat()).isTrue();
 
-    ProverEnvironment copiedProver = context.copyProverEnvironment(prover);
-    assertThat(copiedProver.isUnsat()).isTrue();
-    copiedProver.pop();
-    assertThat(copiedProver.isUnsat()).isFalse();
-    copiedProver.pop();
-    assertThat(copiedProver.isUnsat()).isFalse();
+      try (ProverEnvironment copiedProver = context.copyProverEnvironment(prover)) {
+        assertThat(copiedProver.isUnsat()).isTrue();
+        copiedProver.pop();
+        assertThat(copiedProver.isUnsat()).isFalse();
+        copiedProver.pop();
+        assertThat(copiedProver.isUnsat()).isFalse();
 
-    // Test that the initial prover is unaffected
-    assertThat(prover.isUnsat()).isTrue();
+        // Test that the initial prover is unaffected
+        assertThat(prover.isUnsat()).isTrue();
+      }
+    }
   }
 }

--- a/src/org/sosy_lab/java_smt/test/SolverContextTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverContextTest.java
@@ -152,6 +152,14 @@ public class SolverContextTest extends SolverBasedTest0.ParameterizedSolverBased
   @Test
   public void testProverCopyWithStackAndAssertions() throws InterruptedException, SolverException {
     requireProverCopying();
+
+    assume()
+        .withMessage(
+            "Solver %s does not support prover copying for non-base-level provers",
+            solverToUse())
+        .that(solverToUse())
+        .isNotEqualTo(Solvers.Z3);
+
     IntegerFormula x = imgr.makeVariable("x");
     IntegerFormula one = imgr.makeNumber("1");
     try (ProverEnvironment prover = context.newProverEnvironment()) {


### PR DESCRIPTION
I've added two methods to copy a prover to the solver context with an implementation for Z3 including tests.
Note: it seems like Z3 supports this only for the base level (no pushs to the assertion stack).