### PR TITLE
Add user propagator feature

### DIFF
--- a/build/gitlab-ci.yml
+++ b/build/gitlab-ci.yml
@@ -40,6 +40,7 @@ build-dependencies:
   artifacts:
     paths:
       - "lib/java/"
+    expire_in: 1 day # sufficient for building later stages and near-time debugging
 
 
 # Build binaries and provide them to later stages

--- a/build/gitlab-ci.yml
+++ b/build/gitlab-ci.yml
@@ -52,6 +52,8 @@ build-dependencies:
     paths:
       - "bin/"
       - "*.jar"
+      - "hs_err_pid*.log"
+      - "core.*"
 
 build:jdk-11:
   <<: *build

--- a/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
@@ -189,4 +189,16 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
     /** Returning the result generated after all the {@link #apply} calls went through. */
     R getResult() throws InterruptedException;
   }
+
+  /**
+   * Registers a {@link UserPropagator} for this prover environment.
+   * Only a single user propagator can be registered at a time.
+   *
+   * @param propagator The user propagator to register.
+   * @return true, if the user propagator was successfully registered. Most SMT solvers
+   * do not support user propagators and hence return "false".
+   */
+  default boolean registerUserPropagator(UserPropagator propagator) {
+    return false;
+  }
 }

--- a/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
@@ -191,14 +191,13 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
   }
 
   /**
-   * Registers a {@link UserPropagator} for this prover environment.
-   * Only a single user propagator can be registered at a time, and each user propagator
-   * shall only be registered once in its lifetime (see also
-   * {@link UserPropagator#initializeWithBackend}).
+   * Registers a {@link UserPropagator} for this prover environment. Only a single user propagator
+   * can be registered at a time, and each user propagator shall only be registered once in its
+   * lifetime (see also {@link UserPropagator#initializeWithBackend}).
    *
    * @param propagator The (fresh) user propagator to register.
-   * @return {@code true}, if the user propagator was successfully registered. Most SMT solvers
-   * do not support user propagators and hence return {@code false}.
+   * @return {@code true}, if the user propagator was successfully registered. Most SMT solvers do
+   *     not support user propagators and hence return {@code false}.
    */
   default boolean registerUserPropagator(UserPropagator propagator) {
     return false;

--- a/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
@@ -192,11 +192,13 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
 
   /**
    * Registers a {@link UserPropagator} for this prover environment.
-   * Only a single user propagator can be registered at a time.
+   * Only a single user propagator can be registered at a time, and each user propagator
+   * shall only be registered once in its lifetime (see also
+   * {@link UserPropagator#initializeWithBackend}).
    *
-   * @param propagator The user propagator to register.
-   * @return true, if the user propagator was successfully registered. Most SMT solvers
-   * do not support user propagators and hence return "false".
+   * @param propagator The (fresh) user propagator to register.
+   * @return {@code true}, if the user propagator was successfully registered. Most SMT solvers
+   * do not support user propagators and hence return {@code false}.
    */
   default boolean registerUserPropagator(UserPropagator propagator) {
     return false;

--- a/src/org/sosy_lab/java_smt/api/Evaluator.java
+++ b/src/org/sosy_lab/java_smt/api/Evaluator.java
@@ -2,7 +2,7 @@
 // an API wrapper for a collection of SMT solvers:
 // https://github.com/sosy-lab/java-smt
 //
-// SPDX-FileCopyrightText: 2022 Dirk Beyer <https://www.sosy-lab.org>
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -105,6 +105,13 @@ public interface Evaluator extends AutoCloseable {
    * <p>The formula does not need to be a variable, we also allow complex expression.
    */
   @Nullable String evaluate(EnumerationFormula formula);
+
+  /**
+   * Type-safe evaluation for floating-point formulas.
+   *
+   * <p>The formula does not need to be a variable, we also allow complex expression.
+   */
+  @Nullable FloatingPointNumber evaluate(FloatingPointFormula formula);
 
   /**
    * Free resources associated with this evaluator (existing {@link Formula} instances stay valid,

--- a/src/org/sosy_lab/java_smt/api/FloatingPointNumber.java
+++ b/src/org/sosy_lab/java_smt/api/FloatingPointNumber.java
@@ -1,0 +1,130 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.api;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.Immutable;
+import java.math.BigInteger;
+import java.util.BitSet;
+
+/**
+ * Represents a floating-point number with customizable precision, consisting of sign, exponent, and
+ * mantissa components.
+ */
+@Immutable
+@AutoValue
+public abstract class FloatingPointNumber {
+
+  public static final int SINGLE_PRECISION_EXPONENT_SIZE = 8;
+  public static final int SINGLE_PRECISION_MANTISSA_SIZE = 23;
+  public static final int DOUBLE_PRECISION_EXPONENT_SIZE = 11;
+  public static final int DOUBLE_PRECISION_MANTISSA_SIZE = 52;
+
+  /** Whether the number is positive (TRUE) or negative (FALSE). */
+  public abstract boolean getSign();
+
+  /** The exponent of the floating-point number, given as numeric value. */
+  public abstract BigInteger getExponent();
+
+  /** The mantissa (aka significand) of the floating-point number, given as numeric value. */
+  public abstract BigInteger getMantissa();
+
+  public abstract int getExponentSize();
+
+  public abstract int getMantissaSize();
+
+  public static FloatingPointNumber of(
+      boolean sign, BigInteger exponent, BigInteger mantissa, int exponentSize, int mantissaSize) {
+    Preconditions.checkArgument(exponent.bitLength() <= exponentSize);
+    Preconditions.checkArgument(mantissa.bitLength() <= mantissaSize);
+    Preconditions.checkArgument(exponent.compareTo(BigInteger.ZERO) >= 0);
+    Preconditions.checkArgument(mantissa.compareTo(BigInteger.ZERO) >= 0);
+    return new AutoValue_FloatingPointNumber(sign, exponent, mantissa, exponentSize, mantissaSize);
+  }
+
+  public static FloatingPointNumber of(String bits, int exponentSize, int mantissaSize) {
+    Preconditions.checkArgument(0 < exponentSize);
+    Preconditions.checkArgument(0 < mantissaSize);
+    Preconditions.checkArgument(bits.length() == 1 + exponentSize + mantissaSize);
+    Preconditions.checkArgument(bits.chars().allMatch(c -> c == '0' || c == '1'));
+    boolean sign = bits.charAt(0) == '1';
+    BigInteger exponent = new BigInteger(bits.substring(1, 1 + exponentSize), 2);
+    BigInteger mantissa =
+        new BigInteger(bits.substring(1 + exponentSize, 1 + exponentSize + mantissaSize), 2);
+    return of(sign, exponent, mantissa, exponentSize, mantissaSize);
+  }
+
+  private boolean isSinglePrecision() {
+    return getExponentSize() == SINGLE_PRECISION_EXPONENT_SIZE
+        && getMantissaSize() == SINGLE_PRECISION_MANTISSA_SIZE;
+  }
+
+  private boolean isDoublePrecision() {
+    return getExponentSize() == DOUBLE_PRECISION_EXPONENT_SIZE
+        && getMantissaSize() == DOUBLE_PRECISION_MANTISSA_SIZE;
+  }
+
+  /** compute a representation as Java-based float value, if possible. */
+  public float floatValue() {
+    Preconditions.checkArgument(
+        isSinglePrecision(),
+        "Can not represent floating point number %s as Java-based float value.",
+        this);
+    var bits = getBits();
+    return Float.intBitsToFloat(bits.length() == 0 ? 0 : (int) bits.toLongArray()[0]);
+  }
+
+  /** compute a representation as Java-based double value, if possible. */
+  public double doubleValue() {
+    Preconditions.checkArgument(
+        isSinglePrecision() || isDoublePrecision(),
+        "Can not represent floating point number %s as Java-based double value.",
+        this);
+    if (isSinglePrecision()) {
+      // lets be nice to the user and automatically convert from single to double precision
+      return floatValue();
+    }
+    var bits = getBits();
+    return Double.longBitsToDouble(bits.length() == 0 ? 0 : getBits().toLongArray()[0]);
+  }
+
+  private BitSet getBits() {
+    var mantissaSize = getMantissaSize();
+    var exponentSize = getExponentSize();
+    var mantissa = getMantissa();
+    var exponent = getExponent();
+    var bits = new BitSet(1 + exponentSize + mantissaSize);
+    if (getSign()) {
+      bits.set(exponentSize + mantissaSize);
+    }
+    for (int i = 0; i < exponentSize; i++) {
+      bits.set(mantissaSize + i, exponent.testBit(i));
+    }
+    for (int i = 0; i < mantissaSize; i++) {
+      bits.set(i, mantissa.testBit(i));
+    }
+    return bits;
+  }
+
+  /**
+   * Return a bit-representation of sign-bit, exponent, and mantissa, i.e., a concatenation of their
+   * bit-representations in this exact ordering.
+   */
+  @Override
+  public final String toString() {
+    var length = 1 + getExponentSize() + getMantissaSize();
+    var str = new StringBuilder(length);
+    var bits = getBits();
+    for (int i = 0; i < length; i++) {
+      str.append(bits.get(i) ? '1' : '0');
+    }
+    return str.reverse().toString();
+  }
+}

--- a/src/org/sosy_lab/java_smt/api/FormulaType.java
+++ b/src/org/sosy_lab/java_smt/api/FormulaType.java
@@ -8,6 +8,11 @@
 
 package org.sosy_lab.java_smt.api;
 
+import static org.sosy_lab.java_smt.api.FloatingPointNumber.DOUBLE_PRECISION_EXPONENT_SIZE;
+import static org.sosy_lab.java_smt.api.FloatingPointNumber.DOUBLE_PRECISION_MANTISSA_SIZE;
+import static org.sosy_lab.java_smt.api.FloatingPointNumber.SINGLE_PRECISION_EXPONENT_SIZE;
+import static org.sosy_lab.java_smt.api.FloatingPointNumber.SINGLE_PRECISION_MANTISSA_SIZE;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -213,8 +218,10 @@ public abstract class FormulaType<T extends Formula> {
   @Immutable
   public static final class FloatingPointType extends FormulaType<FloatingPointFormula> {
 
-    private static final FloatingPointType SINGLE_PRECISION_FP_TYPE = new FloatingPointType(8, 23);
-    private static final FloatingPointType DOUBLE_PRECISION_FP_TYPE = new FloatingPointType(11, 52);
+    private static final FloatingPointType SINGLE_PRECISION_FP_TYPE =
+        new FloatingPointType(SINGLE_PRECISION_EXPONENT_SIZE, SINGLE_PRECISION_MANTISSA_SIZE);
+    private static final FloatingPointType DOUBLE_PRECISION_FP_TYPE =
+        new FloatingPointType(DOUBLE_PRECISION_EXPONENT_SIZE, DOUBLE_PRECISION_MANTISSA_SIZE);
 
     private final int exponentSize;
     private final int mantissaSize;

--- a/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
+++ b/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
@@ -1,0 +1,116 @@
+/*
+ *  JavaSMT is an API wrapper for a collection of SMT solvers.
+ *  This file is part of JavaSMT.
+ *
+ *  Copyright (C) 2007-2016  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.sosy_lab.java_smt.api;
+
+/**
+ * The PropagatorBackend class is used by {@link UserPropagator} to implement custom user
+ * propagators.
+ * It contains functions to interact with the SAT/SMT core during solving, for example, it provides
+ * the ability to propagate conflicts.
+ */
+public interface PropagatorBackend {
+
+  /**
+   * Registers an expression to be observed by a {@link UserPropagator}.
+   * Whenever the value of a registered expression becomes known by the solver, this will
+   * get reported to the user propagator by invoking the callback
+   * {@link UserPropagator#onKnownValue} (if notification was enabled via
+   * {@link #notifyOnKnownValue}).
+   * Similarly, equalities between registered expressions are reported via
+   * {@link UserPropagator#onEquality} (if enabled via
+   * {@link #notifyOnEquality()}.
+   * @param theoryExpr The expression to observe.
+   */
+  void registerExpression(BooleanFormula theoryExpr);
+
+  /**
+   * Raises a conflict caused by a set of conflicting assignments. Shall only be called
+   * from within a callback by {@link UserPropagator} such as
+   * {@link UserPropagator#onKnownValue} and
+   * {@link UserPropagator#onFinalCheck()}.
+   *
+   * <p> Effectively causes the solver to learn the implication "/\ conflictLiterals => false"
+   *
+   * @param conflictLiterals A set of inconsistent assignments.
+   */
+  void propagateConflict(BooleanFormula[] conflictLiterals);
+
+  /**
+   * Propagates a consequence implied by a set of assigned literals. Shall only be called
+   * from within a callback by {@link UserPropagator} such as
+   * {@link UserPropagator#onKnownValue} and
+   * {@link UserPropagator#onFinalCheck()}.
+   *
+   * <p> Effectively causes the solver to learn the implication "/\ assignedLiterals => consequence"
+   *
+   * @param assignedLiterals A set of assigned literals.
+   * @param consequence The consequence implied by the assigned literals.
+   */
+  void propagateConsequence(BooleanFormula[] assignedLiterals, BooleanFormula consequence);
+
+  /**
+   * Propagates a consequence as well as a set of equalities implied by a set of assigned literals.
+   * Shall only be called from within a callback by {@link UserPropagator} such as
+   * {@link UserPropagator#onKnownValue} and
+   * {@link UserPropagator#onFinalCheck()}
+   *
+   * <p> Effectively causes the solver to learn the implication "/\ assignedLiterals =>
+   *    (consequence /\ forall i: equalitiesLHS[i] == equalitiesRHS[i])"
+   *
+   * @param assignedLiterals A set of assigned literals.
+   * @param equalitiesLHS The left-hand sides of implied equalities.
+   * @param equalitiesRHS The right-hand sides of implied equalities.
+   * @param consequence The consequence implied by the assigned literals.
+   */
+  void propagateConsequenceWithEqualities(BooleanFormula[] assignedLiterals,
+                                          BooleanFormula[] equalitiesLHS,
+                                          BooleanFormula[] equalitiesRHS,
+                                          BooleanFormula consequence);
+
+  /**
+   * Enables tracking of expression values for the associated {@link UserPropagator} via
+   * {@link UserPropagator#onKnownValue(BooleanFormula, BooleanFormula)}.
+   *
+   * <p>This function is typically called from {@link UserPropagator#initialize()} if the
+   * theory solver needs to listen to the value of expressions registered by
+   * {@link #registerExpression}.
+   */
+  void notifyOnKnownValue();
+
+  /**
+   * Enables tracking of equalities for the associated {@link UserPropagator} via
+   * {@link UserPropagator#onEquality(BooleanFormula, BooleanFormula)}.
+   *
+   * <p>This function is typically called from {@link UserPropagator#initialize()} if the
+   * theory solver needs to observe equalities between expressions registered by
+   * {@link #registerExpression}.
+   */
+  void notifyOnEquality();
+
+  /**
+   * Enables the final callback {@link UserPropagator#onFinalCheck()} that is invoked
+   * when the solver finds a full satisfying assignment.
+   *
+   * <p>This function is typically called from {@link UserPropagator#initialize()} if the
+   * theory solver needs to perform final consistency checks.
+   */
+  void notifyOnFinalCheck();
+}

--- a/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
+++ b/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
@@ -34,9 +34,7 @@ public interface PropagatorBackend {
    * get reported to the user propagator by invoking the callback
    * {@link UserPropagator#onKnownValue} (if notification was enabled via
    * {@link #notifyOnKnownValue}).
-   * Similarly, equalities between registered expressions are reported via
-   * {@link UserPropagator#onEquality} (if enabled via
-   * {@link #notifyOnEquality()}.
+   *
    * @param theoryExpr The expression to observe.
    */
   void registerExpression(BooleanFormula theoryExpr);
@@ -59,31 +57,26 @@ public interface PropagatorBackend {
    * {@link UserPropagator#onKnownValue} and
    * {@link UserPropagator#onFinalCheck()}.
    *
-   * <p> Effectively causes the solver to learn the implication "/\ assignedLiterals => consequence"
+   * <p> Effectively causes the solver to learn the implication "/\ {@code assignedLiterals} =>
+   * {@code consequence}"
+   * It is possible to have an empty set of {@code assignedLiterals} to generate a theory lemma.
    *
    * @param assignedLiterals A set of assigned literals.
-   * @param consequence The consequence implied by the assigned literals.
+   * @param consequence      The consequence implied by the assigned literals.
    */
   void propagateConsequence(BooleanFormula[] assignedLiterals, BooleanFormula consequence);
 
   /**
-   * Propagates a consequence as well as a set of equalities implied by a set of assigned literals.
-   * Shall only be called from within a callback by {@link UserPropagator} such as
-   * {@link UserPropagator#onKnownValue} and
-   * {@link UserPropagator#onFinalCheck()}
+   * Propagates a decision to be made by the solver.
+   * If called during {@link UserPropagator#onKnownValue}, will set the next decision to be made.
    *
-   * <p> Effectively causes the solver to learn the implication "/\ assignedLiterals =>
-   *    (consequence /\ forall i: equalitiesLHS[i] == equalitiesRHS[i])"
-   *
-   * @param assignedLiterals A set of assigned literals.
-   * @param equalitiesLHS The left-hand sides of implied equalities.
-   * @param equalitiesRHS The right-hand sides of implied equalities.
-   * @param consequence The consequence implied by the assigned literals.
+   * @param literal The literal to assign to next.
+   * @param value   The value to be assigned.
+   * @return False, if the value of the literal is already assigned. True, otherwise.
+   * Note that the literal may already be decided before being reported via
+   * {@link UserPropagator#onKnownValue}.
    */
-  void propagateConsequenceWithEqualities(BooleanFormula[] assignedLiterals,
-                                          BooleanFormula[] equalitiesLHS,
-                                          BooleanFormula[] equalitiesRHS,
-                                          BooleanFormula consequence);
+  boolean propagateNextDecision(BooleanFormula literal, boolean value);
 
   /**
    * Enables tracking of expression values for the associated {@link UserPropagator} via
@@ -94,16 +87,6 @@ public interface PropagatorBackend {
    * {@link #registerExpression}.
    */
   void notifyOnKnownValue();
-
-  /**
-   * Enables tracking of equalities for the associated {@link UserPropagator} via
-   * {@link UserPropagator#onEquality(BooleanFormula, BooleanFormula)}.
-   *
-   * <p>This function is typically called from {@link UserPropagator#initialize()} if the
-   * theory solver needs to observe equalities between expressions registered by
-   * {@link #registerExpression}.
-   */
-  void notifyOnEquality();
 
   /**
    * Enables the final callback {@link UserPropagator#onFinalCheck()} that is invoked

--- a/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
+++ b/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
@@ -12,86 +12,81 @@ import java.util.Optional;
 
 /**
  * The PropagatorBackend class is used by {@link UserPropagator} to implement custom user
- * propagators.
- * It contains functions to interact with the SAT/SMT core during solving, for example, it provides
- * the ability to propagate conflicts and to influence the decision-making.
+ * propagators. It contains functions to interact with the SAT/SMT core during solving, for example,
+ * it provides the ability to propagate conflicts and to influence the decision-making.
  */
 public interface PropagatorBackend {
 
   /**
-   * Registers an expression to be observed by a {@link UserPropagator}.
-   * See {@link UserPropagator#onKnownValue} and {@link UserPropagator#onDecision}
-   * for more information.
+   * Registers an expression to be observed by a {@link UserPropagator}. See {@link
+   * UserPropagator#onKnownValue} and {@link UserPropagator#onDecision} for more information.
    *
    * @param theoryExpr The expression to observe.
    */
   void registerExpression(BooleanFormula theoryExpr);
 
   /**
-   * Raises a conflict caused by a set of conflicting assignments. Shall only be called
-   * from within a callback by {@link UserPropagator} such as
-   * {@link UserPropagator#onKnownValue} and
-   * {@link UserPropagator#onFinalCheck()}.
+   * Raises a conflict caused by a set of conflicting assignments. Shall only be called from within
+   * a callback by {@link UserPropagator} such as {@link UserPropagator#onKnownValue} and {@link
+   * UserPropagator#onFinalCheck()}.
    *
-   * <p> Effectively causes the solver to learn the implication "{@code conflictExpressions} =>
-   *   false"
+   * <p>Effectively causes the solver to learn the implication "{@code conflictExpressions} =>
+   * false"
    *
    * @param conflictExpressions A set of inconsistent assignments.
    */
   void propagateConflict(BooleanFormula[] conflictExpressions);
 
   /**
-   * Propagates a consequence implied by a set of assigned expressions. Shall only be called
-   * from within a callback by {@link UserPropagator} such as
-   * {@link UserPropagator#onKnownValue} and
+   * Propagates a consequence implied by a set of assigned expressions. Shall only be called from
+   * within a callback by {@link UserPropagator} such as {@link UserPropagator#onKnownValue} and
    * {@link UserPropagator#onFinalCheck()}.
    *
-   * <p> Effectively causes the solver to learn the implication "/\ {@code assignedExpressions} =>
-   * {@code consequence}"
-   * It is possible to have an empty set of {@code assignedExpressions} to generate a theory lemma.
+   * <p>Effectively causes the solver to learn the implication "/\ {@code assignedExpressions} =>
+   * {@code consequence}" It is possible to have an empty set of {@code assignedExpressions} to
+   * generate a theory lemma.
    *
    * @param assignedExpressions A set of assigned expressions.
-   * @param consequence      The consequence implied by the assigned expressions.
+   * @param consequence The consequence implied by the assigned expressions.
    */
   void propagateConsequence(BooleanFormula[] assignedExpressions, BooleanFormula consequence);
 
   /**
-   * Propagates a decision to be made by the solver.
-   * If called during {@link UserPropagator#onKnownValue}, will set the next decision to be made.
-   * If called during {@link UserPropagator#onDecision}, will overwrite the current decision to be
-   * made.
+   * Propagates a decision to be made by the solver. If called during {@link
+   * UserPropagator#onKnownValue}, will set the next decision to be made. If called during {@link
+   * UserPropagator#onDecision}, will overwrite the current decision to be made.
    *
    * @param expr The expression to assign to next.
-   * @param value   The value to be assigned. If not given, the solver will decide.
-   * @return False, if the value of {@code expr} is already assigned. True, otherwise.
-   * Note that the value of {@code expr} may already be decided before being reported via
-   * {@link UserPropagator#onKnownValue}.
+   * @param value The value to be assigned. If not given, the solver will decide.
+   * @return False, if the value of {@code expr} is already assigned. True, otherwise. Note that the
+   *     value of {@code expr} may already be decided before being reported via {@link
+   *     UserPropagator#onKnownValue}.
    */
   boolean propagateNextDecision(BooleanFormula expr, Optional<Boolean> value);
 
   /**
-   * Enables tracking of expression values for the associated {@link UserPropagator} via
-   * {@link UserPropagator#onKnownValue}.
+   * Enables tracking of expression values for the associated {@link UserPropagator} via {@link
+   * UserPropagator#onKnownValue}.
    *
    * <p>This function is typically called from {@link UserPropagator#initializeWithBackend} if the
-   * theory solver needs to listen to the value of expressions registered by
-   * {@link #registerExpression}.
+   * theory solver needs to listen to the value of expressions registered by {@link
+   * #registerExpression}.
    */
   void notifyOnKnownValue();
 
   /**
-   * Enables tracking of decisions made for the associated {@link UserPropagator} via
-   * {@link UserPropagator#onDecision(BooleanFormula, boolean)}.
+   * Enables tracking of decisions made for the associated {@link UserPropagator} via {@link
+   * UserPropagator#onDecision(BooleanFormula, boolean)}.
    *
    * <p>This function is typically called from {@link UserPropagator#initializeWithBackend} if the
-   * theory solver needs to listen to and/or modify the decisions made by the solver on
-   * expressions registered by {@link #registerExpression}.
+   * theory solver needs to listen to and/or modify the decisions made by the solver on expressions
+   * registered by {@link #registerExpression}.
    */
   void notifyOnDecision();
 
   /**
-   * Enables the final callback {@link UserPropagator#onFinalCheck()} that is invoked
-   * when the solver finds a full satisfying assignment.
+   * Enables the final callback {@link UserPropagator#onFinalCheck()} that is invoked when the
+   * solver finds a full satisfying assignment.
    *
    * <p>This function is typically called from {@link UserPropagator#initializeWithBackend} if the
    * theory solver needs to perform final consistency checks.

--- a/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
+++ b/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
@@ -14,16 +14,14 @@ import java.util.Optional;
  * The PropagatorBackend class is used by {@link UserPropagator} to implement custom user
  * propagators.
  * It contains functions to interact with the SAT/SMT core during solving, for example, it provides
- * the ability to propagate conflicts.
+ * the ability to propagate conflicts and to influence the decision-making.
  */
 public interface PropagatorBackend {
 
   /**
    * Registers an expression to be observed by a {@link UserPropagator}.
-   * Whenever the value of a registered expression becomes known by the solver, this will
-   * get reported to the user propagator by invoking the callback
-   * {@link UserPropagator#onKnownValue} (if notification was enabled via
-   * {@link #notifyOnKnownValue}).
+   * See {@link UserPropagator#onKnownValue} and {@link UserPropagator#onDecision}
+   * for more information.
    *
    * @param theoryExpr The expression to observe.
    */
@@ -60,6 +58,8 @@ public interface PropagatorBackend {
   /**
    * Propagates a decision to be made by the solver.
    * If called during {@link UserPropagator#onKnownValue}, will set the next decision to be made.
+   * If called during {@link UserPropagator#onDecision}, will overwrite the current decision to be
+   * made.
    *
    * @param expr The expression to assign to next.
    * @param value   The value to be assigned. If not given, the solver will decide.
@@ -78,6 +78,16 @@ public interface PropagatorBackend {
    * {@link #registerExpression}.
    */
   void notifyOnKnownValue();
+
+  /**
+   * Enables tracking of decisions made for the associated {@link UserPropagator} via
+   * {@link UserPropagator#onDecision(BooleanFormula, boolean)}.
+   *
+   * <p>This function is typically called from {@link UserPropagator#initialize()} if the
+   * theory solver needs to listen to and/or modify the decisions made by the solver on
+   * expressions registered by {@link #registerExpression}.
+   */
+  void notifyOnDecision();
 
   /**
    * Enables the final callback {@link UserPropagator#onFinalCheck()} that is invoked

--- a/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
+++ b/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
@@ -30,7 +30,7 @@ public interface PropagatorBackend {
    * a callback by {@link UserPropagator} such as {@link UserPropagator#onKnownValue} and {@link
    * UserPropagator#onFinalCheck()}.
    *
-   * <p>Effectively causes the solver to learn the implication "{@code conflictExpressions} =>
+   * <p>Effectively causes the solver to learn the implication "{@code conflictExpressions} =&gt;
    * false"
    *
    * @param conflictExpressions A set of inconsistent assignments.
@@ -42,7 +42,7 @@ public interface PropagatorBackend {
    * within a callback by {@link UserPropagator} such as {@link UserPropagator#onKnownValue} and
    * {@link UserPropagator#onFinalCheck()}.
    *
-   * <p>Effectively causes the solver to learn the implication "/\ {@code assignedExpressions} =>
+   * <p>Effectively causes the solver to learn the implication "/\ {@code assignedExpressions} =&gt;
    * {@code consequence}" It is possible to have an empty set of {@code assignedExpressions} to
    * generate a theory lemma.
    *

--- a/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
+++ b/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
@@ -1,22 +1,10 @@
-/*
- *  JavaSMT is an API wrapper for a collection of SMT solvers.
- *  This file is part of JavaSMT.
- *
- *  Copyright (C) 2007-2016  Dirk Beyer
- *  All rights reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package org.sosy_lab.java_smt.api;
 

--- a/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
+++ b/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
@@ -20,6 +20,8 @@
 
 package org.sosy_lab.java_smt.api;
 
+import java.util.Optional;
+
 /**
  * The PropagatorBackend class is used by {@link UserPropagator} to implement custom user
  * propagators.
@@ -45,38 +47,39 @@ public interface PropagatorBackend {
    * {@link UserPropagator#onKnownValue} and
    * {@link UserPropagator#onFinalCheck()}.
    *
-   * <p> Effectively causes the solver to learn the implication "/\ conflictLiterals => false"
+   * <p> Effectively causes the solver to learn the implication "{@code conflictExpressions} =>
+   *   false"
    *
-   * @param conflictLiterals A set of inconsistent assignments.
+   * @param conflictExpressions A set of inconsistent assignments.
    */
-  void propagateConflict(BooleanFormula[] conflictLiterals);
+  void propagateConflict(BooleanFormula[] conflictExpressions);
 
   /**
-   * Propagates a consequence implied by a set of assigned literals. Shall only be called
+   * Propagates a consequence implied by a set of assigned expressions. Shall only be called
    * from within a callback by {@link UserPropagator} such as
    * {@link UserPropagator#onKnownValue} and
    * {@link UserPropagator#onFinalCheck()}.
    *
-   * <p> Effectively causes the solver to learn the implication "/\ {@code assignedLiterals} =>
+   * <p> Effectively causes the solver to learn the implication "/\ {@code assignedExpressions} =>
    * {@code consequence}"
-   * It is possible to have an empty set of {@code assignedLiterals} to generate a theory lemma.
+   * It is possible to have an empty set of {@code assignedExpressions} to generate a theory lemma.
    *
-   * @param assignedLiterals A set of assigned literals.
-   * @param consequence      The consequence implied by the assigned literals.
+   * @param assignedExpressions A set of assigned expressions.
+   * @param consequence      The consequence implied by the assigned expressions.
    */
-  void propagateConsequence(BooleanFormula[] assignedLiterals, BooleanFormula consequence);
+  void propagateConsequence(BooleanFormula[] assignedExpressions, BooleanFormula consequence);
 
   /**
    * Propagates a decision to be made by the solver.
    * If called during {@link UserPropagator#onKnownValue}, will set the next decision to be made.
    *
-   * @param literal The literal to assign to next.
-   * @param value   The value to be assigned.
-   * @return False, if the value of the literal is already assigned. True, otherwise.
-   * Note that the literal may already be decided before being reported via
+   * @param expr The expression to assign to next.
+   * @param value   The value to be assigned. If not given, the solver will decide.
+   * @return False, if the value of {@code expr} is already assigned. True, otherwise.
+   * Note that the value of {@code expr} may already be decided before being reported via
    * {@link UserPropagator#onKnownValue}.
    */
-  boolean propagateNextDecision(BooleanFormula literal, boolean value);
+  boolean propagateNextDecision(BooleanFormula expr, Optional<Boolean> value);
 
   /**
    * Enables tracking of expression values for the associated {@link UserPropagator} via

--- a/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
+++ b/src/org/sosy_lab/java_smt/api/PropagatorBackend.java
@@ -71,9 +71,9 @@ public interface PropagatorBackend {
 
   /**
    * Enables tracking of expression values for the associated {@link UserPropagator} via
-   * {@link UserPropagator#onKnownValue(BooleanFormula, BooleanFormula)}.
+   * {@link UserPropagator#onKnownValue}.
    *
-   * <p>This function is typically called from {@link UserPropagator#initialize()} if the
+   * <p>This function is typically called from {@link UserPropagator#initializeWithBackend} if the
    * theory solver needs to listen to the value of expressions registered by
    * {@link #registerExpression}.
    */
@@ -83,7 +83,7 @@ public interface PropagatorBackend {
    * Enables tracking of decisions made for the associated {@link UserPropagator} via
    * {@link UserPropagator#onDecision(BooleanFormula, boolean)}.
    *
-   * <p>This function is typically called from {@link UserPropagator#initialize()} if the
+   * <p>This function is typically called from {@link UserPropagator#initializeWithBackend} if the
    * theory solver needs to listen to and/or modify the decisions made by the solver on
    * expressions registered by {@link #registerExpression}.
    */
@@ -93,7 +93,7 @@ public interface PropagatorBackend {
    * Enables the final callback {@link UserPropagator#onFinalCheck()} that is invoked
    * when the solver finds a full satisfying assignment.
    *
-   * <p>This function is typically called from {@link UserPropagator#initialize()} if the
+   * <p>This function is typically called from {@link UserPropagator#initializeWithBackend} if the
    * theory solver needs to perform final consistency checks.
    */
   void notifyOnFinalCheck();

--- a/src/org/sosy_lab/java_smt/api/UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/api/UserPropagator.java
@@ -59,9 +59,9 @@ public interface UserPropagator {
    * {@link PropagatorBackend#notifyOnKnownValue()}.
    *
    * @param expr  The expressions whose value is known.
-   * @param value The value of the expression (true or false).
+   * @param value The value of the expression.
    */
-  void onKnownValue(BooleanFormula expr, BooleanFormula value);
+  void onKnownValue(BooleanFormula expr, boolean value);
 
   /**
    * This callback is invoked if the solver decides to branch on a registered expression.

--- a/src/org/sosy_lab/java_smt/api/UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/api/UserPropagator.java
@@ -38,7 +38,7 @@ public interface UserPropagator {
    * This callback is invoked when the solver finds a complete satisfying assignment.
    * The user can check the found model for consistency and potentially raise conflicts via
    * {@link PropagatorBackend#propagateConflict(BooleanFormula[])}.
-   *
+   * <p>
    * Note: This callback is only invoked if the user propagator enabled it via
    * {@link PropagatorBackend#notifyOnFinalCheck()}.
    */
@@ -47,20 +47,34 @@ public interface UserPropagator {
   /**
    * This callback is invoked if the solver gets to know the value of a registered expression
    * ({@link #registerExpression}).
-   * WIthin the callback, the user can raise conflicts via
+   * Within the callback, the user can raise conflicts via
    * {@link PropagatorBackend#propagateConflict}, propagate consequences via
    * {@link PropagatorBackend#propagateConsequence}, or influence the solvers decision heuristics
    * via {@link PropagatorBackend#propagateNextDecision}.
-   *
+   * <p>
    * The reported value is only known on the current and later push levels,
    * but will get invalidated when backtracking.
-   *
+   * <p>
    * Note: This callback is only invoked if the user propagator enabled it via
    * {@link PropagatorBackend#notifyOnKnownValue()}.
-   * @param expr The expressions whose value is known.
-   * @param val The value of the expression (true or false).
+   *
+   * @param expr  The expressions whose value is known.
+   * @param value The value of the expression (true or false).
    */
-  void onKnownValue(BooleanFormula expr, BooleanFormula val);
+  void onKnownValue(BooleanFormula expr, BooleanFormula value);
+
+  /**
+   * This callback is invoked if the solver decides to branch on a registered expression.
+   * ({@link #registerExpression}).
+   * Within the callback, the user can change the decision by calling
+   * {@link PropagatorBackend#propagateNextDecision}.
+   * <p>
+   * Note: This callback is only invoked if the user propagator enabled it via
+   * {@link PropagatorBackend#notifyOnDecision()}.
+   * @param expr The expressions whose value gets decided (usually a literal).
+   * @param value The decision value.
+   */
+  void onDecision(BooleanFormula expr, boolean value);
 
   /**
    * Connects this user propagator with a {@link PropagatorBackend}. The backend is used
@@ -78,10 +92,20 @@ public interface UserPropagator {
 
   /**
    * Registers an expression to be observed by the {@link UserPropagator}.
-   * Whenever the value of a registered expression becomes known by the solver, this will
-   * get reported to the user propagator by invoking the callback
-   * {@link UserPropagator#onKnownValue} (if notification was enabled via
-   * {@link PropagatorBackend#notifyOnKnownValue}).
+   * Solver actions related to the expression are reported:
+   * <ul>
+   *   <li>
+   *     The callback {@link UserPropagator#onKnownValue} gets invoked if the value of a
+   *     registered expression becomes known (if notification was enabled via
+   *    {@link PropagatorBackend#notifyOnKnownValue}).
+   *   </li>
+   *   <li>
+   *     The callback {@link UserPropagator#onDecision} gets invoked right before the
+   *     solver decides on the value of a registered expression (if notification was enabled via
+   *     {@link PropagatorBackend#notifyOnDecision()}).
+   *   </li>
+   * </ul>
+   *
    * @param theoryExpr The expression to observe.
    */
   void registerExpression(BooleanFormula theoryExpr);

--- a/src/org/sosy_lab/java_smt/api/UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/api/UserPropagator.java
@@ -57,27 +57,11 @@ public interface UserPropagator {
   void onFinalCheck();
 
   /**
-   * This callback is invoked if the solver finds two registered expressions
-   * ({@link #registerExpression})
-   * to be equal.
-   *
-   * <p>The solver may not report all quadratically-many equalities. Instead, the solver may report
-   * only linearly many equalities (~ a spanning tree) that are sufficient to reconstruct the full
-   * equivalence relation (e.g., via a union-find data structure).
-   *
-   * <p>The reported equalities hold only true on the current and later push levels,
-   * but will in general get invalidated when backtracking.
-   *
-   * Note: This callback is only invoked if the user propagator enabled it via
-   * {@link PropagatorBackend#notifyOnEquality()}.
-   * @param x The first expression.
-   * @param y The second expression that equals the first one.
-   */
-  void onEquality(BooleanFormula x, BooleanFormula y);
-
-  /**
    * This callback is invoked if the solver gets to know the value of a registered expression
    * ({@link #registerExpression}).
+   *
+   * The reported value is only known on the current and later push levels,
+   * but will get invalidated when backtracking.
    *
    * Note: This callback is only invoked if the user propagator enabled it via
    * {@link PropagatorBackend#notifyOnKnownValue()}.
@@ -106,9 +90,6 @@ public interface UserPropagator {
    * get reported to the user propagator by invoking the callback
    * {@link UserPropagator#onKnownValue} (if notification was enabled via
    * {@link PropagatorBackend#notifyOnKnownValue}).
-   * Similarly, equalities between registered expressions are reported via
-   * {@link UserPropagator#onEquality} (if enabled via
-   * {@link PropagatorBackend#notifyOnEquality()}.
    * @param theoryExpr The expression to observe.
    */
   void registerExpression(BooleanFormula theoryExpr);

--- a/src/org/sosy_lab/java_smt/api/UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/api/UserPropagator.java
@@ -9,105 +9,105 @@
 package org.sosy_lab.java_smt.api;
 
 /**
- * Allows user-defined propagators (~ theory solvers) to be implemented.
- * It is advised to inherit from {@link org.sosy_lab.java_smt.basicimpl.AbstractUserPropagator}
- * rather than implementing this interface directly.
+ * Allows user-defined propagators (~ theory solvers) to be implemented. It is advised to inherit
+ * from {@link org.sosy_lab.java_smt.basicimpl.AbstractUserPropagator} rather than implementing this
+ * interface directly.
  *
- * <p> A user propagator provides various callbacks that are invoked by the solver during the
- * solving process. Within these callbacks, the user can react to and influence the solver
- * by calling into the {@link PropagatorBackend}. For example, he can raise conflicts
- * whenever the solver makes assignments inconsistent to the user-defined theory.
+ * <p>A user propagator provides various callbacks that are invoked by the solver during the solving
+ * process. Within these callbacks, the user can react to and influence the solver by calling into
+ * the {@link PropagatorBackend}. For example, he can raise conflicts whenever the solver makes
+ * assignments inconsistent to the user-defined theory.
  */
 public interface UserPropagator {
 
   /**
-   * This callback is invoked whenever the solver creates a new decision level.
-   * A user propagator should maintain backtracking points on each push to enable later
-   * backtracking.
+   * This callback is invoked whenever the solver creates a new decision level. A user propagator
+   * should maintain backtracking points on each push to enable later backtracking.
+   *
+   * <p>The onPush or onPop operation refers to internal state of the SMT/SAT solver while running a
+   * SAT check. This does not relate to Prover operations in the SMT-based API, such as {@link
+   * ProverEnvironment#push} or {@link ProverEnvironment#pop}.
    */
   void onPush();
 
   /**
-   * This callback is invoked when the solver backtracks. The solver can backtrack multiple
-   * levels simultaneously.
+   * This callback is invoked when the solver backtracks. The solver can backtrack multiple levels
+   * simultaneously.
+   *
+   * <p>The onPush or onPop operation refers to internal state of the SMT/SAT solver while running a
+   * SAT check. This does not relate to Prover operations in the SMT-based API, such as {@link
+   * ProverEnvironment#push} or {@link ProverEnvironment#pop}.
+   *
    * @param numPoppedLevels The number of levels to backtrack (~ number of pushes to backtrack).
    */
   void onPop(int numPoppedLevels);
 
   /**
-   * This callback is invoked when the solver finds a complete satisfying assignment.
-   * The user can check the found model for consistency and potentially raise conflicts via
-   * {@link PropagatorBackend#propagateConflict(BooleanFormula[])}.
-   * <p>
-   * Note: This callback is only invoked if the user propagator enabled it via
-   * {@link PropagatorBackend#notifyOnFinalCheck()}.
+   * This callback is invoked when the solver finds a complete satisfying assignment. The user can
+   * check the found model for consistency and potentially raise conflicts via {@link
+   * PropagatorBackend#propagateConflict(BooleanFormula[])}.
+   *
+   * <p>Note: This callback is only invoked if the user propagator enabled it via {@link
+   * PropagatorBackend#notifyOnFinalCheck()}.
    */
   void onFinalCheck();
 
   /**
    * This callback is invoked if the solver gets to know the value of a registered expression
-   * ({@link #registerExpression}).
-   * Within the callback, the user can raise conflicts via
-   * {@link PropagatorBackend#propagateConflict}, propagate consequences via
-   * {@link PropagatorBackend#propagateConsequence}, or influence the solvers decision heuristics
-   * via {@link PropagatorBackend#propagateNextDecision}.
-   * <p>
-   * The reported value is only known on the current and later push levels,
-   * but will get invalidated when backtracking.
-   * <p>
-   * Note: This callback is only invoked if the user propagator enabled it via
-   * {@link PropagatorBackend#notifyOnKnownValue()}.
+   * ({@link #registerExpression}). Within the callback, the user can raise conflicts via {@link
+   * PropagatorBackend#propagateConflict}, propagate consequences via {@link
+   * PropagatorBackend#propagateConsequence}, or influence the solvers decision heuristics via
+   * {@link PropagatorBackend#propagateNextDecision}.
    *
-   * @param expr  The expressions whose value is known.
+   * <p>The reported value is only known on the current and later push levels, but will get
+   * invalidated when backtracking.
+   *
+   * <p>Note: This callback is only invoked if the user propagator enabled it via {@link
+   * PropagatorBackend#notifyOnKnownValue()}.
+   *
+   * @param expr The expressions whose value is known.
    * @param value The value of the expression.
    */
   void onKnownValue(BooleanFormula expr, boolean value);
 
   /**
-   * This callback is invoked if the solver decides to branch on a registered expression.
-   * ({@link #registerExpression}).
-   * Within the callback, the user can change the decision by calling
-   * {@link PropagatorBackend#propagateNextDecision}.
-   * <p>
-   * Note: This callback is only invoked if the user propagator enabled it via
-   * {@link PropagatorBackend#notifyOnDecision()}.
+   * This callback is invoked if the solver decides to branch on a registered expression. ({@link
+   * #registerExpression}). Within the callback, the user can change the decision by calling {@link
+   * PropagatorBackend#propagateNextDecision}.
+   *
+   * <p>Note: This callback is only invoked if the user propagator enabled it via {@link
+   * PropagatorBackend#notifyOnDecision()}.
+   *
    * @param expr The expressions whose value gets decided (usually a literal).
    * @param value The decision value.
    */
   void onDecision(BooleanFormula expr, boolean value);
 
   /**
-   * This method is invoked after the user propagator is registered via
-   * {@link ProverEnvironment#registerUserPropagator(UserPropagator)}.
-   * The user can enable notifications by accessing the provided {@link PropagatorBackend}.
+   * This method is invoked after the user propagator is registered via {@link
+   * ProverEnvironment#registerUserPropagator(UserPropagator)}. The user can enable notifications by
+   * accessing the provided {@link PropagatorBackend}.
    *
-   * <p>
-   *   Warning: During its lifetime, a user propagator shall only be registered once
-   *   via {@link ProverEnvironment#registerUserPropagator(UserPropagator)} for otherwise
-   *   unexpected errors can occur.
-   *   Implementations are advised to throw exceptions if this method is called multiple times.
+   * <p>Warning: During its lifetime, a user propagator shall only be registered once via {@link
+   * ProverEnvironment#registerUserPropagator(UserPropagator)} for otherwise unexpected errors can
+   * occur. Implementations are advised to throw exceptions if this method is called multiple times.
    */
   void initializeWithBackend(PropagatorBackend backend);
 
   /**
-   * Registers an expression to be observed by the {@link UserPropagator}.
-   * Solver actions related to the expression are reported:
+   * Registers an expression to be observed by the {@link UserPropagator}. Solver actions related to
+   * the expression are reported:
+   *
    * <ul>
-   *   <li>
-   *     The callback {@link UserPropagator#onKnownValue} gets invoked if the value of a
-   *     registered expression becomes known (if notification was enabled via
-   *    {@link PropagatorBackend#notifyOnKnownValue}).
-   *   </li>
-   *   <li>
-   *     The callback {@link UserPropagator#onDecision} gets invoked right before the
-   *     solver decides on the value of a registered expression (if notification was enabled via
-   *     {@link PropagatorBackend#notifyOnDecision()}).
-   *   </li>
+   *   <li>The callback {@link UserPropagator#onKnownValue} gets invoked if the value of a
+   *       registered expression becomes known (if notification was enabled via {@link
+   *       PropagatorBackend#notifyOnKnownValue}).
+   *   <li>The callback {@link UserPropagator#onDecision} gets invoked right before the solver
+   *       decides on the value of a registered expression (if notification was enabled via {@link
+   *       PropagatorBackend#notifyOnDecision()}).
    * </ul>
    *
    * @param theoryExpr The expression to observe.
    */
   void registerExpression(BooleanFormula theoryExpr);
-
-
 }

--- a/src/org/sosy_lab/java_smt/api/UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/api/UserPropagator.java
@@ -1,0 +1,117 @@
+/*
+ *  JavaSMT is an API wrapper for a collection of SMT solvers.
+ *  This file is part of JavaSMT.
+ *
+ *  Copyright (C) 2007-2016  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.sosy_lab.java_smt.api;
+
+/**
+ * Allows user-defined propagators (~ theory solvers) to be implemented.
+ * It is advised to inherit from {@link org.sosy_lab.java_smt.basicimpl.AbstractUserPropagator}
+ * rather than implementing this interface directly.
+ *
+ * <p> A user propagator provides various callbacks that are invoked by the solver during the
+ * solving process. Within these callbacks, the user can react to and influence the solver
+ * by calling into the {@link PropagatorBackend}. For example, he can raise conflicts
+ * whenever the solver makes assignments inconsistent to the user-defined theory.
+ */
+public interface UserPropagator {
+
+  /**
+   * This callback is invoked whenever the solver creates a new decision level.
+   * A user propagator should maintain backtracking points on each push to enable later
+   * backtracking.
+   */
+  void onPush();
+
+  /**
+   * This callback is invoked when the solver backtracks. The solver can backtrack multiple
+   * levels simultaneously.
+   * @param numPoppedLevels The number of levels to backtrack (~ number of pushes to backtrack).
+   */
+  void onPop(int numPoppedLevels);
+
+  /**
+   * This callback is invoked when the solver finds a complete satisfying assignment.
+   * The user can check the found model for consistency and potentially raise conflicts via
+   * {@link PropagatorBackend#propagateConflict(BooleanFormula[])}.
+   *
+   * Note: This callback is only invoked if the user propagator enabled it via
+   * {@link PropagatorBackend#notifyOnFinalCheck()}.
+   */
+  void onFinalCheck();
+
+  /**
+   * This callback is invoked if the solver finds two registered expressions
+   * ({@link #registerExpression})
+   * to be equal.
+   *
+   * <p>The solver may not report all quadratically-many equalities. Instead, the solver may report
+   * only linearly many equalities (~ a spanning tree) that are sufficient to reconstruct the full
+   * equivalence relation (e.g., via a union-find data structure).
+   *
+   * <p>The reported equalities hold only true on the current and later push levels,
+   * but will in general get invalidated when backtracking.
+   *
+   * Note: This callback is only invoked if the user propagator enabled it via
+   * {@link PropagatorBackend#notifyOnEquality()}.
+   * @param x The first expression.
+   * @param y The second expression that equals the first one.
+   */
+  void onEquality(BooleanFormula x, BooleanFormula y);
+
+  /**
+   * This callback is invoked if the solver gets to know the value of a registered expression
+   * ({@link #registerExpression}).
+   *
+   * Note: This callback is only invoked if the user propagator enabled it via
+   * {@link PropagatorBackend#notifyOnKnownValue()}.
+   * @param expr The expressions whose value is known.
+   * @param val The value of the expression (true or false).
+   */
+  void onKnownValue(BooleanFormula expr, BooleanFormula val);
+
+  /**
+   * Connects this user propagator with a {@link PropagatorBackend}. The backend is used
+   * to register expressions, raise conflicts, propagate consequences, etc.
+   * @param backend The propagator backend.
+   */
+  void injectBackend(PropagatorBackend backend);
+
+  /**
+   * This method is similar to a constructor but is guaranteed to get invoked only after
+   * {@link #injectBackend} was successfully called.
+   * The user can enable notifications by accessing the injected {@link PropagatorBackend}.
+   */
+  void initialize();
+
+  /**
+   * Registers an expression to be observed by the {@link UserPropagator}.
+   * Whenever the value of a registered expression becomes known by the solver, this will
+   * get reported to the user propagator by invoking the callback
+   * {@link UserPropagator#onKnownValue} (if notification was enabled via
+   * {@link PropagatorBackend#notifyOnKnownValue}).
+   * Similarly, equalities between registered expressions are reported via
+   * {@link UserPropagator#onEquality} (if enabled via
+   * {@link PropagatorBackend#notifyOnEquality()}.
+   * @param theoryExpr The expression to observe.
+   */
+  void registerExpression(BooleanFormula theoryExpr);
+
+
+}

--- a/src/org/sosy_lab/java_smt/api/UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/api/UserPropagator.java
@@ -77,18 +77,17 @@ public interface UserPropagator {
   void onDecision(BooleanFormula expr, boolean value);
 
   /**
-   * Connects this user propagator with a {@link PropagatorBackend}. The backend is used
-   * to register expressions, raise conflicts, propagate consequences, etc.
-   * @param backend The propagator backend.
+   * This method is invoked after the user propagator is registered via
+   * {@link ProverEnvironment#registerUserPropagator(UserPropagator)}.
+   * The user can enable notifications by accessing the provided {@link PropagatorBackend}.
+   *
+   * <p>
+   *   Warning: During its lifetime, a user propagator shall only be registered once
+   *   via {@link ProverEnvironment#registerUserPropagator(UserPropagator)} for otherwise
+   *   unexpected errors can occur.
+   *   Implementations are advised to throw exceptions if this method is called multiple times.
    */
-  void injectBackend(PropagatorBackend backend);
-
-  /**
-   * This method is similar to a constructor but is guaranteed to get invoked only after
-   * {@link #injectBackend} was successfully called.
-   * The user can enable notifications by accessing the injected {@link PropagatorBackend}.
-   */
-  void initialize();
+  void initializeWithBackend(PropagatorBackend backend);
 
   /**
    * Registers an expression to be observed by the {@link UserPropagator}.

--- a/src/org/sosy_lab/java_smt/api/UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/api/UserPropagator.java
@@ -1,22 +1,10 @@
-/*
- *  JavaSMT is an API wrapper for a collection of SMT solvers.
- *  This file is part of JavaSMT.
- *
- *  Copyright (C) 2007-2016  Dirk Beyer
- *  All rights reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package org.sosy_lab.java_smt.api;
 

--- a/src/org/sosy_lab/java_smt/api/UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/api/UserPropagator.java
@@ -59,6 +59,10 @@ public interface UserPropagator {
   /**
    * This callback is invoked if the solver gets to know the value of a registered expression
    * ({@link #registerExpression}).
+   * WIthin the callback, the user can raise conflicts via
+   * {@link PropagatorBackend#propagateConflict}, propagate consequences via
+   * {@link PropagatorBackend#propagateConsequence}, or influence the solvers decision heuristics
+   * via {@link PropagatorBackend#propagateNextDecision}.
    *
    * The reported value is only known on the current and later push levels,
    * but will get invalidated when backtracking.

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractEvaluator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractEvaluator.java
@@ -31,8 +31,8 @@ public abstract class AbstractEvaluator<TFormulaInfo, TType, TEnv> implements Ev
 
   protected AbstractEvaluator(
       AbstractProver<?> pProver, FormulaCreator<TFormulaInfo, TType, TEnv, ?> creator) {
-    this.prover = pProver;
-    this.creator = creator;
+    this.prover = Preconditions.checkNotNull(pProver);
+    this.creator = Preconditions.checkNotNull(creator);
   }
 
   @SuppressWarnings("unchecked")
@@ -126,9 +126,7 @@ public abstract class AbstractEvaluator<TFormulaInfo, TType, TEnv> implements Ev
 
   @Override
   public void close() {
-    if (prover != null) { // can be NULL for testing
-      prover.unregisterEvaluator(this);
-    }
+    prover.unregisterEvaluator(this);
     closed = true;
   }
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractEvaluator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractEvaluator.java
@@ -2,7 +2,7 @@
 // an API wrapper for a collection of SMT solvers:
 // https://github.com/sosy-lab/java-smt
 //
-// SPDX-FileCopyrightText: 2022 Dirk Beyer <https://www.sosy-lab.org>
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,6 +17,8 @@ import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.Evaluator;
+import org.sosy_lab.java_smt.api.FloatingPointFormula;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
@@ -82,6 +84,12 @@ public abstract class AbstractEvaluator<TFormulaInfo, TType, TEnv> implements Ev
   public final String evaluate(EnumerationFormula f) {
     Preconditions.checkState(!isClosed());
     return (String) evaluateImpl(creator.extractInfo(f));
+  }
+
+  @Override
+  public final @Nullable FloatingPointNumber evaluate(FloatingPointFormula f) {
+    Preconditions.checkState(!isClosed());
+    return (FloatingPointNumber) evaluateImpl(creator.extractInfo(f));
   }
 
   @Nullable

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
@@ -1,0 +1,59 @@
+/*
+ *  JavaSMT is an API wrapper for a collection of SMT solvers.
+ *  This file is part of JavaSMT.
+ *
+ *  Copyright (C) 2007-2016  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.sosy_lab.java_smt.basicimpl;
+
+import com.google.common.base.Preconditions;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.UserPropagator;
+import org.sosy_lab.java_smt.api.PropagatorBackend;
+
+public abstract class AbstractUserPropagator implements UserPropagator  {
+
+  protected @Nullable PropagatorBackend backend;
+
+  @Override
+  public void onFinalCheck() {
+
+  }
+
+  @Override
+  public void onEquality(BooleanFormula x, BooleanFormula y) {
+
+  }
+
+  @Override
+  public void onKnownValue(BooleanFormula expr, BooleanFormula val) {
+
+  }
+
+  @Override
+  public final void injectBackend(PropagatorBackend backend) {
+    this.backend = Preconditions.checkNotNull(backend);
+  }
+
+  @Override
+  public void registerExpression(BooleanFormula theoryExpr) {
+    Preconditions.checkState(backend != null);
+    backend.registerExpression(theoryExpr);
+  }
+
+}

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
@@ -36,7 +36,7 @@ public abstract class AbstractUserPropagator implements UserPropagator  {
   }
 
   @Override
-  public void onKnownValue(BooleanFormula expr, BooleanFormula value) {
+  public void onKnownValue(BooleanFormula expr, boolean value) {
 
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
@@ -46,13 +46,17 @@ public abstract class AbstractUserPropagator implements UserPropagator  {
   }
 
   @Override
-  public final void injectBackend(PropagatorBackend backend) {
+  public void initializeWithBackend(PropagatorBackend backend) {
+    Preconditions.checkState(this.backend == null,
+        "Trying to register a user propagator that has been registered before.");
     this.backend = Preconditions.checkNotNull(backend);
   }
 
   @Override
   public void registerExpression(BooleanFormula theoryExpr) {
-    Preconditions.checkState(backend != null);
+    Preconditions.checkState(backend != null,
+        "Uninitialized backend. Make sure to register the user propagator with the prover"
+            + "before calling this method.");
     backend.registerExpression(theoryExpr);
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
@@ -24,6 +24,12 @@ public abstract class AbstractUserPropagator implements UserPropagator {
   }
 
   @Override
+  public void onPush() {}
+
+  @Override
+  public void onPop(int numPoppedLevels) {}
+
+  @Override
   public void onFinalCheck() {}
 
   @Override

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
@@ -36,11 +36,6 @@ public abstract class AbstractUserPropagator implements UserPropagator  {
   }
 
   @Override
-  public void onEquality(BooleanFormula x, BooleanFormula y) {
-
-  }
-
-  @Override
   public void onKnownValue(BooleanFormula expr, BooleanFormula val) {
 
   }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
@@ -1,22 +1,10 @@
-/*
- *  JavaSMT is an API wrapper for a collection of SMT solvers.
- *  This file is part of JavaSMT.
- *
- *  Copyright (C) 2007-2016  Dirk Beyer
- *  All rights reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package org.sosy_lab.java_smt.basicimpl;
 
@@ -28,7 +16,12 @@ import org.sosy_lab.java_smt.api.UserPropagator;
 
 public abstract class AbstractUserPropagator implements UserPropagator {
 
-  protected @Nullable PropagatorBackend backend;
+  private @Nullable PropagatorBackend backend;
+
+  protected PropagatorBackend getBackend() {
+    return Preconditions.checkNotNull(
+        backend, "Trying to access an uninitialized user propagator.");
+  }
 
   @Override
   public void onFinalCheck() {}
@@ -40,11 +33,11 @@ public abstract class AbstractUserPropagator implements UserPropagator {
   public void onDecision(BooleanFormula expr, boolean value) {}
 
   @Override
-  public void initializeWithBackend(PropagatorBackend backend) {
+  public void initializeWithBackend(PropagatorBackend pBackend) {
     Preconditions.checkState(
         this.backend == null,
         "Trying to register a user propagator that has been registered before.");
-    this.backend = Preconditions.checkNotNull(backend);
+    this.backend = Preconditions.checkNotNull(pBackend);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
@@ -36,7 +36,12 @@ public abstract class AbstractUserPropagator implements UserPropagator  {
   }
 
   @Override
-  public void onKnownValue(BooleanFormula expr, BooleanFormula val) {
+  public void onKnownValue(BooleanFormula expr, BooleanFormula value) {
+
+  }
+
+  @Override
+  public void onDecision(BooleanFormula expr, boolean value) {
 
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractUserPropagator.java
@@ -23,41 +23,36 @@ package org.sosy_lab.java_smt.basicimpl;
 import com.google.common.base.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.UserPropagator;
 import org.sosy_lab.java_smt.api.PropagatorBackend;
+import org.sosy_lab.java_smt.api.UserPropagator;
 
-public abstract class AbstractUserPropagator implements UserPropagator  {
+public abstract class AbstractUserPropagator implements UserPropagator {
 
   protected @Nullable PropagatorBackend backend;
 
   @Override
-  public void onFinalCheck() {
-
-  }
+  public void onFinalCheck() {}
 
   @Override
-  public void onKnownValue(BooleanFormula expr, boolean value) {
-
-  }
+  public void onKnownValue(BooleanFormula expr, boolean value) {}
 
   @Override
-  public void onDecision(BooleanFormula expr, boolean value) {
-
-  }
+  public void onDecision(BooleanFormula expr, boolean value) {}
 
   @Override
   public void initializeWithBackend(PropagatorBackend backend) {
-    Preconditions.checkState(this.backend == null,
+    Preconditions.checkState(
+        this.backend == null,
         "Trying to register a user propagator that has been registered before.");
     this.backend = Preconditions.checkNotNull(backend);
   }
 
   @Override
   public void registerExpression(BooleanFormula theoryExpr) {
-    Preconditions.checkState(backend != null,
+    Preconditions.checkState(
+        backend != null,
         "Uninitialized backend. Make sure to register the user propagator with the prover"
             + "before calling this method.");
     backend.registerExpression(theoryExpr);
   }
-
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/CachingModel.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/CachingModel.java
@@ -16,6 +16,8 @@ import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.EnumerationFormula;
+import org.sosy_lab.java_smt.api.FloatingPointFormula;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
@@ -82,6 +84,11 @@ public class CachingModel implements Model {
 
   @Override
   public @Nullable String evaluate(EnumerationFormula formula) {
+    return delegate.evaluate(formula);
+  }
+
+  @Override
+  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula formula) {
     return delegate.evaluate(formula);
   }
 

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsModel.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsModel.java
@@ -17,6 +17,8 @@ import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.EnumerationFormula;
+import org.sosy_lab.java_smt.api.FloatingPointFormula;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
@@ -77,6 +79,12 @@ class StatisticsModel implements Model {
 
   @Override
   public @Nullable String evaluate(EnumerationFormula pF) {
+    stats.modelEvaluations.getAndIncrement();
+    return delegate.evaluate(pF);
+  }
+
+  @Override
+  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula pF) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.evaluate(pF);
   }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModel.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModel.java
@@ -17,6 +17,8 @@ import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.EnumerationFormula;
+import org.sosy_lab.java_smt.api.FloatingPointFormula;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
@@ -85,6 +87,13 @@ class SynchronizedModel implements Model {
 
   @Override
   public @Nullable String evaluate(EnumerationFormula pF) {
+    synchronized (sync) {
+      return delegate.evaluate(pF);
+    }
+  }
+
+  @Override
+  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula pF) {
     synchronized (sync) {
       return delegate.evaluate(pF);
     }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModelWithContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModelWithContext.java
@@ -17,6 +17,8 @@ import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.EnumerationFormula;
+import org.sosy_lab.java_smt.api.FloatingPointFormula;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaManager;
 import org.sosy_lab.java_smt.api.Model;
@@ -84,6 +86,11 @@ class SynchronizedModelWithContext implements Model {
 
   @Override
   public @Nullable String evaluate(EnumerationFormula pF) {
+    throw new UnsupportedOperationException(UNSUPPORTED_OPERATION);
+  }
+
+  @Override
+  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula formula) {
     throw new UnsupportedOperationException(UNSUPPORTED_OPERATION);
   }
 

--- a/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
@@ -1,26 +1,12 @@
-/*
- *  JavaSMT is an API wrapper for a collection of SMT solvers.
- *  This file is part of JavaSMT.
- *
- *  Copyright (C) 2007-2016  Dirk Beyer
- *  All rights reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package org.sosy_lab.java_smt.example;
-
-import static com.google.common.base.Verify.verify;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +47,6 @@ public class SimpleUserPropagator {
       testWithBlockedLiterals(context, bmgr, logger);
       testWithBlockedClause(context, bmgr, logger);
       testWithBlockedSubclauses(context, bmgr, logger);
-
 
     } catch (InvalidConfigurationException | UnsatisfiedLinkError e) {
       logger.logUserException(Level.INFO, e, "Z3 is not available.");

--- a/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
@@ -8,12 +8,11 @@
 
 package org.sosy_lab.java_smt.example;
 
+import com.google.common.base.Verify;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
-
-import com.google.common.base.Verify;
 import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
@@ -30,19 +29,17 @@ import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractUserPropagator;
 
-/**
- * Example of a simple user propagator that prohibits variables/expressions to be set to true.
- */
+/** Example of a simple user propagator that prohibits variables/expressions to be set to true. */
 public class SimpleUserPropagator {
 
-  public static void main (String[] args) throws InvalidConfigurationException,
-                                                 InterruptedException, SolverException {
+  public static void main(String[] args)
+      throws InvalidConfigurationException, InterruptedException, SolverException {
     Configuration config = Configuration.defaultConfiguration();
     LogManager logger = BasicLogManager.create(config);
     ShutdownNotifier notifier = ShutdownNotifier.createDummy();
 
-    try (SolverContext context = SolverContextFactory.createSolverContext(config, logger, notifier,
-            Solvers.Z3)) {
+    try (SolverContext context =
+        SolverContextFactory.createSolverContext(config, logger, notifier, Solvers.Z3)) {
       final BooleanFormulaManager bmgr = context.getFormulaManager().getBooleanFormulaManager();
 
       testWithBlockedLiterals(context, bmgr, logger);
@@ -54,11 +51,11 @@ public class SimpleUserPropagator {
     } catch (UnsupportedOperationException e) {
       logger.logUserException(Level.INFO, e, e.getMessage());
     }
-
   }
 
-  private static void testWithBlockedLiterals(SolverContext context, BooleanFormulaManager bmgr,
-                                 LogManager logger) throws InterruptedException, SolverException {
+  private static void testWithBlockedLiterals(
+      SolverContext context, BooleanFormulaManager bmgr, LogManager logger)
+      throws InterruptedException, SolverException {
     try (ProverEnvironment prover = context.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
       // assert "p or q or r or s"
       BooleanFormula p = bmgr.makeVariable("p");
@@ -68,8 +65,11 @@ public class SimpleUserPropagator {
       BooleanFormula clause = bmgr.or(p, q, r, s);
       prover.addConstraint(clause);
 
-      logger.log(Level.INFO, "========== Checking satisfiability of", clause, "while blocking "
-          + "all literals ==========");
+      logger.log(
+          Level.INFO,
+          "========== Checking satisfiability of",
+          clause,
+          "while blocking " + "all literals ==========");
 
       // Create user propagator that prohibits variables to be set to true
       MyUserPropagator myUserPropagator = new MyUserPropagator(logger);
@@ -85,8 +85,9 @@ public class SimpleUserPropagator {
     }
   }
 
-  private static void testWithBlockedClause(SolverContext context, BooleanFormulaManager bmgr,
-                                         LogManager logger) throws InterruptedException, SolverException {
+  private static void testWithBlockedClause(
+      SolverContext context, BooleanFormulaManager bmgr, LogManager logger)
+      throws InterruptedException, SolverException {
     try (ProverEnvironment prover = context.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
       // assert "p or q or r or s"
       BooleanFormula p = bmgr.makeVariable("p");
@@ -96,8 +97,11 @@ public class SimpleUserPropagator {
       BooleanFormula clause = bmgr.or(p, q, r, s);
       prover.addConstraint(clause);
 
-      logger.log(Level.INFO, "========== Checking satisfiability of", clause, "while blocking "
-          + "the full clause ==========");
+      logger.log(
+          Level.INFO,
+          "========== Checking satisfiability of",
+          clause,
+          "while blocking " + "the full clause ==========");
 
       // Create user propagator that prohibits the full clause to be set to true.
       MyUserPropagator myUserPropagator = new MyUserPropagator(logger);
@@ -110,8 +114,9 @@ public class SimpleUserPropagator {
     }
   }
 
-  private static void testWithBlockedSubclauses(SolverContext context, BooleanFormulaManager bmgr,
-                                 LogManager logger) throws InterruptedException, SolverException {
+  private static void testWithBlockedSubclauses(
+      SolverContext context, BooleanFormulaManager bmgr, LogManager logger)
+      throws InterruptedException, SolverException {
     try (ProverEnvironment prover = context.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
       // assert "p or q or r or s"
       BooleanFormula p = bmgr.makeVariable("p");
@@ -123,8 +128,15 @@ public class SimpleUserPropagator {
       BooleanFormula subclause2 = bmgr.or(r, s);
       prover.addConstraint(clause);
 
-      logger.log(Level.INFO, "========== Checking satisfiability of", clause, "while blocking "
-          + "the subclauses", subclause1, "and", subclause2, "==========");
+      logger.log(
+          Level.INFO,
+          "========== Checking satisfiability of",
+          clause,
+          "while blocking " + "the subclauses",
+          subclause1,
+          "and",
+          subclause2,
+          "==========");
 
       // Create user propagator that prohibits (sub)clauses to be set to true.
       // Note that the subclauses are not directly asserted in the original input formula.
@@ -139,9 +151,7 @@ public class SimpleUserPropagator {
     }
   }
 
-  /**
-   * This user propagator will raise a conflict whenever a registered expression is set to true.
-   */
+  /** This user propagator will raise a conflict whenever a registered expression is set to true. */
   private static class MyUserPropagator extends AbstractUserPropagator {
 
     private final List<BooleanFormula> disabledExpressions = new ArrayList<>();
@@ -166,7 +176,7 @@ public class SimpleUserPropagator {
       logger.log(Level.INFO, "Solver assigned", expr, "to", value);
       if (value && disabledExpressions.contains(expr)) {
         logger.log(Level.INFO, "User propagator raised conflict on", expr);
-        backend.propagateConflict(new BooleanFormula[] { expr });
+        backend.propagateConflict(new BooleanFormula[] {expr});
       }
     }
 
@@ -181,9 +191,12 @@ public class SimpleUserPropagator {
         if (backend.propagateNextDecision(disExpr, Optional.of(decisionValue))) {
           // The above call returns "true" if the provided literal is yet undecided, otherwise
           // false.
-          logger.log(Level.INFO, String.format("User propagator overwrites decision "
-              + "from '%s = %s' to '%s = %s'", expr, value, disExpr, decisionValue));
-          return;
+          logger.log(
+              Level.INFO,
+              String.format(
+                  "User propagator overwrites decision from '%s = %s' to '%s = %s'",
+                  expr, value, disExpr, decisionValue));
+          break;
         }
       }
     }

--- a/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
@@ -1,0 +1,130 @@
+/*
+ *  JavaSMT is an API wrapper for a collection of SMT solvers.
+ *  This file is part of JavaSMT.
+ *
+ *  Copyright (C) 2007-2016  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.sosy_lab.java_smt.example;
+
+import static com.google.common.base.Verify.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+import com.google.common.base.Verify;
+import org.sosy_lab.common.ShutdownNotifier;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.common.log.BasicLogManager;
+import org.sosy_lab.common.log.LogManager;
+import org.sosy_lab.java_smt.SolverContextFactory;
+import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
+import org.sosy_lab.java_smt.api.SolverContext;
+import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
+import org.sosy_lab.java_smt.api.SolverException;
+import org.sosy_lab.java_smt.basicimpl.AbstractUserPropagator;
+
+/**
+ * Example of a simple user propagator that prohibits variables to be set to true.
+ */
+public class SimpleUserPropagator {
+
+  public static void main (String[] args) throws InvalidConfigurationException,
+                                                 InterruptedException, SolverException {
+    Configuration config = Configuration.defaultConfiguration();
+    LogManager logger = BasicLogManager.create(config);
+    ShutdownNotifier notifier = ShutdownNotifier.createDummy();
+
+    try (SolverContext context = SolverContextFactory.createSolverContext(config, logger, notifier,
+            Solvers.Z3);
+         ProverEnvironment prover = context.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
+      final BooleanFormulaManager bmgr = context.getFormulaManager().getBooleanFormulaManager();
+
+      // assert "p or q"
+      BooleanFormula p = bmgr.makeVariable("p");
+      BooleanFormula q = bmgr.makeVariable("q");
+      BooleanFormula p_or_q = bmgr.or(p, q);
+      prover.addConstraint(p_or_q);
+
+      // Create user propagator that prohibits variables to be set to true
+      MyUserPropagator myUserPropagator = new MyUserPropagator(bmgr, logger);
+      Verify.verify(prover.registerUserPropagator(myUserPropagator));
+      myUserPropagator.registerExpression(p);
+      myUserPropagator.registerExpression(q);
+
+      // Instance should be UNSAT now due to the user propagator
+      boolean isUnsat = prover.isUnsat();
+      logger.log(Level.INFO, "Formula", p_or_q, "is", isUnsat ? "UNSAT" : "SAT");
+
+    } catch (InvalidConfigurationException | UnsatisfiedLinkError e) {
+      logger.logUserException(Level.INFO, e, "Z3 is not available.");
+    } catch (UnsupportedOperationException e) {
+      logger.logUserException(Level.INFO, e, e.getMessage());
+    }
+
+  }
+
+  /**
+   * This user propagator will raise a conflict whenever a variable is set to true.
+   */
+  private static class MyUserPropagator extends AbstractUserPropagator {
+
+    private final List<BooleanFormula> disabledLiterals = new ArrayList<>();
+    private final BooleanFormulaManager bmgr;
+    private final LogManager logger;
+
+    public MyUserPropagator(BooleanFormulaManager bmgr, LogManager logger) {
+      this.bmgr = bmgr;
+      this.logger = logger;
+    }
+
+    @Override
+    public void onPush() {
+      logger.log(Level.INFO, "Solver pushed");
+    }
+
+    @Override
+    public void onPop(int numPoppedLevels) {
+      logger.log(Level.INFO, "Solver popped", numPoppedLevels, "levels");
+    }
+
+    @Override
+    public void onKnownValue(BooleanFormula expr, BooleanFormula val) {
+      logger.log(Level.INFO, "Solver assigned", expr, "to", val);
+      if (disabledLiterals.contains(expr) && bmgr.isTrue(val)) {
+        logger.log(Level.INFO, "User propagator raised conflict on", expr);
+        backend.propagateConflict(new BooleanFormula[] { expr });
+      }
+    }
+
+    @Override
+    public void initialize() {
+      // Enable "onKnownValue" callback
+      backend.notifyOnKnownValue();
+    }
+
+    @Override
+    public void registerExpression(BooleanFormula theoryExpr) {
+      disabledLiterals.add(theoryExpr);
+      super.registerExpression(theoryExpr);
+    }
+  }
+}

--- a/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
@@ -32,6 +32,8 @@ import org.sosy_lab.java_smt.basicimpl.AbstractUserPropagator;
 /** Example of a simple user propagator that prohibits variables/expressions to be set to true. */
 public class SimpleUserPropagator {
 
+  private SimpleUserPropagator() {}
+
   public static void main(String[] args)
       throws InvalidConfigurationException, InterruptedException, SolverException {
     Configuration config = Configuration.defaultConfiguration();
@@ -157,7 +159,7 @@ public class SimpleUserPropagator {
     private final List<BooleanFormula> disabledExpressions = new ArrayList<>();
     private final LogManager logger;
 
-    public MyUserPropagator(LogManager logger) {
+    MyUserPropagator(LogManager logger) {
       this.logger = logger;
     }
 
@@ -176,7 +178,7 @@ public class SimpleUserPropagator {
       logger.log(Level.INFO, "Solver assigned", expr, "to", value);
       if (value && disabledExpressions.contains(expr)) {
         logger.log(Level.INFO, "User propagator raised conflict on", expr);
-        backend.propagateConflict(new BooleanFormula[] {expr});
+        getBackend().propagateConflict(new BooleanFormula[] {expr});
       }
     }
 
@@ -188,7 +190,7 @@ public class SimpleUserPropagator {
       // decision the solver would make.
       for (BooleanFormula disExpr : disabledExpressions) {
         final boolean decisionValue = true;
-        if (backend.propagateNextDecision(disExpr, Optional.of(decisionValue))) {
+        if (getBackend().propagateNextDecision(disExpr, Optional.of(decisionValue))) {
           // The above call returns "true" if the provided literal is yet undecided, otherwise
           // false.
           logger.log(

--- a/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
@@ -163,9 +163,9 @@ public class SimpleUserPropagator {
     }
 
     @Override
-    public void onKnownValue(BooleanFormula expr, BooleanFormula value) {
+    public void onKnownValue(BooleanFormula expr, boolean value) {
       logger.log(Level.INFO, "Solver assigned", expr, "to", value);
-      if (disabledExpressions.contains(expr) && bmgr.isTrue(value)) {
+      if (value && disabledExpressions.contains(expr)) {
         logger.log(Level.INFO, "User propagator raised conflict on", expr);
         backend.propagateConflict(new BooleanFormula[] { expr });
       }

--- a/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
@@ -163,9 +163,9 @@ public class SimpleUserPropagator {
     }
 
     @Override
-    public void onKnownValue(BooleanFormula expr, BooleanFormula val) {
-      logger.log(Level.INFO, "Solver assigned", expr, "to", val);
-      if (disabledExpressions.contains(expr) && bmgr.isTrue(val)) {
+    public void onKnownValue(BooleanFormula expr, BooleanFormula value) {
+      logger.log(Level.INFO, "Solver assigned", expr, "to", value);
+      if (disabledExpressions.contains(expr) && bmgr.isTrue(value)) {
         logger.log(Level.INFO, "User propagator raised conflict on", expr);
         backend.propagateConflict(new BooleanFormula[] { expr });
       }

--- a/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
@@ -71,7 +71,7 @@ public class SimpleUserPropagator {
           + "all literals ==========");
 
       // Create user propagator that prohibits variables to be set to true
-      MyUserPropagator myUserPropagator = new MyUserPropagator(bmgr, logger);
+      MyUserPropagator myUserPropagator = new MyUserPropagator(logger);
       Verify.verify(prover.registerUserPropagator(myUserPropagator));
       myUserPropagator.registerExpression(p);
       myUserPropagator.registerExpression(q);
@@ -99,7 +99,7 @@ public class SimpleUserPropagator {
           + "the full clause ==========");
 
       // Create user propagator that prohibits the full clause to be set to true.
-      MyUserPropagator myUserPropagator = new MyUserPropagator(bmgr, logger);
+      MyUserPropagator myUserPropagator = new MyUserPropagator(logger);
       Verify.verify(prover.registerUserPropagator(myUserPropagator));
       myUserPropagator.registerExpression(clause);
 
@@ -127,7 +127,7 @@ public class SimpleUserPropagator {
 
       // Create user propagator that prohibits (sub)clauses to be set to true.
       // Note that the subclauses are not directly asserted in the original input formula.
-      MyUserPropagator myUserPropagator = new MyUserPropagator(bmgr, logger);
+      MyUserPropagator myUserPropagator = new MyUserPropagator(logger);
       Verify.verify(prover.registerUserPropagator(myUserPropagator));
       myUserPropagator.registerExpression(subclause1);
       myUserPropagator.registerExpression(subclause2);
@@ -144,11 +144,9 @@ public class SimpleUserPropagator {
   private static class MyUserPropagator extends AbstractUserPropagator {
 
     private final List<BooleanFormula> disabledExpressions = new ArrayList<>();
-    private final BooleanFormulaManager bmgr;
     private final LogManager logger;
 
-    public MyUserPropagator(BooleanFormulaManager bmgr, LogManager logger) {
-      this.bmgr = bmgr;
+    public MyUserPropagator(LogManager logger) {
       this.logger = logger;
     }
 

--- a/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/SimpleUserPropagator.java
@@ -23,6 +23,7 @@ import org.sosy_lab.java_smt.SolverContextFactory;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.PropagatorBackend;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
@@ -188,7 +189,8 @@ public class SimpleUserPropagator {
     }
 
     @Override
-    public void initialize() {
+    public void initializeWithBackend(PropagatorBackend backend) {
+      super.initializeWithBackend(backend);
       // Enable callbacks
       backend.notifyOnKnownValue();
       backend.notifyOnDecision();

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueens.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueens.java
@@ -1,0 +1,365 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2020 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Unlicense OR Apache-2.0 OR MIT
+
+package org.sosy_lab.java_smt.example.nqueens_user_propagator;
+
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import org.sosy_lab.common.ShutdownNotifier;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.common.log.BasicLogManager;
+import org.sosy_lab.common.log.LogManager;
+import org.sosy_lab.java_smt.SolverContextFactory;
+import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
+import org.sosy_lab.java_smt.api.SolverContext;
+import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
+import org.sosy_lab.java_smt.api.SolverException;
+
+/**
+ * This example program solves a NQueens problem of given size and prints a possible solution.
+ *
+ * <p>For example, the Queen can be placed in these ways for a field size of 4:
+ *
+ * <pre>
+ *   .Q..
+ *   ...Q
+ *   Q...
+ *   ..Q.
+ * </pre>
+ */
+public class NQueens {
+  private final SolverContext context;
+  private final BooleanFormulaManager bmgr;
+  private final int n;
+  private NQueensEnumeratingPropagator theorySolver;
+
+  public NQueens(SolverContext pContext, int n) {
+    context = pContext;
+    bmgr = context.getFormulaManager().getBooleanFormulaManager();
+    this.n = n;
+  }
+
+  public static void main(String... args)
+      throws InvalidConfigurationException, SolverException, InterruptedException {
+    Configuration config = Configuration.defaultConfiguration();
+    LogManager logger = BasicLogManager.create(config);
+    ShutdownNotifier notifier = ShutdownNotifier.createDummy();
+
+    try (SolverContext context =
+        SolverContextFactory.createSolverContext(config, logger, notifier, Solvers.Z3);
+         ProverEnvironment prover = context.newProverEnvironment(ProverOptions.GENERATE_MODELS,
+             ProverOptions.GENERATE_ALL_SAT)) {
+      int n = Integer.parseInt(args[0]);
+      int method = Integer.parseInt(args[1]);
+
+      long timeSnapshot = System.currentTimeMillis();
+      NQueens myQueen = new NQueens(context, n);
+      int solutions;
+      if (method == 1) {
+        System.out.println("Enumerating Nqueens solutions with classical blocking clauses.");
+        solutions = myQueen.enumerateSolutionsClassic(prover);
+      } else if (method == 2) {
+        System.out.println("Enumerating Nqueens solutions with enumerating propagator.");
+        solutions = myQueen.enumerateSolutionsWithPropagator(prover);
+      } else if (method == 3) {
+        System.out.println("Enumerating Nqueens solutions with enumerating and constraining propagator.");
+        solutions = myQueen.enumerateSolutionsWithConstraintPropagator(prover);
+      } else {
+        throw new IllegalArgumentException("The second method argument must be in {1, 2, 3}.");
+      }
+      long passedMillis = System.currentTimeMillis() - timeSnapshot;
+      System.out.printf("Found %d solutions in %.2f seconds%n", solutions, (passedMillis / 1000d));
+
+    } catch (InvalidConfigurationException | UnsatisfiedLinkError e) {
+      logger.logUserException(Level.INFO, e, "Solver Z3 is not available.");
+    } catch (UnsupportedOperationException e) {
+      logger.logUserException(Level.INFO, e, e.getMessage());
+    }
+  }
+
+
+  /**
+   * Creates a 2D array of BooleanFormula objects to represent the variables for each cell in a grid
+   * of size N x N.
+   *
+   * @return a 2D array of BooleanFormula objects, where each BooleanFormula object represents a
+   *     variable for a cell in the grid.
+   */
+  private BooleanFormula[][] getSymbols() {
+    final BooleanFormula[][] symbols = new BooleanFormula[n][n];
+    for (int row = 0; row < n; row++) {
+      for (int col = 0; col < n; col++) {
+        symbols[row][col] = bmgr.makeVariable("q_" + row + "_" + col);
+      }
+    }
+    return symbols;
+  }
+
+  /**
+   * Rule 1: At least one queen per row, or we can say make sure that there are N Queens on the
+   * board.
+   *
+   * @param symbols a 2D Boolean array representing the board. Each element is true if there is a
+   *     queen in that cell, false otherwise.
+   * @return a List of BooleanFormulas representing the rules for this constraint.
+   */
+  private List<BooleanFormula> rowRule1(BooleanFormula[][] symbols) {
+    final List<BooleanFormula> rules = new ArrayList<>();
+    for (BooleanFormula[] rowSymbols : symbols) {
+      List<BooleanFormula> clause = new ArrayList<>();
+      for (int i = 0; i < n; i++) {
+        clause.add(rowSymbols[i]);
+      }
+      rules.add(bmgr.or(clause));
+    }
+    return rules;
+  }
+
+  /**
+   * Rule 2: Add constraints to ensure that at most one queen is placed in each row. For n=4:
+   *
+   * <pre>
+   *   0123
+   * 0 ----
+   * 1 ----
+   * 2 ----
+   * 3 ----
+   * </pre>
+   *
+   * <p>We add a negation of the conjunction of all possible pairs of variables in each row.
+   *
+   * @param symbols a 2D array of BooleanFormula objects representing the variables for each cell on
+   *     the board.
+   * @return a list of BooleanFormula objects representing the constraints added by this rule.
+   */
+  private List<BooleanFormula> rowRule2(BooleanFormula[][] symbols) {
+    final List<BooleanFormula> rules = new ArrayList<>();
+    for (BooleanFormula[] rowSymbol : symbols) {
+      for (int j1 = 0; j1 < n; j1++) {
+        for (int j2 = j1 + 1; j2 < n; j2++) {
+          rules.add(bmgr.not(bmgr.and(rowSymbol[j1], rowSymbol[j2])));
+        }
+      }
+    }
+    return rules;
+  }
+
+  /**
+   * Rule 3: Add constraints to ensure that at most one queen is placed in each column. For n=4:
+   *
+   * <pre>
+   *   0123
+   * 0 ||||
+   * 1 ||||
+   * 2 ||||
+   * 3 ||||
+   * </pre>
+   *
+   * <p>We add a negation of the conjunction of all possible pairs of variables in each column.
+   *
+   * @param symbols a 2D array of BooleanFormula representing the placement of queens on the
+   *     chessboard
+   * @return a list of BooleanFormula objects representing the constraints added by this rule.
+   */
+  private List<BooleanFormula> columnRule(BooleanFormula[][] symbols) {
+    final List<BooleanFormula> rules = new ArrayList<>();
+    for (int j = 0; j < n; j++) {
+      for (int i1 = 0; i1 < n; i1++) {
+        for (int i2 = i1 + 1; i2 < n; i2++) {
+          rules.add(bmgr.not(bmgr.and(symbols[i1][j], symbols[i2][j])));
+        }
+      }
+    }
+    return rules;
+  }
+
+  /**
+   * Rule 4: At most one queen per diagonal transform the field (=symbols) from square shape into a
+   * (downwards/upwards directed) rhombus that is embedded in a rectangle
+   * (=downwardDiagonal/upwardDiagonal). For example for N=4 from this square:
+   *
+   * <pre>
+   *   0123
+   * 0 xxxx
+   * 1 xxxx
+   * 2 xxxx
+   * 3 xxxx
+   * </pre>
+   *
+   * <p>to this rhombus/rectangle:
+   *
+   * <pre>
+   *   0123
+   * 0 x---
+   * 1 xx--
+   * 2 xxx-
+   * 3 xxxx
+   * 4 -xxx
+   * 5 --xx
+   * 6 ---x
+   * </pre>
+   *
+   * @param symbols a two-dimensional array of Boolean formulas representing the chessboard
+   *     configuration
+   * @return a list of BooleanFormula objects representing the constraints added by this rule.
+   */
+  private List<BooleanFormula> diagonalRule(BooleanFormula[][] symbols) {
+    final List<BooleanFormula> rules = new ArrayList<>();
+    int numDiagonals = 2 * n - 1;
+    BooleanFormula[][] downwardDiagonal = new BooleanFormula[numDiagonals][n];
+    BooleanFormula[][] upwardDiagonal = new BooleanFormula[numDiagonals][n];
+    for (int i = 0; i < n; i++) {
+      for (int j = 0; j < n; j++) {
+        downwardDiagonal[i + j][i] = symbols[i][j];
+        upwardDiagonal[i - j + n - 1][i] = symbols[i][j];
+      }
+    }
+    for (int d = 0; d < numDiagonals; d++) {
+      BooleanFormula[] diagonal1 = downwardDiagonal[d];
+      BooleanFormula[] diagonal2 = upwardDiagonal[d];
+      List<BooleanFormula> downwardDiagonalQueen = new ArrayList<>();
+      List<BooleanFormula> upwardDiagonalQueen = new ArrayList<>();
+      for (int i = 0; i < n; i++) {
+        if (diagonal1[i] != null) {
+          downwardDiagonalQueen.add(diagonal1[i]);
+        }
+        if (diagonal2[i] != null) {
+          upwardDiagonalQueen.add(diagonal2[i]);
+        }
+      }
+      for (int i = 0; i < downwardDiagonalQueen.size(); i++) {
+        for (int j = i + 1; j < downwardDiagonalQueen.size(); j++) {
+          rules.add(bmgr.not(bmgr.and(downwardDiagonalQueen.get(i), downwardDiagonalQueen.get(j))));
+        }
+      }
+      for (int i = 0; i < upwardDiagonalQueen.size(); i++) {
+        for (int j = i + 1; j < upwardDiagonalQueen.size(); j++) {
+          rules.add(bmgr.not(bmgr.and(upwardDiagonalQueen.get(i), upwardDiagonalQueen.get(j))));
+        }
+      }
+    }
+    return rules;
+  }
+
+  /**
+   * Returns a boolean value indicating whether a queen is placed on the cell corresponding to the
+   * given row and column.
+   *
+   * @param symbols a 2D BooleanFormula array representing the cells of the chess board.
+   * @param model the Model object representing the current state of the board.
+   * @param row the row index of the cell to check.
+   * @param col the column index of the cell to check.
+   * @return true if a queen is placed on the cell, false otherwise.
+   */
+  private boolean getValue(BooleanFormula[][] symbols, Model model, int row, int col) {
+    return Boolean.TRUE.equals(model.evaluate(symbols[row][col]));
+  }
+
+  private void addConstraints(ProverEnvironment prover, BooleanFormula[][] symbols) throws InterruptedException, SolverException{
+    List<BooleanFormula> rules =
+            ImmutableList.<BooleanFormula>builder()
+                    .addAll(rowRule1(symbols))
+                    .addAll(rowRule2(symbols))
+                    .addAll(columnRule(symbols))
+                    .addAll(diagonalRule(symbols))
+                    .build();
+    prover.addConstraint(bmgr.and(rules));
+  }
+
+  private int enumerateSolutionsClassic(ProverEnvironment prover) throws InterruptedException, SolverException {
+    BooleanFormula[][] symbols = getSymbols();
+    // Add full Nqueens encoding
+    List<BooleanFormula> rules =
+            ImmutableList.<BooleanFormula>builder()
+                    .addAll(rowRule1(symbols))
+                    .addAll(rowRule2(symbols))
+                    .addAll(columnRule(symbols))
+                    .addAll(diagonalRule(symbols))
+                    .build();
+    prover.addConstraint(bmgr.and(rules));
+
+    // Enumerate all solutions by iteratively adding blocking clauses
+    int numSolutions = 0;
+    while (!prover.isUnsat()) {
+      var assignments = prover.getModelAssignments();
+      BooleanFormula modelFormula = bmgr.makeTrue();
+      for (var assgn : assignments) {
+        modelFormula = bmgr.and(modelFormula, assgn.getAssignmentAsFormula());
+      }
+      prover.addConstraint(bmgr.not(modelFormula));
+      numSolutions++;
+    }
+    return numSolutions;
+  }
+
+  private int enumerateSolutionsWithPropagator(ProverEnvironment prover) throws InterruptedException, SolverException {
+    BooleanFormula[][] symbols = getSymbols();
+    // Add full Nqueens encoding
+    List<BooleanFormula> rules =
+            ImmutableList.<BooleanFormula>builder()
+                    .addAll(rowRule1(symbols))
+                    .addAll(rowRule2(symbols))
+                    .addAll(columnRule(symbols))
+                    .addAll(diagonalRule(symbols))
+                    .build();
+    prover.addConstraint(bmgr.and(rules));
+
+    // Enumerate all solutions via a custom user propagator.
+    NQueensEnumeratingPropagator enumeratingPropagator = new NQueensEnumeratingPropagator();
+    Verify.verify(prover.registerUserPropagator(enumeratingPropagator));
+    for (BooleanFormula[] symbolRow : symbols) {
+      for (BooleanFormula symbol : symbolRow) {
+        enumeratingPropagator.registerExpression(symbol);
+      }
+    }
+
+    boolean isUnsat = prover.isUnsat();
+    Verify.verify(isUnsat); // The propagator should make sure that the instance becomes unsat by eventually
+    // blocking all models.
+
+    return enumeratingPropagator.getNumOfSolutions();
+  }
+
+  private int enumerateSolutionsWithConstraintPropagator(ProverEnvironment prover) throws InterruptedException, SolverException {
+    BooleanFormula[][] symbols = getSymbols();
+    // Add partial Nqueens encoding (only enforce a queen per row)
+    // The remaining constraints are enforced by the user propagator
+    List<BooleanFormula> rules =
+            ImmutableList.<BooleanFormula>builder()
+                    .addAll(rowRule1(symbols))
+                    //.addAll(rowRule2(symbols))
+                    //.addAll(columnRule(symbols))
+                    //.addAll(diagonalRule(symbols))
+                    .build();
+    prover.addConstraint(bmgr.and(rules));
+
+    // Enumerate all solutions via a custom user propagator that enforces unique placement constraints.
+    NQueensConstraintPropagator constraintPropagator = new NQueensConstraintPropagator(symbols, bmgr);
+    Verify.verify(prover.registerUserPropagator(constraintPropagator));
+    for (BooleanFormula[] symbolRow : symbols) {
+      for (BooleanFormula symbol : symbolRow) {
+        constraintPropagator.registerExpression(symbol);
+      }
+    }
+
+    boolean isUnsat = prover.isUnsat();
+    Verify.verify(isUnsat); // The propagator should make sure that the instance becomes unsat by eventually
+    // blocking all models.
+
+    return constraintPropagator.getNumOfSolutions();
+  }
+
+}

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueens.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueens.java
@@ -321,7 +321,7 @@ public class NQueens {
     prover.addConstraint(bmgr.and(rules));
 
     // Enumerate all solutions via a custom user propagator that enforces unique placement constraints.
-    NQueensConstraintPropagator constraintPropagator = new NQueensConstraintPropagator(symbols, bmgr);
+    NQueensConstraintPropagator constraintPropagator = new NQueensConstraintPropagator(symbols);
     Verify.verify(prover.registerUserPropagator(constraintPropagator));
     for (BooleanFormula[] symbolRow : symbols) {
       for (BooleanFormula symbol : symbolRow) {

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueens.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueens.java
@@ -44,7 +44,6 @@ public class NQueens {
   private final SolverContext context;
   private final BooleanFormulaManager bmgr;
   private final int n;
-  private NQueensEnumeratingPropagator theorySolver;
 
   public NQueens(SolverContext pContext, int n) {
     context = pContext;
@@ -252,31 +251,6 @@ public class NQueens {
       }
     }
     return rules;
-  }
-
-  /**
-   * Returns a boolean value indicating whether a queen is placed on the cell corresponding to the
-   * given row and column.
-   *
-   * @param symbols a 2D BooleanFormula array representing the cells of the chess board.
-   * @param model the Model object representing the current state of the board.
-   * @param row the row index of the cell to check.
-   * @param col the column index of the cell to check.
-   * @return true if a queen is placed on the cell, false otherwise.
-   */
-  private boolean getValue(BooleanFormula[][] symbols, Model model, int row, int col) {
-    return Boolean.TRUE.equals(model.evaluate(symbols[row][col]));
-  }
-
-  private void addConstraints(ProverEnvironment prover, BooleanFormula[][] symbols) throws InterruptedException, SolverException{
-    List<BooleanFormula> rules =
-            ImmutableList.<BooleanFormula>builder()
-                    .addAll(rowRule1(symbols))
-                    .addAll(rowRule2(symbols))
-                    .addAll(columnRule(symbols))
-                    .addAll(diagonalRule(symbols))
-                    .build();
-    prover.addConstraint(bmgr.and(rules));
   }
 
   private int enumerateSolutionsClassic(ProverEnvironment prover) throws InterruptedException, SolverException {

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueens.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueens.java
@@ -357,7 +357,7 @@ public class NQueens {
     }
 
     AllSatCallback<Integer> cb =
-        new AllSatCallback<Integer>() {
+        new AllSatCallback<>() {
           int counter = 0;
 
           @Override

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
@@ -11,6 +11,7 @@ package org.sosy_lab.java_smt.example.nqueens_user_propagator;
 import io.github.cvc5.Pair;
 import java.util.HashMap;
 
+import java.util.Map;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 
@@ -20,11 +21,10 @@ import org.sosy_lab.java_smt.api.BooleanFormulaManager;
  */
 public class NQueensConstraintPropagator extends NQueensEnumeratingPropagator {
   private final BooleanFormula[][] symbols;
-  private final HashMap<BooleanFormula, Pair<Integer, Integer>> symbolToCoordinates;
+  private final Map<BooleanFormula, Pair<Integer, Integer>> symbolToCoordinates;
   private final BooleanFormulaManager bmgr;
 
   public NQueensConstraintPropagator(BooleanFormula[][] symbols, BooleanFormulaManager bmgr) {
-    super();
     this.symbols = symbols;
     this.bmgr = bmgr;
     symbolToCoordinates = new HashMap<>();
@@ -40,13 +40,12 @@ public class NQueensConstraintPropagator extends NQueensEnumeratingPropagator {
   }
 
   @Override
-  public void onKnownValue(BooleanFormula var, BooleanFormula value) {
-    if (bmgr.isTrue(value)) {
+  public void onKnownValue(BooleanFormula var, boolean value) {
+    if (value) {
       // Check if the placed queen conflicts with another queen
       Pair<Integer, Integer> coordinates = symbolToCoordinates.get(var);
       for (BooleanFormula other : fixedVariables) {
-        BooleanFormula otherValue = currentModel.get(other);
-        if (bmgr.isTrue(otherValue)) {
+        if (currentModel.get(other)) {
           Pair<Integer, Integer> otherCoordinates = symbolToCoordinates.get(other);
 
           int x1 = coordinates.first;

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
@@ -8,20 +8,28 @@
 
 package org.sosy_lab.java_smt.example.nqueens_user_propagator;
 
-import io.github.cvc5.Pair;
 import java.util.HashMap;
-
 import java.util.Map;
 import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 
 /**
- * In addition to the enumeration done by {@link NQueensEnumeratingPropagator},
- * this propagator also enforces the queen placement constraints without explicit encoding.
+ * In addition to the enumeration done by {@link NQueensEnumeratingPropagator}, this propagator also
+ * enforces the queen placement constraints without explicit encoding.
  */
 public class NQueensConstraintPropagator extends NQueensEnumeratingPropagator {
+
+  private static class Coordinates {
+    final int x;
+    final int y;
+
+    private Coordinates(int pX, int pY) {
+      x = pX;
+      y = pY;
+    }
+  }
+
   private final BooleanFormula[][] symbols;
-  private final Map<BooleanFormula, Pair<Integer, Integer>> symbolToCoordinates;
+  private final Map<BooleanFormula, Coordinates> symbolToCoordinates;
 
   public NQueensConstraintPropagator(BooleanFormula[][] symbols) {
     this.symbols = symbols;
@@ -32,7 +40,7 @@ public class NQueensConstraintPropagator extends NQueensEnumeratingPropagator {
   private void fillCoordinateMap() {
     for (int i = 0; i < symbols[0].length; i++) {
       for (int j = 0; j < symbols[i].length; j++) {
-        symbolToCoordinates.put(symbols[i][j], new Pair<>(i, j));
+        symbolToCoordinates.put(symbols[i][j], new Coordinates(i, j));
       }
     }
   }
@@ -41,19 +49,19 @@ public class NQueensConstraintPropagator extends NQueensEnumeratingPropagator {
   public void onKnownValue(BooleanFormula var, boolean value) {
     if (value) {
       // Check if the placed queen conflicts with another queen
-      Pair<Integer, Integer> coordinates = symbolToCoordinates.get(var);
+      Coordinates coordinates = symbolToCoordinates.get(var);
       for (BooleanFormula other : fixedVariables) {
         if (currentModel.get(other)) {
-          Pair<Integer, Integer> otherCoordinates = symbolToCoordinates.get(other);
+          Coordinates otherCoordinates = symbolToCoordinates.get(other);
 
-          int x1 = coordinates.first;
-          int y1 = coordinates.second;
-          int x2 = otherCoordinates.first;
-          int y2 = otherCoordinates.second;
+          int x1 = coordinates.x;
+          int y1 = coordinates.y;
+          int x2 = otherCoordinates.x;
+          int y2 = otherCoordinates.y;
           if (x1 == x2 || y1 == y2 || Math.abs(x1 - x2) == Math.abs(y1 - y2)) {
             // We have two queens on the same row, same column, or same diagonal.
             // This is not allowed, so we raise a conflict.
-            backend.propagateConflict(new BooleanFormula[] { var, other });
+            backend.propagateConflict(new BooleanFormula[] {var, other});
           }
         }
       }
@@ -61,5 +69,4 @@ public class NQueensConstraintPropagator extends NQueensEnumeratingPropagator {
 
     super.onKnownValue(var, value);
   }
-
 }

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
@@ -61,7 +61,7 @@ public class NQueensConstraintPropagator extends NQueensEnumeratingPropagator {
           if (x1 == x2 || y1 == y2 || Math.abs(x1 - x2) == Math.abs(y1 - y2)) {
             // We have two queens on the same row, same column, or same diagonal.
             // This is not allowed, so we raise a conflict.
-            backend.propagateConflict(new BooleanFormula[] {var, other});
+            getBackend().propagateConflict(new BooleanFormula[] {var, other});
           }
         }
       }

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
@@ -1,0 +1,80 @@
+/*
+ *  JavaSMT is an API wrapper for a collection of SMT solvers.
+ *  This file is part of JavaSMT.
+ *
+ *  Copyright (C) 2007-2016  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.sosy_lab.java_smt.example.nqueens_user_propagator;
+
+import io.github.cvc5.Pair;
+import java.util.HashMap;
+
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+
+/**
+ * In addition to the enumeration done by {@link NQueensEnumeratingPropagator},
+ * this propagator also enforces the queen placement constraints without explicit encoding.
+ */
+public class NQueensConstraintPropagator extends NQueensEnumeratingPropagator {
+  private final BooleanFormula[][] symbols;
+  private final HashMap<BooleanFormula, Pair<Integer, Integer>> symbolToCoordinates;
+  private final BooleanFormulaManager bmgr;
+
+  public NQueensConstraintPropagator(BooleanFormula[][] symbols, BooleanFormulaManager bmgr) {
+    super();
+    this.symbols = symbols;
+    this.bmgr = bmgr;
+    symbolToCoordinates = new HashMap<>();
+    fillCoordinateMap();
+  }
+
+  private void fillCoordinateMap() {
+    for (int i = 0; i < symbols[0].length; i++) {
+      for (int j = 0; j < symbols[i].length; j++) {
+        symbolToCoordinates.put(symbols[i][j], new Pair<>(i, j));
+      }
+    }
+  }
+
+  @Override
+  public void onKnownValue(BooleanFormula var, BooleanFormula value) {
+    if (bmgr.isTrue(value)) {
+      // Check if the placed queen conflicts with another queen
+      Pair<Integer, Integer> coordinates = symbolToCoordinates.get(var);
+      for (BooleanFormula other : fixedVariables) {
+        BooleanFormula otherValue = currentModel.get(other);
+        if (bmgr.isTrue(otherValue)) {
+          Pair<Integer, Integer> otherCoordinates = symbolToCoordinates.get(other);
+
+          int x1 = coordinates.first;
+          int y1 = coordinates.second;
+          int x2 = otherCoordinates.first;
+          int y2 = otherCoordinates.second;
+          if (x1 == x2 || y1 == y2 || Math.abs(x1 - x2) == Math.abs(y1 - y2)) {
+            // We have two queens on the same row, same column, or same diagonal.
+            // This is not allowed, so we raise a conflict.
+            backend.propagateConflict(new BooleanFormula[] { var, other });
+          }
+        }
+      }
+    }
+
+    super.onKnownValue(var, value);
+  }
+
+}

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
@@ -1,22 +1,10 @@
-/*
- *  JavaSMT is an API wrapper for a collection of SMT solvers.
- *  This file is part of JavaSMT.
- *
- *  Copyright (C) 2007-2016  Dirk Beyer
- *  All rights reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package org.sosy_lab.java_smt.example.nqueens_user_propagator;
 

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensConstraintPropagator.java
@@ -22,11 +22,9 @@ import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 public class NQueensConstraintPropagator extends NQueensEnumeratingPropagator {
   private final BooleanFormula[][] symbols;
   private final Map<BooleanFormula, Pair<Integer, Integer>> symbolToCoordinates;
-  private final BooleanFormulaManager bmgr;
 
-  public NQueensConstraintPropagator(BooleanFormula[][] symbols, BooleanFormulaManager bmgr) {
+  public NQueensConstraintPropagator(BooleanFormula[][] symbols) {
     this.symbols = symbols;
-    this.bmgr = bmgr;
     symbolToCoordinates = new HashMap<>();
     fillCoordinateMap();
   }

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
@@ -1,0 +1,81 @@
+/*
+ *  JavaSMT is an API wrapper for a collection of SMT solvers.
+ *  This file is part of JavaSMT.
+ *
+ *  Copyright (C) 2007-2016  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.sosy_lab.java_smt.example.nqueens_user_propagator;
+
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.basicimpl.AbstractUserPropagator;
+
+import java.util.*;
+
+/**
+ * This propagator enumerates the solutions of the Nqueens problem
+ * by raising a conflict whenever the solver finds a model.
+ */
+public class NQueensEnumeratingPropagator extends AbstractUserPropagator {
+  // For backtracking
+  protected final Deque<Integer> fixedCount = new ArrayDeque<>();
+  protected final Deque<BooleanFormula> fixedVariables = new ArrayDeque<>();
+
+  protected final HashMap<BooleanFormula, BooleanFormula> currentModel = new HashMap<>();
+
+  // Set of found solutions
+  protected final Set<HashMap<BooleanFormula, BooleanFormula>> modelSet = new HashSet<>();
+
+  public int getNumOfSolutions() { return modelSet.size(); }
+
+  @Override
+  public void onPush() {
+    fixedCount.push(fixedVariables.size());
+  }
+
+  @Override
+  public void onPop(int numPoppedLevel) {
+    for (int i = 0; i < numPoppedLevel; i++) {
+      int lastCount = fixedCount.pop();
+      while (fixedVariables.size() > lastCount) {
+        currentModel.remove(fixedVariables.pop());
+      }
+    }
+  }
+
+  @Override
+  public void onFinalCheck() {
+    modelSet.add(currentModel);
+    // We found a model. Note that the solver is allowed to revise a previously found model,
+    // so we rely on the uniqueness provided by the <modelSet> to avoid duplicate counting.
+
+    // Raise conflict on the whole model to force the solver to find another one.
+    // NOTE: It should be sufficient to raise a conflict on only the positive variables.
+    backend.propagateConflict(fixedVariables.toArray(new BooleanFormula[0]));
+  }
+
+  @Override
+  public void onKnownValue(BooleanFormula var, BooleanFormula val) {
+    fixedVariables.push(var);
+    currentModel.put(var, val);
+  }
+
+  @Override
+  public void initialize() {
+    backend.notifyOnFinalCheck();
+    backend.notifyOnKnownValue();
+  }
+}

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
@@ -63,7 +63,7 @@ public class NQueensEnumeratingPropagator extends AbstractUserPropagator {
 
     // Raise conflict on the whole model to force the solver to find another one.
     // NOTE: It should be sufficient to raise a conflict on only the positive variables.
-    backend.propagateConflict(fixedVariables.toArray(new BooleanFormula[0]));
+    getBackend().propagateConflict(fixedVariables.toArray(new BooleanFormula[0]));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
@@ -56,9 +56,9 @@ public class NQueensEnumeratingPropagator extends AbstractUserPropagator {
   }
 
   @Override
-  public void onKnownValue(BooleanFormula var, BooleanFormula val) {
+  public void onKnownValue(BooleanFormula var, BooleanFormula value) {
     fixedVariables.push(var);
-    currentModel.put(var, val);
+    currentModel.put(var, value);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
@@ -8,30 +8,35 @@
 
 package org.sosy_lab.java_smt.example.nqueens_user_propagator;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.PropagatorBackend;
 import org.sosy_lab.java_smt.basicimpl.AbstractUserPropagator;
 
-import java.util.*;
-
 /**
- * This propagator enumerates the solutions of the Nqueens problem
- * by raising a conflict whenever the solver finds a model.
+ * This propagator enumerates the solutions of the NQueens problem by raising a conflict whenever
+ * the solver finds a model.
  */
 public class NQueensEnumeratingPropagator extends AbstractUserPropagator {
   // For backtracking
   protected final Deque<Integer> fixedCount = new ArrayDeque<>();
   protected final Deque<BooleanFormula> fixedVariables = new ArrayDeque<>();
-
   protected final Map<BooleanFormula, Boolean> currentModel = new HashMap<>();
 
   // Set of found solutions
-  // Implementation note: The hashcodes of the different Nqueens models tend to overlap (due to
+  // Implementation note: The hashcodes of the different NQueens models tend to overlap (due to
   // patterns in the models) which degrades the <modelSet>'s performance.
   // So instead, we transform the model before storing it.
   protected final Set<Map<BooleanFormula, Integer>> modelSet = new HashSet<>();
 
-  public int getNumOfSolutions() { return modelSet.size(); }
+  public int getNumOfSolutions() {
+    return modelSet.size();
+  }
 
   @Override
   public void onPush() {
@@ -73,5 +78,4 @@ public class NQueensEnumeratingPropagator extends AbstractUserPropagator {
     backend.notifyOnFinalCheck();
     backend.notifyOnKnownValue();
   }
-
 }

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
@@ -9,6 +9,7 @@
 package org.sosy_lab.java_smt.example.nqueens_user_propagator;
 
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.PropagatorBackend;
 import org.sosy_lab.java_smt.basicimpl.AbstractUserPropagator;
 
 import java.util.*;
@@ -67,8 +68,10 @@ public class NQueensEnumeratingPropagator extends AbstractUserPropagator {
   }
 
   @Override
-  public void initialize() {
+  public void initializeWithBackend(PropagatorBackend backend) {
+    super.initializeWithBackend(backend);
     backend.notifyOnFinalCheck();
     backend.notifyOnKnownValue();
   }
+
 }

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
@@ -22,10 +22,10 @@ public class NQueensEnumeratingPropagator extends AbstractUserPropagator {
   protected final Deque<Integer> fixedCount = new ArrayDeque<>();
   protected final Deque<BooleanFormula> fixedVariables = new ArrayDeque<>();
 
-  protected final HashMap<BooleanFormula, BooleanFormula> currentModel = new HashMap<>();
+  protected final Map<BooleanFormula, Boolean> currentModel = new HashMap<>();
 
   // Set of found solutions
-  protected final Set<HashMap<BooleanFormula, BooleanFormula>> modelSet = new HashSet<>();
+  protected final Set<Map<BooleanFormula, Boolean>> modelSet = new HashSet<>();
 
   public int getNumOfSolutions() { return modelSet.size(); }
 
@@ -46,7 +46,7 @@ public class NQueensEnumeratingPropagator extends AbstractUserPropagator {
 
   @Override
   public void onFinalCheck() {
-    modelSet.add(currentModel);
+    modelSet.add(Map.copyOf(currentModel));
     // We found a model. Note that the solver is allowed to revise a previously found model,
     // so we rely on the uniqueness provided by the <modelSet> to avoid duplicate counting.
 
@@ -56,7 +56,7 @@ public class NQueensEnumeratingPropagator extends AbstractUserPropagator {
   }
 
   @Override
-  public void onKnownValue(BooleanFormula var, BooleanFormula value) {
+  public void onKnownValue(BooleanFormula var, boolean value) {
     fixedVariables.push(var);
     currentModel.put(var, value);
   }

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/NQueensEnumeratingPropagator.java
@@ -1,22 +1,10 @@
-/*
- *  JavaSMT is an API wrapper for a collection of SMT solvers.
- *  This file is part of JavaSMT.
- *
- *  Copyright (C) 2007-2016  Dirk Beyer
- *  All rights reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package org.sosy_lab.java_smt.example.nqueens_user_propagator;
 

--- a/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/package-info.java
+++ b/src/org/sosy_lab/java_smt/example/nqueens_user_propagator/package-info.java
@@ -1,0 +1,10 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2020 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Unlicense OR Apache-2.0 OR MIT
+
+/** Some basic examples for using Java-SMT. */
+package org.sosy_lab.java_smt.example.nqueens_user_propagator;

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
@@ -15,14 +15,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.primitives.UnsignedInteger;
-import com.google.common.primitives.UnsignedLong;
+import com.google.common.primitives.Ints;
 import edu.stanford.CVC4.ArrayType;
 import edu.stanford.CVC4.BitVectorType;
 import edu.stanford.CVC4.Expr;
 import edu.stanford.CVC4.ExprManager;
-import edu.stanford.CVC4.FloatingPoint;
-import edu.stanford.CVC4.FloatingPointSize;
 import edu.stanford.CVC4.FunctionType;
 import edu.stanford.CVC4.Integer;
 import edu.stanford.CVC4.Kind;
@@ -35,12 +32,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.ArrayFormulaType;
@@ -591,7 +588,7 @@ public class CVC4FormulaCreator extends FormulaCreator<Expr, Type, ExprManager, 
       }
 
     } else if (valueType.isFloatingPoint()) {
-      return parseFloatingPoint(value);
+      return convertFloatingPoint(value);
 
     } else if (valueType.isString()) {
       return value.getConstString().toString();
@@ -602,29 +599,26 @@ public class CVC4FormulaCreator extends FormulaCreator<Expr, Type, ExprManager, 
     }
   }
 
-  private Object parseFloatingPoint(Expr fpExpr) {
-    Matcher matcher = FLOATING_POINT_PATTERN.matcher(fpExpr.toString());
+  private FloatingPointNumber convertFloatingPoint(Expr fpExpr) {
+    final var matcher = FLOATING_POINT_PATTERN.matcher(fpExpr.toString());
     if (!matcher.matches()) {
       throw new NumberFormatException("Unknown floating-point format: " + fpExpr);
     }
 
-    FloatingPoint fp = fpExpr.getConstFloatingPoint();
-    FloatingPointSize fpType = fp.getT();
-    long expWidth = fpType.exponentWidth();
-    long mantWidth = fpType.significandWidth() - 1; // without sign bit
+    final var fp = fpExpr.getConstFloatingPoint();
+    final var fpType = fp.getT();
+    final var expWidth = Ints.checkedCast(fpType.exponentWidth());
+    final var mantWidth = Ints.checkedCast(fpType.significandWidth() - 1); // without sign bit
 
-    assert matcher.group("sign").length() == 1;
-    assert matcher.group("exp").length() == expWidth;
-    assert matcher.group("mant").length() == mantWidth;
+    final var sign = matcher.group("sign");
+    final var exp = matcher.group("exp");
+    final var mant = matcher.group("mant");
 
-    String str = matcher.group("sign") + matcher.group("exp") + matcher.group("mant");
-    if (expWidth == 11 && mantWidth == 52) {
-      return Double.longBitsToDouble(UnsignedLong.valueOf(str, 2).longValue());
-    } else if (expWidth == 8 && mantWidth == 23) {
-      return Float.intBitsToFloat(UnsignedInteger.valueOf(str, 2).intValue());
-    }
+    Preconditions.checkArgument(sign.length() == 1 && "01".contains(sign));
+    Preconditions.checkArgument(exp.length() == expWidth);
+    Preconditions.checkArgument(mant.length() == mantWidth);
 
-    // TODO to be fully correct, we would need to interpret this string
-    return fpExpr.toString();
+    return FloatingPointNumber.of(
+        sign.equals("1"), new BigInteger(exp, 2), new BigInteger(mant, 2), expWidth, mantWidth);
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Table;
+import com.google.common.primitives.Ints;
 import io.github.cvc5.CVC5ApiException;
 import io.github.cvc5.Datatype;
 import io.github.cvc5.DatatypeConstructor;
@@ -29,9 +30,7 @@ import io.github.cvc5.Pair;
 import io.github.cvc5.Solver;
 import io.github.cvc5.Sort;
 import io.github.cvc5.Term;
-import io.github.cvc5.Triplet;
 import java.lang.reflect.Array;
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,6 +43,7 @@ import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.ArrayFormulaType;
@@ -801,38 +801,9 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, Solver, Term>
         String bitvectorValue = value.getBitVectorValue();
         return new BigInteger(bitvectorValue, 2);
 
-      } else if (value.isFloatingPointNaN()) {
-        return Float.NaN;
-
-      } else if (value.isFloatingPointNegInf()) {
-        return Float.NEGATIVE_INFINITY;
-
-      } else if (value.isFloatingPointPosInf()) {
-        return Float.POSITIVE_INFINITY;
-
-      } else if (value.isFloatingPointPosZero()) {
-        return BigDecimal.ZERO;
-
       } else if (value.isFloatingPointValue()) {
-        // Negative zero falls under this category
-        // String valueString =
-        // solver.getValue(solver.mkTerm(Kind.FLOATINGPOINT_TO_REAL, fpTerm)).toString();
-        // return new BigDecimal(valueString).stripTrailingZeros();
-        final Triplet<Long, Long, Term> fpValue = value.getFloatingPointValue();
-        final long expWidth = fpValue.first;
-        final long mantWidth = fpValue.second - 1; // CVC5 also counts the sign-bit in the mantissa
-        final Term bvValue = fpValue.third;
-        Preconditions.checkState(bvValue.isBitVectorValue());
-        BigInteger bits = new BigInteger(bvValue.getBitVectorValue(), 2);
+        return convertFloatingPoint(value);
 
-        if (expWidth == 11 && mantWidth == 52) { // standard IEEE double type with 64 bits
-          return Double.longBitsToDouble(bits.longValue());
-        } else if (expWidth == 8 && mantWidth == 23) { // standard IEEE float type with 32 bits
-          return Float.intBitsToFloat(bits.intValue());
-        } else {
-          // TODO to be fully correct, we would need to interpret the BV as FP or Rational
-          return value.toString(); // returns a BV representation of the FP
-        }
       } else if (value.isBooleanValue()) {
         return value.getBooleanValue();
 
@@ -850,6 +821,16 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, Solver, Term>
               value, valueType, type),
           e);
     }
+  }
+
+  private FloatingPointNumber convertFloatingPoint(Term value) throws CVC5ApiException {
+    final var fpValue = value.getFloatingPointValue();
+    final var expWidth = Ints.checkedCast(fpValue.first);
+    final var mantWidth = Ints.checkedCast(fpValue.second - 1); // without sign bit
+    final var bvValue = fpValue.third;
+    Preconditions.checkState(bvValue.isBitVectorValue());
+    final var bits = bvValue.getBitVectorValue();
+    return FloatingPointNumber.of(bits, expWidth, mantWidth);
   }
 
   private Term accessVariablesCache(String name, Sort sort) {

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2Model.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2Model.java
@@ -68,7 +68,7 @@ public class Yices2Model extends AbstractModel<Integer, Integer, Long> {
   protected Yices2Model(long model, Yices2TheoremProver prover, Yices2FormulaCreator pCreator) {
     super(prover, pCreator);
     this.model = model;
-    this.prover = prover; // can be NULL for testing
+    this.prover = prover;
     this.formulaCreator = Preconditions.checkNotNull(pCreator);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2NativeApiTest.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2NativeApiTest.java
@@ -2,7 +2,7 @@
 // an API wrapper for a collection of SMT solvers:
 // https://github.com/sosy-lab/java-smt
 //
-// SPDX-FileCopyrightText: 2020 Dirk Beyer <https://www.sosy-lab.org>
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
 //
 // SPDX-License-Identifier: Apache-2.0 OR GPL-3.0-or-later
 
@@ -17,15 +17,12 @@ import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.YICES_BV_SUM;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.YICES_EQ_TERM;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.YICES_NOT_TERM;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.YICES_OR_TERM;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.YICES_STATUS_SAT;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.YVAL_RATIONAL;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_add;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_and;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_and2;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_application;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_arith_eq_atom;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_arith_gt_atom;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_arith_lt_atom;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_assert_formula;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bool_const_value;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bool_type;
@@ -43,23 +40,19 @@ import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvsum_c
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvxor2;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_check_context;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_context_disable_option;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_def_terms;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_eq;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_exit;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_false;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_free_config;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_free_context;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_function_type;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_get_model;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_get_term_name;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_get_value;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_idiv;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_iff;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_init;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_int32;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_int64;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_int_type;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_model_to_string;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_mul;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_named_variable;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_new_config;
@@ -73,9 +66,7 @@ import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_parse_r
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_parse_term;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_product_component;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_proj_arg;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_push;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_rational32;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_real_type;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_redand;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_set_config;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_set_term_name;
@@ -90,7 +81,6 @@ import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_term_is
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_term_num_children;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_term_to_string;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_true;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_val_get_mpq;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_zero_extend;
 
 import com.google.common.base.Joiner;
@@ -108,7 +98,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.sosy_lab.common.NativeLibraries;
 import org.sosy_lab.common.rationals.Rational;
-import org.sosy_lab.java_smt.api.Model;
 
 @SuppressWarnings("unused")
 public class Yices2NativeApiTest {
@@ -449,74 +438,6 @@ public class Yices2NativeApiTest {
     int[] argArray = new int[] {yices_int32(123), yices_int32(456)};
     int app = yices_application(uf, argArray.length, argArray);
     assertThat(yices_term_constructor(app)).isEqualTo(YICES_APP_TERM);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  public void modelTest() {
-    int varx = yices_named_variable(yices_real_type(), "x");
-    int eq = yices_arith_eq_atom(varx, yices_int32(10));
-    int query = yices_named_variable(yices_real_type(), "x");
-    Yices2FormulaCreator creator = new Yices2FormulaCreator();
-    yices_push(env);
-    yices_assert_formula(env, eq);
-    System.out.println("varx: " + varx);
-    System.out.println("query: " + query);
-    if (yices_check_context(env, 0) == YICES_STATUS_SAT) {
-      Model m = new Yices2Model(yices_get_model(env, 1), null, creator);
-      Object val = m.evaluate(creator.encapsulateWithTypeOf(varx));
-      System.out.println(val);
-      m.close();
-    }
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  public void modelExplorationTest() {
-    int x = yices_int32(5);
-    int y = yices_int32(7);
-    int z = yices_named_variable(yices_int_type(), "z");
-    int gt = yices_arith_gt_atom(z, x);
-    int lt = yices_arith_lt_atom(z, y);
-    int x2 = yices_int32(333);
-    int y2 = yices_int32(335);
-    int z2 = yices_named_variable(yices_int_type(), "z2");
-    int gt2 = yices_arith_gt_atom(z2, x2);
-    int lt2 = yices_arith_lt_atom(z2, y2);
-    int sub = yices_sub(z2, z);
-    int eq = yices_arith_eq_atom(sub, yices_int32(328));
-    Yices2FormulaCreator creator = new Yices2FormulaCreator();
-    yices_push(env);
-    yices_assert_formula(env, gt);
-    yices_assert_formula(env, lt);
-    yices_assert_formula(env, gt2);
-    yices_assert_formula(env, lt2);
-    yices_assert_formula(env, eq);
-    if (yices_check_context(env, 0) == YICES_STATUS_SAT) {
-      long model = yices_get_model(env, 1);
-      Model m = new Yices2Model(model, null, creator);
-      System.out.println(yices_model_to_string(model));
-      Object val = m.evaluate(creator.encapsulateWithTypeOf(eq));
-      System.out.println(val);
-      int addT = yices_add(z, z2);
-      Object val2 = m.evaluate(creator.encapsulateWithTypeOf(addT));
-      System.out.println(val2);
-      System.out.println("DEFINED TERMS");
-      int[] terms = yices_def_terms(model);
-      for (int term : terms) {
-        System.out.println(yices_term_to_string(term));
-        System.out.println("Term id is: " + term);
-        int[] yval = yices_get_value(model, term);
-        System.out.println("Node id is: " + yval[0]);
-        System.out.println("Node tag is: " + yval[1]);
-        if (yval[1] == YVAL_RATIONAL) {
-          System.out.println("Value is: " + yices_val_get_mpq(model, yval[0], yval[1]));
-        }
-      }
-      m.close();
-    } else {
-      throw new IllegalArgumentException("The environment is not solvable!");
-    }
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -41,7 +41,7 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
 
   protected final Z3FormulaCreator creator;
   protected final long z3context;
-  private final Z3FormulaManager mgr;
+  protected final Z3FormulaManager mgr;
 
   private final UniqueIdGenerator trackId = new UniqueIdGenerator();
   @Nullable private final Deque<PersistentMap<String, BooleanFormula>> storedConstraints;

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3BooleanFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3BooleanFormulaManager.java
@@ -152,12 +152,12 @@ class Z3BooleanFormulaManager extends AbstractBooleanFormulaManager<Long, Long, 
 
   @Override
   protected boolean isTrue(Long pParam) {
-    return isOP(z3context, pParam, Z3_decl_kind.Z3_OP_TRUE);
+    return z3true.equals(pParam);
   }
 
   @Override
   protected boolean isFalse(Long pParam) {
-    return isOP(z3context, pParam, Z3_decl_kind.Z3_OP_FALSE);
+    return z3false.equals(pParam);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
@@ -10,6 +10,7 @@ package org.sosy_lab.java_smt.solvers.z3;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -44,10 +45,12 @@ import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.EnumerationFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingMode;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.ArrayFormulaType;
+import org.sosy_lab.java_smt.api.FormulaType.FloatingPointType;
 import org.sosy_lab.java_smt.api.FunctionDeclarationKind;
 import org.sosy_lab.java_smt.api.QuantifiedFormulaManager.Quantifier;
 import org.sosy_lab.java_smt.api.RegexFormula;
@@ -74,11 +77,6 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
       ImmutableMap.<Integer, Object>builder()
           .put(Z3_decl_kind.Z3_OP_TRUE.toInt(), true)
           .put(Z3_decl_kind.Z3_OP_FALSE.toInt(), false)
-          .put(Z3_decl_kind.Z3_OP_FPA_PLUS_ZERO.toInt(), +0.0)
-          .put(Z3_decl_kind.Z3_OP_FPA_MINUS_ZERO.toInt(), -0.0)
-          .put(Z3_decl_kind.Z3_OP_FPA_PLUS_INF.toInt(), Double.POSITIVE_INFINITY)
-          .put(Z3_decl_kind.Z3_OP_FPA_MINUS_INF.toInt(), Double.NEGATIVE_INFINITY)
-          .put(Z3_decl_kind.Z3_OP_FPA_NAN.toInt(), Double.NaN)
           .put(
               Z3_decl_kind.Z3_OP_FPA_RM_NEAREST_TIES_TO_EVEN.toInt(),
               FloatingPointRoundingMode.NEAREST_TIES_TO_EVEN)
@@ -93,6 +91,14 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
               FloatingPointRoundingMode.TOWARD_NEGATIVE)
           .put(Z3_decl_kind.Z3_OP_FPA_RM_TOWARD_ZERO.toInt(), FloatingPointRoundingMode.TOWARD_ZERO)
           .buildOrThrow();
+
+  private static final ImmutableSet<Integer> Z3_FP_CONSTANTS =
+      ImmutableSet.of(
+          Z3_decl_kind.Z3_OP_FPA_PLUS_ZERO.toInt(),
+          Z3_decl_kind.Z3_OP_FPA_MINUS_ZERO.toInt(),
+          Z3_decl_kind.Z3_OP_FPA_PLUS_INF.toInt(),
+          Z3_decl_kind.Z3_OP_FPA_MINUS_INF.toInt(),
+          Z3_decl_kind.Z3_OP_FPA_NAN.toInt());
 
   // Set of error messages that might occur if Z3 is interrupted.
   private static final ImmutableSet<String> Z3_INTERRUPT_ERRORS =
@@ -422,6 +428,9 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
           Object value = Z3_CONSTANTS.get(declKind);
           if (value != null) {
             return visitor.visitConstant(formula, value);
+
+          } else if (Z3_FP_CONSTANTS.contains(declKind)) {
+            return visitor.visitConstant(formula, convertValue(f));
 
             // Rounding mode
           } else if (declKind == Z3_decl_kind.Z3_OP_FPA_NUM.toInt()
@@ -810,8 +819,7 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
       } else if (type.isBitvectorType()) {
         return new BigInteger(Native.getNumeralString(environment, value));
       } else if (type.isFloatingPointType()) {
-        // Converting to Rational first.
-        return convertValue(Native.simplify(environment, Native.mkFpaToReal(environment, value)));
+        return convertFloatingPoint((FloatingPointType) type, value);
       } else if (type.isEnumerationType()) {
         return Native.astToString(environment, value);
       } else {
@@ -823,6 +831,51 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
     } finally {
       Native.decRef(environment, value);
     }
+  }
+
+  private FloatingPointNumber convertFloatingPoint(FloatingPointType pType, Long pValue) {
+    if (Native.fpaIsNumeralInf(environment, pValue)) {
+      // Floating Point Inf uses:
+      //  - an sign for posiive/negative infinity,
+      //  - "11..11" as exponent,
+      //  - "00..00" as mantissa.
+      String sign = getSign(pValue) ? "1" : "0";
+      return FloatingPointNumber.of(
+          sign + "1".repeat(pType.getExponentSize()) + "0".repeat(pType.getMantissaSize()),
+          pType.getExponentSize(),
+          pType.getMantissaSize());
+    } else if (Native.fpaIsNumeralNan(environment, pValue)) {
+      // TODO We are underspecified here and choose several bits on our own.
+      //  This is not sound, if we combine FP anf BV theory.
+      // Floating Point NaN uses:
+      //  - an unspecified sign (we choose "0"),
+      //  - "11..11" as exponent,
+      //  - an unspecified mantissa (we choose all "1").
+      return FloatingPointNumber.of(
+          "0" + "1".repeat(pType.getExponentSize()) + "1".repeat(pType.getMantissaSize()),
+          pType.getExponentSize(),
+          pType.getMantissaSize());
+    } else {
+      boolean sign = getSign(pValue);
+      var exponentBv = Native.fpaGetNumeralExponentBv(environment, pValue, true);
+      var exponent = Native.getNumeralString(environment, exponentBv);
+      var mantissaBv = Native.fpaGetNumeralSignificandBv(environment, pValue);
+      var mantissa = Native.getNumeralString(environment, mantissaBv);
+      return FloatingPointNumber.of(
+          sign,
+          new BigInteger(exponent),
+          new BigInteger(mantissa),
+          pType.getExponentSize(),
+          pType.getMantissaSize());
+    }
+  }
+
+  private boolean getSign(Long pValue) {
+    Native.IntPtr signPtr = new Native.IntPtr();
+    Preconditions.checkState(
+        Native.fpaGetNumeralSign(environment, pValue, signPtr), "Sign is not a Boolean value");
+    var sign = signPtr.value != 0;
+    return sign;
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
@@ -23,11 +23,14 @@ import org.sosy_lab.common.io.PathCounterTemplate;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
+import org.sosy_lab.java_smt.api.UserPropagator;
 
 class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
 
   private final long z3solver;
   private final ShutdownRequestListener interruptListener;
+
+  private @Nullable Z3UserPropagator propagator = null;
 
   Z3TheoremProver(
       Z3FormulaCreator creator,
@@ -155,6 +158,18 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
   }
 
   @Override
+  public boolean registerUserPropagator(UserPropagator prop) {
+    Preconditions.checkState(!closed);
+    if (propagator != null) {
+      propagator.close();
+    }
+    propagator = new Z3UserPropagator(z3context, z3solver, creator, mgr, prop);
+    prop.injectBackend(propagator);
+    prop.initialize();
+    return true;
+  }
+
+  @Override
   public String toString() {
     Preconditions.checkState(!closed);
     return Native.solverToString(z3context, z3solver);
@@ -169,8 +184,12 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
 
       Native.solverReset(z3context, z3solver); // remove all assertions from the solver
       Native.solverDecRef(z3context, z3solver);
+      if (propagator != null) {
+        propagator.close();
+      }
       shutdownNotifier.unregister(interruptListener);
     }
     super.close();
   }
+
 }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
@@ -164,8 +164,7 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
       propagator.close();
     }
     propagator = new Z3UserPropagator(z3context, z3solver, creator, mgr, prop);
-    prop.injectBackend(propagator);
-    prop.initialize();
+    prop.initializeWithBackend(propagator);
     return true;
   }
 
@@ -186,6 +185,7 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
       Native.solverDecRef(z3context, z3solver);
       if (propagator != null) {
         propagator.close();
+        propagator = null;
       }
       shutdownNotifier.unregister(interruptListener);
     }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
@@ -191,5 +191,4 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
     }
     super.close();
   }
-
 }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
@@ -88,10 +88,10 @@ final class Z3UserPropagator extends UserPropagatorBase implements PropagatorBac
   protected void createdWrapper(long le) {}
 
   @Override
-  protected void decideWrapper(long lvar, int bit, boolean is_pos) {
+  protected void decideWrapper(long lvar, int bit, boolean isPositive) {
     // We currently only allow tracking of decision on boolean formulas,
     // so we ignore the <bit> parameter
-    userPropagator.onDecision(encapsulate(lvar), is_pos);
+    userPropagator.onDecision(encapsulate(lvar), isPositive);
   }
 
   // ===========================================================================

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
@@ -170,7 +170,11 @@ final class Z3UserPropagator extends UserPropagatorBase implements PropagatorBac
   }
 
   private BooleanFormula encapsulate(long z3Expr) {
-    return canonicalizer.computeIfAbsent(z3Expr, creator::encapsulateBoolean);
+    // We fill the lowest 3 bits that are always 0 due pointer alignment.
+    // This reduces collision in the map.
+    assert (z3Expr & 7) == 0; // Make sure the lowest 3 bits are free
+    return canonicalizer.computeIfAbsent(z3Expr >> 3,
+        key -> creator.encapsulateBoolean(key << 3));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
@@ -170,11 +170,11 @@ final class Z3UserPropagator extends UserPropagatorBase implements PropagatorBac
   }
 
   private BooleanFormula encapsulate(long z3Expr) {
-    // We fill the lowest 3 bits that are always 0 due pointer alignment.
-    // This reduces collision in the map.
-    assert (z3Expr & 7) == 0; // Make sure the lowest 3 bits are free
-    return canonicalizer.computeIfAbsent(z3Expr >> 3,
-        key -> creator.encapsulateBoolean(key << 3));
+    // Due to pointer alignment, the lowest 2-3 bits are always 0 which can lead to
+    // more collisions in the hashmap. To counteract, we fill the lowest bits by rotating the
+    // value.
+    return canonicalizer.computeIfAbsent(Long.rotateRight(z3Expr, 3),
+        key -> creator.encapsulateBoolean(Long.rotateLeft(key, 3)));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
@@ -22,6 +22,8 @@ final class Z3UserPropagator extends UserPropagatorBase implements PropagatorBac
   private final Z3FormulaCreator creator;
   private final Z3FormulaManager manager;
   private final UserPropagator userPropagator;
+  private final long z3True;
+  private final long z3False;
 
   // We use this map to reuse existing formula wrappers and avoid creating
   // unnecessary phantom references (if enabled).
@@ -36,6 +38,8 @@ final class Z3UserPropagator extends UserPropagatorBase implements PropagatorBac
     this.creator = creator;
     this.userPropagator = userPropagator;
     this.manager = manager;
+    z3True = creator.extractInfo(manager.getBooleanFormulaManager().makeTrue());
+    z3False = creator.extractInfo(manager.getBooleanFormulaManager().makeFalse());
   }
 
   // ===========================================================================
@@ -65,7 +69,8 @@ final class Z3UserPropagator extends UserPropagatorBase implements PropagatorBac
 
   @Override
   protected void fixedWrapper(long lvar, long lvalue) {
-    userPropagator.onKnownValue(encapsulate(lvar), encapsulate(lvalue));
+    assert lvalue == z3True || lvalue == z3False;
+    userPropagator.onKnownValue(encapsulate(lvar), lvalue == z3True);
   }
 
   // TODO: This method is called if Z3 re-instantiates a user propagator for a subproblem

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
@@ -1,22 +1,10 @@
-/*
- *  JavaSMT is an API wrapper for a collection of SMT solvers.
- *  This file is part of JavaSMT.
- *
- *  Copyright (C) 2007-2016  Dirk Beyer
- *  All rights reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package org.sosy_lab.java_smt.solvers.z3;
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
@@ -90,7 +90,7 @@ final class Z3UserPropagator extends UserPropagatorBase implements PropagatorBac
 
   @Override
   protected void decideWrapper(long lvar, int bit, boolean is_pos) {
-    // We currently only allow tracking of decision on boolean formulas
+    // We currently only allow tracking of decision on boolean formulas,
     // so we ignore the <bit> parameter
     userPropagator.onDecision(encapsulate(lvar), is_pos);
   }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3UserPropagator.java
@@ -1,0 +1,135 @@
+/*
+ *  JavaSMT is an API wrapper for a collection of SMT solvers.
+ *  This file is part of JavaSMT.
+ *
+ *  Copyright (C) 2007-2016  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.sosy_lab.java_smt.solvers.z3;
+
+
+import com.google.common.base.Preconditions;
+import com.microsoft.z3.Native;
+import org.sosy_lab.java_smt.api.PropagatorBackend;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.UserPropagator;
+
+final class Z3UserPropagator extends Native.UserPropagatorBase implements PropagatorBackend {
+  private final Z3FormulaCreator creator;
+  private final Z3FormulaManager manager;
+  private final UserPropagator userPropagator;
+
+  // function calls from z3's side
+  // (forwarding callbacks to the user propagator)
+  @Override
+  public void pushWrapper() {
+    userPropagator.onPush();
+  }
+
+  @Override
+  public void popWrapper(int num) {
+    userPropagator.onPop(num);
+  }
+
+  @Override
+  public void finWrapper() {
+    userPropagator.onFinalCheck();
+  }
+
+  @Override
+  public void eqWrapper(long lx, long ly) {
+    userPropagator.onEquality(creator.encapsulateBoolean(lx), creator.encapsulateBoolean(ly));
+  }
+
+  // to function correctly, new prop and context are needed
+  // currently, there is no support for delegating subproblems to new user propagators
+  @Override
+  public Z3UserPropagator freshWrapper(long lctx) {
+    return this;
+  }
+
+  @Override
+  public void createdWrapper(long le) {
+  }
+
+  @Override
+  public void fixedWrapper(long lvar, long lvalue) {
+    userPropagator.onKnownValue(creator.encapsulateBoolean(lvar),
+        creator.encapsulateBoolean(lvalue));
+  }
+
+  public void decideWrapper(long expr, int i, int j) {}
+
+
+  // function calls from java-smt's side (mostly calls to the smt backend)
+  // (register events on z3's side)
+
+  Z3UserPropagator(long ctx, long solver, Z3FormulaCreator creator, Z3FormulaManager manager,
+                          UserPropagator userPropagator) {
+    super(ctx, solver);
+    this.creator = creator;
+    this.userPropagator = userPropagator;
+    this.manager = manager;
+  }
+
+  @Override
+  public void registerExpression(BooleanFormula exprToWatch) {
+    Native.propagateAdd(this, ctx, solver, javainfo, creator.extractInfo(exprToWatch));
+  }
+
+  @Override
+  public void propagateConflict(BooleanFormula[] conflictLiterals) {
+    propagateConsequence(conflictLiterals, manager.getBooleanFormulaManager().makeFalse());
+  }
+
+  @Override
+  public void propagateConsequence(BooleanFormula[] assignedLiterals, BooleanFormula consequence) {
+    propagateConsequenceWithEqualities(assignedLiterals, new BooleanFormula[0],
+        new BooleanFormula[0], consequence);
+  }
+
+  @Override
+  public void propagateConsequenceWithEqualities(
+      BooleanFormula[] assignedLiterals,
+      BooleanFormula[] equalitiesLHS,
+      BooleanFormula[] equalitiesRHS,
+      BooleanFormula consequence) {
+    Preconditions.checkArgument(equalitiesLHS.length == equalitiesRHS.length);
+    Native.propagateConflict(this, ctx, solver, javainfo, assignedLiterals.length,
+        formulaArrayToLong(assignedLiterals)
+        , equalitiesLHS.length, formulaArrayToLong(equalitiesLHS), formulaArrayToLong(equalitiesRHS),
+        creator.extractInfo(consequence));
+  }
+
+  private long[] formulaArrayToLong(BooleanFormula[] formulaArray) {
+    long[] formulaInfos = new long[formulaArray.length];
+    for (int i = 0; i < formulaArray.length; i++) {
+      if (formulaArray[i] != null) {
+        formulaInfos[i] = creator.extractInfo(formulaArray[i]);
+      }
+    }
+    return formulaInfos;
+  }
+
+  @Override
+  public void notifyOnKnownValue() { registerFixed(); }
+
+  @Override
+  public void notifyOnEquality() { registerEq(); }
+
+  @Override
+  public void notifyOnFinalCheck() { registerFinal(); }
+}

--- a/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/EnumerationFormulaManagerTest.java
@@ -9,7 +9,6 @@
 package org.sosy_lab.java_smt.test;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.TruthJUnit.assume;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -36,16 +35,6 @@ public class EnumerationFormulaManagerTest extends SolverBasedTest0.Parameterize
   @Before
   public void init() {
     requireEnumeration();
-
-    if (solverToUse() == Solvers.MATHSAT5) {
-      System.out.println(context.getVersion());
-      assume()
-          .withMessage(
-              "Solver %s in version 5.6.8 does not yet support the theory of enumerations",
-              solverToUse())
-          .that(context.getVersion())
-          .doesNotContain("MathSAT5 version 5.6.8");
-    }
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -18,17 +18,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
-import org.sosy_lab.common.rationals.ExtendedRational;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingMode;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.FloatingPointType;
@@ -815,7 +814,7 @@ public class FloatingPointFormulaManagerTest
   }
 
   @Test
-  public void fpModelValue() throws SolverException, InterruptedException {
+  public void fpModelContent() throws SolverException, InterruptedException {
     FloatingPointFormula zeroVar = fpmgr.makeVariable("zero", singlePrecType);
     BooleanFormula zeroEq = fpmgr.assignment(zeroVar, zero);
 
@@ -825,63 +824,68 @@ public class FloatingPointFormulaManagerTest
     FloatingPointFormula nanVar = fpmgr.makeVariable("nan", singlePrecType);
     BooleanFormula nanEq = fpmgr.assignment(nanVar, nan);
 
-    FloatingPointFormula posInfVar = fpmgr.makeVariable("posInf", singlePrecType);
-    BooleanFormula posInfEq = fpmgr.assignment(posInfVar, posInf);
-
-    FloatingPointFormula negInfVar = fpmgr.makeVariable("negInf", singlePrecType);
-    BooleanFormula negInfEq = fpmgr.assignment(negInfVar, negInf);
-
     try (ProverEnvironment prover = context.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
       prover.push(zeroEq);
       prover.push(oneEq);
       prover.push(nanEq);
-      prover.push(posInfEq);
-      prover.push(negInfEq);
 
       assertThat(prover).isSatisfiable();
 
       try (Model model = prover.getModel()) {
 
-        Object zeroValue = model.evaluate(zeroVar);
-        ValueAssignment zeroAssignment =
-            new ValueAssignment(zeroVar, zero, zeroEq, "zero", zeroValue, ImmutableList.of());
-        assertThat(zeroValue)
-            .isAnyOf(ExtendedRational.ZERO, Rational.ZERO, BigDecimal.ZERO, 0.0, 0.0f);
-
-        Object oneValue = model.evaluate(oneVar);
+        FloatingPointNumber oneValue = model.evaluate(oneVar);
         ValueAssignment oneAssignment =
             new ValueAssignment(oneVar, one, oneEq, "one", oneValue, ImmutableList.of());
-        assertThat(oneValue)
-            .isAnyOf(
-                new ExtendedRational(Rational.ONE),
-                BigInteger.ONE,
-                Rational.ONE,
-                BigDecimal.ONE,
-                1.0,
-                1.0f);
 
-        Object nanValue = model.evaluate(nanVar);
+        FloatingPointNumber zeroValue = model.evaluate(zeroVar);
+        ValueAssignment zeroAssignment =
+            new ValueAssignment(zeroVar, zero, zeroEq, "zero", zeroValue, ImmutableList.of());
+
+        FloatingPointNumber nanValue = model.evaluate(nanVar);
         ValueAssignment nanAssignment =
             new ValueAssignment(nanVar, nan, nanEq, "nan", nanValue, ImmutableList.of());
-        assertThat(nanValue).isAnyOf(ExtendedRational.NaN, Double.NaN, Float.NaN);
 
-        Object posInfValue = model.evaluate(posInfVar);
-        ValueAssignment posInfAssignment =
-            new ValueAssignment(
-                posInfVar, posInf, posInfEq, "posInf", posInfValue, ImmutableList.of());
-        assertThat(posInfValue)
-            .isAnyOf(ExtendedRational.INFTY, Double.POSITIVE_INFINITY, Float.POSITIVE_INFINITY);
+        assertThat(model).containsExactly(zeroAssignment, oneAssignment, nanAssignment);
+      }
+    }
+  }
 
-        Object negInfValue = model.evaluate(negInfVar);
-        ValueAssignment negInfAssignment =
-            new ValueAssignment(
-                negInfVar, negInf, negInfEq, "negInf", negInfValue, ImmutableList.of());
-        assertThat(negInfValue)
-            .isAnyOf(ExtendedRational.NEG_INFTY, Double.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
+  @Test
+  public void fpModelValue() throws SolverException, InterruptedException {
+    try (ProverEnvironment prover = context.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
+      prover.push(bmgr.makeTrue());
 
-        assertThat(model)
-            .containsExactly(
-                zeroAssignment, oneAssignment, nanAssignment, posInfAssignment, negInfAssignment);
+      assertThat(prover).isSatisfiable();
+
+      try (Model model = prover.getModel()) {
+        assertThat(model).isEmpty();
+
+        for (float f :
+            new float[] {
+              0,
+              1,
+              2,
+              3,
+              4,
+              256,
+              1000,
+              1024,
+              -1,
+              -2,
+              -3,
+              -4,
+              -1000,
+              -1024,
+              Float.NEGATIVE_INFINITY,
+              Float.POSITIVE_INFINITY,
+              Float.MAX_VALUE,
+              Float.MIN_VALUE,
+              Float.MIN_NORMAL,
+            }) {
+          FloatingPointNumber fiveValue = model.evaluate(fpmgr.makeNumber(f, singlePrecType));
+          assertThat(fiveValue.floatValue()).isEqualTo(f);
+          assertThat(fiveValue.doubleValue()).isEqualTo((double) f);
+        }
       }
     }
   }

--- a/src/org/sosy_lab/java_smt/test/FloatingPointNumberTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointNumberTest.java
@@ -1,0 +1,97 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.sosy_lab.java_smt.api.FloatingPointNumber.DOUBLE_PRECISION_EXPONENT_SIZE;
+import static org.sosy_lab.java_smt.api.FloatingPointNumber.DOUBLE_PRECISION_MANTISSA_SIZE;
+import static org.sosy_lab.java_smt.api.FloatingPointNumber.SINGLE_PRECISION_EXPONENT_SIZE;
+import static org.sosy_lab.java_smt.api.FloatingPointNumber.SINGLE_PRECISION_MANTISSA_SIZE;
+
+import com.google.common.base.Strings;
+import java.math.BigInteger;
+import org.junit.Test;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
+
+public class FloatingPointNumberTest {
+
+  @Test
+  public void floatingPointNumberWithSinglePrecision() {
+    for (float f :
+        new float[] {
+          0,
+          1,
+          2,
+          3,
+          4,
+          256,
+          1000,
+          1024,
+          -1,
+          -2,
+          -3,
+          -4,
+          -1000,
+          -1024,
+          Float.NEGATIVE_INFINITY,
+          Float.POSITIVE_INFINITY,
+          Float.MAX_VALUE,
+          Float.MIN_VALUE,
+          Float.MIN_NORMAL,
+        }) {
+      var bits = Strings.padStart(Integer.toBinaryString(Float.floatToRawIntBits(f)), 32, '0');
+      var fpNum =
+          FloatingPointNumber.of(
+              bits, SINGLE_PRECISION_EXPONENT_SIZE, SINGLE_PRECISION_MANTISSA_SIZE);
+      assertThat(fpNum.floatValue()).isEqualTo(f);
+      assertThat(fpNum.doubleValue()).isEqualTo((double) f); // float is a strict subtype of double.
+    }
+  }
+
+  @Test
+  public void floatingPointNumberWithDoublePrecision() {
+    for (double d :
+        new double[] {
+          0,
+          1,
+          2,
+          3,
+          4,
+          256,
+          1000,
+          1024,
+          -1,
+          -2,
+          -3,
+          -4,
+          -1000,
+          -1024,
+          Double.NEGATIVE_INFINITY,
+          Double.POSITIVE_INFINITY,
+          Double.MAX_VALUE,
+          Double.MIN_VALUE,
+          Double.MIN_NORMAL,
+        }) {
+      var bits = Strings.padStart(Long.toBinaryString(Double.doubleToRawLongBits(d)), 64, '0');
+      var fpNum =
+          FloatingPointNumber.of(
+              bits, DOUBLE_PRECISION_EXPONENT_SIZE, DOUBLE_PRECISION_MANTISSA_SIZE);
+      assertThat(fpNum.doubleValue()).isEqualTo(d);
+    }
+  }
+
+  @Test
+  public void floatingPointNumberWithArbitraryPrecision() {
+    var fpNum = FloatingPointNumber.of(false, BigInteger.valueOf(10), BigInteger.ONE, 5, 7);
+    assertThat(fpNum.toString()).isEqualTo("0" + "01010" + "0000001");
+    assertThrows(IllegalArgumentException.class, () -> fpNum.floatValue());
+    assertThrows(IllegalArgumentException.class, () -> fpNum.doubleValue());
+  }
+}

--- a/src/org/sosy_lab/java_smt/test/ModelTest.java
+++ b/src/org/sosy_lab/java_smt/test/ModelTest.java
@@ -35,6 +35,7 @@ import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
+import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.ArrayFormulaType;
@@ -1788,8 +1789,16 @@ public class ModelTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
       assignmentFormulas.add(va.getAssignmentAsFormula());
       assertThatFormula(va.getAssignmentAsFormula())
           .isEqualTo(makeAssignment(va.getKey(), va.getValueAsFormula()));
-      assertThat(va.getValue().getClass())
-          .isIn(ImmutableList.of(Boolean.class, BigInteger.class, Rational.class, Double.class));
+      assertThat(
+              ImmutableList.of(
+                      Boolean.class,
+                      BigInteger.class,
+                      Rational.class,
+                      Double.class,
+                      FloatingPointNumber.class)
+                  .stream()
+                  .anyMatch(cls -> cls.isInstance(va.getValue())))
+          .isTrue();
     }
 
     // Check that model is not contradicting

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -349,6 +349,13 @@ public abstract class SolverBasedTest0 {
         .isNotEqualTo(Solvers.BOOLECTOR);
   }
 
+  protected void requireUserPropagators() {
+    assume()
+        .withMessage("Solver %s does not support user propagation", solverToUse())
+        .that(solverToUse())
+        .isEqualTo(Solvers.Z3);
+  }
+
   /**
    * Use this for checking assertions about BooleanFormulas with Truth: <code>
    * assertThatFormula(formula).is...()</code>.

--- a/src/org/sosy_lab/java_smt/test/SolverContextFactoryTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverContextFactoryTest.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.sosy_lab.common.NativeLibraries;
 import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
@@ -101,10 +102,28 @@ public class SolverContextFactoryTest {
         return;
       case Z3:
         assume.that(IS_LINUX || IS_WINDOWS || IS_MAC).isTrue();
+        if (IS_LINUX) {
+          assume.that(isSufficientVersionOfLibcxx()).isTrue();
+        }
         return;
       default:
         throw new AssertionError("unexpected solver: " + solverToUse());
     }
+  }
+
+  /**
+   * The official Z3 release does only run with GLIBCXX in version 3.4.26 or newer. This excludes
+   * Ubuntu 18.04.
+   */
+  private boolean isSufficientVersionOfLibcxx() {
+    try {
+      NativeLibraries.loadLibrary("z3");
+    } catch (UnsatisfiedLinkError e) {
+      if (e.getMessage().contains("version `GLIBCXX_3.4.26' not found")) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Before

--- a/src/org/sosy_lab/java_smt/test/SolverContextFactoryTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverContextFactoryTest.java
@@ -10,6 +10,7 @@ package org.sosy_lab.java_smt.test;
 
 import static com.google.common.truth.Truth.assert_;
 import static com.google.common.truth.TruthJUnit.assume;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.base.StandardSystemProperty;
 import com.google.common.truth.StandardSubjectBuilder;
@@ -132,13 +133,10 @@ public class SolverContextFactoryTest {
     SolverContextFactory factory =
         new SolverContextFactory(
             config, logger, shutdownManager.getNotifier(), System::loadLibrary);
-    try (SolverContext context = factory.generateContext()) {
-      assert_().fail();
-      @SuppressWarnings("unused")
-      FormulaManager mgr = context.getFormulaManager();
-    } catch (InvalidConfigurationException e) {
-      assert_().that(e).hasCauseThat().isInstanceOf(UnsatisfiedLinkError.class);
-    }
+    assert_()
+        .that(assertThrows(InvalidConfigurationException.class, () -> factory.generateContext()))
+        .hasCauseThat()
+        .isInstanceOf(UnsatisfiedLinkError.class);
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/test/UserPropagatorTest.java
+++ b/src/org/sosy_lab/java_smt/test/UserPropagatorTest.java
@@ -1,0 +1,86 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.test;
+
+import com.google.common.base.Verify;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.PropagatorBackend;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
+import org.sosy_lab.java_smt.api.SolverException;
+import org.sosy_lab.java_smt.api.UserPropagator;
+import org.sosy_lab.java_smt.basicimpl.AbstractUserPropagator;
+
+public class UserPropagatorTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
+
+  @Before
+  public void init() {
+    requireUserPropagators();
+  }
+
+  @Test
+  public void testWithBlockedLiterals() throws SolverException, InterruptedException {
+    // assert "p or q or r or s"
+    BooleanFormula p = bmgr.makeVariable("p");
+    BooleanFormula q = bmgr.makeVariable("q");
+    BooleanFormula r = bmgr.makeVariable("r");
+    BooleanFormula clause = bmgr.or(p, q, r);
+
+    try (ProverEnvironment prover = context.newProverEnvironment()) {
+      prover.push(clause);
+      // Create user propagator that prohibits variables to be set to true
+      UserPropagator prop = new TestUserPropagator();
+      Verify.verify(prover.registerUserPropagator(prop));
+      prop.registerExpression(p);
+      prop.registerExpression(q);
+      prop.registerExpression(r);
+      assertThatEnvironment(prover).isUnsatisfiable();
+    }
+  }
+
+  /** This user propagator will raise a conflict whenever a registered expression is set to true. */
+  private static class TestUserPropagator extends AbstractUserPropagator {
+
+    private final List<BooleanFormula> disabledExpressions = new ArrayList<>();
+
+    @Override
+    public void onKnownValue(BooleanFormula expr, boolean value) {
+      if (value && disabledExpressions.contains(expr)) {
+        getBackend().propagateConflict(new BooleanFormula[] {expr});
+      }
+    }
+
+    @Override
+    public void onDecision(BooleanFormula expr, boolean value) {
+      for (BooleanFormula disExpr : disabledExpressions) {
+        if (getBackend().propagateNextDecision(disExpr, Optional.of(true))) {
+          break;
+        }
+      }
+    }
+
+    @Override
+    public void initializeWithBackend(PropagatorBackend backend) {
+      super.initializeWithBackend(backend);
+      // Enable callbacks
+      backend.notifyOnKnownValue();
+      backend.notifyOnDecision();
+    }
+
+    @Override
+    public void registerExpression(BooleanFormula theoryExpr) {
+      disabledExpressions.add(theoryExpr);
+      super.registerExpression(theoryExpr);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the user propagator feature to JavaSMT (~ user-defined theory solvers).
Currently, the only SMT backend that supports this feature is Z3, but CVC5 also seems to be working on adding support for user propagators.
For now, only the most important (and most general) user propagator features are exposed.

The PR contains 3 example implementations: `SimpleUserPropagator` and two propagators for `Nqueens`.
Both `NQueens` propagators are enumerating all models of an `Nqueens` instance, but one of them also implements the placement constraints inside the user propagator (the other works on the original encoding).
The user propagator gives tremendeous speed-up when enumerating the models: we measure up-to two orders of magnitude speed-up (a couple of minutes rather than hours for large instances).

The speed-up can be easily observed on Nqueens with `N=11`: iterating all models with the classical approach takes around 22 seconds (on my machine), whereas the user propagator solutions need only about 2 seconds. The difference gets larger with larger `N`.

~**Problems:** The user propagator feature needs the recent version of Z3 and does not work with the current version used by JavaSMT.~ Thanks @kfriedberger for updating the Z3 version.

*Edit:* I just noticed that I accidentally copied the license headers into some of the source files.
How are the licensing rules? Shall I remove the headers or replace them using my name?