### PR TITLE
Add rotation operations to BitvectorFormulaManager

### DIFF
--- a/src/org/sosy_lab/java_smt/api/BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/BitvectorFormulaManager.java
@@ -266,6 +266,18 @@ public interface BitvectorFormulaManager {
    */
   BitvectorFormula shiftLeft(BitvectorFormula number, BitvectorFormula toShift);
 
+  /**
+   * This method returns a term representing the right rotation of number by toRotate. The result
+   * has the same length as the given number.
+   */
+  BitvectorFormula rotateRight(BitvectorFormula number, BitvectorFormula toRotate);
+
+  /**
+   * This method returns a term representing the left shift of number by toRotate. The result
+   * has the same length as the given number.
+   */
+  BitvectorFormula rotateLeft(BitvectorFormula number, BitvectorFormula toRotate);
+
   /** Concatenate two bitvectors. */
   BitvectorFormula concat(BitvectorFormula prefix, BitvectorFormula suffix);
 

--- a/src/org/sosy_lab/java_smt/api/BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/BitvectorFormulaManager.java
@@ -273,8 +273,8 @@ public interface BitvectorFormulaManager {
   BitvectorFormula rotateRight(BitvectorFormula number, BitvectorFormula toRotate);
 
   /**
-   * This method returns a term representing the left shift of number by toRotate. The result
-   * has the same length as the given number.
+   * This method returns a term representing the left shift of number by toRotate. The result has
+   * the same length as the given number.
    */
   BitvectorFormula rotateLeft(BitvectorFormula number, BitvectorFormula toRotate);
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
@@ -314,9 +314,7 @@ public abstract class AbstractBitvectorFormulaManager<TFormulaInfo, TType, TEnv,
 
   protected abstract TFormulaInfo shiftLeft(TFormulaInfo pExtract, TFormulaInfo pExtract2);
 
-  /**
-   * Return a term representing the right rotation of number by toRotate.
-   */
+  /** Return a term representing the right rotation of number by toRotate. */
   @Override
   public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula toRotate) {
     TFormulaInfo param1 = extractInfo(pNumber);
@@ -327,9 +325,7 @@ public abstract class AbstractBitvectorFormulaManager<TFormulaInfo, TType, TEnv,
 
   protected abstract TFormulaInfo rotateRight(TFormulaInfo pNumber, TFormulaInfo toRotate);
 
-  /**
-   * Return a term representing the left rotation of number by toRotate.
-   */
+  /** Return a term representing the left rotation of number by toRotate. */
   @Override
   public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula toRotate) {
     TFormulaInfo param1 = extractInfo(pNumber);

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
@@ -318,27 +318,27 @@ public abstract class AbstractBitvectorFormulaManager<TFormulaInfo, TType, TEnv,
    * Return a term representing the right rotation of number by toRotate.
    */
   @Override
-  public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula toShift) {
+  public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula toRotate) {
     TFormulaInfo param1 = extractInfo(pNumber);
-    TFormulaInfo param2 = extractInfo(toShift);
+    TFormulaInfo param2 = extractInfo(toRotate);
 
     return wrap(rotateRight(param1, param2));
   }
 
-  protected abstract TFormulaInfo rotateRight(TFormulaInfo pNumber, TFormulaInfo toShift);
+  protected abstract TFormulaInfo rotateRight(TFormulaInfo pNumber, TFormulaInfo toRotate);
 
   /**
    * Return a term representing the left rotation of number by toRotate.
    */
   @Override
-  public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula toShift) {
+  public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula toRotate) {
     TFormulaInfo param1 = extractInfo(pNumber);
-    TFormulaInfo param2 = extractInfo(toShift);
+    TFormulaInfo param2 = extractInfo(toRotate);
 
     return wrap(rotateLeft(param1, param2));
   }
 
-  protected abstract TFormulaInfo rotateLeft(TFormulaInfo pExtract, TFormulaInfo pExtract2);
+  protected abstract TFormulaInfo rotateLeft(TFormulaInfo pNumber, TFormulaInfo toRotate);
 
   @Override
   public final BitvectorFormula concat(BitvectorFormula pNumber, BitvectorFormula pAppend) {

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
@@ -314,6 +314,32 @@ public abstract class AbstractBitvectorFormulaManager<TFormulaInfo, TType, TEnv,
 
   protected abstract TFormulaInfo shiftLeft(TFormulaInfo pExtract, TFormulaInfo pExtract2);
 
+  /**
+   * Return a term representing the right rotation of number by toRotate.
+   */
+  @Override
+  public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula toShift) {
+    TFormulaInfo param1 = extractInfo(pNumber);
+    TFormulaInfo param2 = extractInfo(toShift);
+
+    return wrap(rotateRight(param1, param2));
+  }
+
+  protected abstract TFormulaInfo rotateRight(TFormulaInfo pNumber, TFormulaInfo toShift);
+
+  /**
+   * Return a term representing the left rotation of number by toRotate.
+   */
+  @Override
+  public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula toShift) {
+    TFormulaInfo param1 = extractInfo(pNumber);
+    TFormulaInfo param2 = extractInfo(toShift);
+
+    return wrap(rotateLeft(param1, param2));
+  }
+
+  protected abstract TFormulaInfo rotateLeft(TFormulaInfo pExtract, TFormulaInfo pExtract2);
+
   @Override
   public final BitvectorFormula concat(BitvectorFormula pNumber, BitvectorFormula pAppend) {
     TFormulaInfo param1 = extractInfo(pNumber);

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsBitvectorFormulaManager.java
@@ -179,6 +179,18 @@ class StatisticsBitvectorFormulaManager implements BitvectorFormulaManager {
   }
 
   @Override
+  public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula pToRotate) {
+    stats.bvOperations.getAndIncrement();
+    return delegate.rotateRight(pNumber, pToRotate);
+  }
+
+  @Override
+  public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula pToRotate) {
+    stats.bvOperations.getAndIncrement();
+    return delegate.rotateLeft(pNumber, pToRotate);
+  }
+
+  @Override
   public BitvectorFormula concat(BitvectorFormula pNumber, BitvectorFormula pAppend) {
     stats.bvOperations.getAndIncrement();
     return delegate.concat(pNumber, pAppend);

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBitvectorFormulaManager.java
@@ -205,6 +205,20 @@ class SynchronizedBitvectorFormulaManager implements BitvectorFormulaManager {
   }
 
   @Override
+  public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula pToRotate) {
+    synchronized (sync) {
+      return delegate.rotateRight(pNumber, pToRotate);
+    }
+  }
+
+  @Override
+  public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula pToRotate) {
+    synchronized (sync) {
+      return delegate.rotateLeft(pNumber, pToRotate);
+    }
+  }
+
+  @Override
   public BitvectorFormula concat(BitvectorFormula pNumber, BitvectorFormula pAppend) {
     synchronized (sync) {
       return delegate.concat(pNumber, pAppend);

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorBitvectorFormulaManager.java
@@ -16,6 +16,8 @@ import static org.sosy_lab.java_smt.solvers.boolector.BtorJNI.boolector_mul;
 import static org.sosy_lab.java_smt.solvers.boolector.BtorJNI.boolector_neg;
 import static org.sosy_lab.java_smt.solvers.boolector.BtorJNI.boolector_not;
 import static org.sosy_lab.java_smt.solvers.boolector.BtorJNI.boolector_or;
+import static org.sosy_lab.java_smt.solvers.boolector.BtorJNI.boolector_rol;
+import static org.sosy_lab.java_smt.solvers.boolector.BtorJNI.boolector_ror;
 import static org.sosy_lab.java_smt.solvers.boolector.BtorJNI.boolector_sdiv;
 import static org.sosy_lab.java_smt.solvers.boolector.BtorJNI.boolector_sext;
 import static org.sosy_lab.java_smt.solvers.boolector.BtorJNI.boolector_sgt;
@@ -185,6 +187,16 @@ class BoolectorBitvectorFormulaManager
   @Override
   public Long shiftLeft(Long bitVec, Long toShift) {
     return boolector_sll(btor, bitVec, toShift);
+  }
+
+  @Override
+  protected Long rotateRight(Long pNumber, Long toRotate) {
+    return boolector_ror(btor, pNumber, toRotate);
+  }
+
+  @Override
+  protected Long rotateLeft(Long pNumber, Long toRotate) {
+    return boolector_rol(btor, pNumber, toRotate);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4BitvectorFormulaManager.java
@@ -10,7 +10,6 @@ package org.sosy_lab.java_smt.solvers.cvc4;
 
 import edu.stanford.CVC4.BitVector;
 import edu.stanford.CVC4.BitVectorExtract;
-import edu.stanford.CVC4.BitVectorRotateLeft;
 import edu.stanford.CVC4.BitVectorSignExtend;
 import edu.stanford.CVC4.BitVectorType;
 import edu.stanford.CVC4.BitVectorZeroExtend;

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4BitvectorFormulaManager.java
@@ -10,6 +10,7 @@ package org.sosy_lab.java_smt.solvers.cvc4;
 
 import edu.stanford.CVC4.BitVector;
 import edu.stanford.CVC4.BitVectorExtract;
+import edu.stanford.CVC4.BitVectorRotateLeft;
 import edu.stanford.CVC4.BitVectorSignExtend;
 import edu.stanford.CVC4.BitVectorType;
 import edu.stanford.CVC4.BitVectorZeroExtend;
@@ -82,6 +83,24 @@ public class CVC4BitvectorFormulaManager
   @Override
   protected Expr shiftLeft(Expr pParam1, Expr pParam2) {
     return exprManager.mkExpr(Kind.BITVECTOR_SHL, pParam1, pParam2);
+  }
+
+  @Override
+  protected Expr rotateRight(Expr pNumber, Expr toRotate) {
+    // cvc4 does not support non-literal rotation, so we rewrite it to (bvor (bvlshr pNumber
+    // toRotate) (bvshl pNumber (bvsub size toRotate)))
+    final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
+    final Expr size = this.makeBitvectorImpl(bitsize, bitsize);
+    return or(shiftRight(pNumber, toRotate, false), shiftLeft(pNumber, subtract(size, toRotate)));
+  }
+
+  @Override
+  protected Expr rotateLeft(Expr pNumber, Expr toRotate) {
+    // cvc4 does not support non-literal rotation, so we rewrite it to (bvor (bvshl pNumber
+    // toRotate) (bvlshr pNumber (bvsub size toRotate)))
+    final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
+    final Expr size = this.makeBitvectorImpl(bitsize, bitsize);
+    return or(shiftLeft(pNumber, toRotate), shiftRight(pNumber, subtract(size, toRotate), false));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5BitvectorFormulaManager.java
@@ -8,7 +8,6 @@
 
 package org.sosy_lab.java_smt.solvers.cvc5;
 
-import edu.stanford.CVC4.Expr;
 import io.github.cvc5.CVC5ApiException;
 import io.github.cvc5.Kind;
 import io.github.cvc5.Op;

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5BitvectorFormulaManager.java
@@ -20,6 +20,7 @@ import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_number;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_or;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_plus;
+import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_ror;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_sdiv;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_sext;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_sleq;
@@ -37,7 +38,9 @@ import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_int_from_ubv;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_int_to_bv;
 
+import edu.stanford.CVC4.Expr;
 import java.math.BigInteger;
+import org.sosy_lab.java_smt.api.FormulaType.BitvectorType;
 import org.sosy_lab.java_smt.basicimpl.AbstractBitvectorFormulaManager;
 
 /** Mathsat Bitvector Theory, build out of Bitvector*Operations. */
@@ -123,6 +126,24 @@ class Mathsat5BitvectorFormulaManager
   @Override
   public Long shiftLeft(Long number, Long toShift) {
     return msat_make_bv_lshl(mathsatEnv, number, toShift);
+  }
+
+  @Override
+  protected Long rotateRight(Long pNumber, Long toRotate) {
+    // MathSAT5 does not support non-literal rotation, so we rewrite it to (bvor (bvlshr pNumber
+    // toRotate) (bvshl pNumber (bvsub size toRotate)))
+    final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
+    final Long size = this.makeBitvectorImpl(bitsize, bitsize);
+    return or(shiftRight(pNumber, toRotate, false), shiftLeft(pNumber, subtract(size, toRotate)));
+  }
+
+  @Override
+  protected Long rotateLeft(Long pNumber, Long toRotate) {
+    // MathSAT5 does not support non-literal rotation, so we rewrite it to (bvor (bvshl pNumber
+    // toRotate) (bvlshr pNumber (bvsub size toRotate)))
+    final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
+    final Long size = this.makeBitvectorImpl(bitsize, bitsize);
+    return or(shiftLeft(pNumber, toRotate), shiftRight(pNumber, subtract(size, toRotate), false));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5BitvectorFormulaManager.java
@@ -20,7 +20,6 @@ import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_number;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_or;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_plus;
-import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_ror;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_sdiv;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_sext;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_bv_sleq;
@@ -38,7 +37,6 @@ import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_int_from_ubv;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_int_to_bv;
 
-import edu.stanford.CVC4.Expr;
 import java.math.BigInteger;
 import org.sosy_lab.java_smt.api.FormulaType.BitvectorType;
 import org.sosy_lab.java_smt.basicimpl.AbstractBitvectorFormulaManager;

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessBitvectorFormulaManager.java
@@ -15,7 +15,6 @@ import ap.theories.bitvectors.ModuloArithmetic$;
 import ap.types.Sort;
 import ap.types.Sort$;
 import com.google.common.base.Preconditions;
-import edu.stanford.CVC4.Expr;
 import java.math.BigInteger;
 import org.sosy_lab.java_smt.api.FormulaType.BitvectorType;
 import org.sosy_lab.java_smt.basicimpl.AbstractBitvectorFormulaManager;

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2BitvectorFormulaManager.java
@@ -35,18 +35,14 @@ import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvsrem;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvsub;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvxor2;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_parse_bvbin;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_rotate_left;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_rotate_right;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_sign_extend;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_zero_extend;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import edu.stanford.CVC4.Expr;
 import java.math.BigInteger;
 import org.sosy_lab.java_smt.api.FormulaType.BitvectorType;
 import org.sosy_lab.java_smt.basicimpl.AbstractBitvectorFormulaManager;
-import scala.Int;
 
 public class Yices2BitvectorFormulaManager
     extends AbstractBitvectorFormulaManager<Integer, Integer, Long, Integer> {

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2BitvectorFormulaManager.java
@@ -35,13 +35,18 @@ import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvsrem;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvsub;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvxor2;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_parse_bvbin;
+import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_rotate_left;
+import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_rotate_right;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_sign_extend;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_zero_extend;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import edu.stanford.CVC4.Expr;
 import java.math.BigInteger;
+import org.sosy_lab.java_smt.api.FormulaType.BitvectorType;
 import org.sosy_lab.java_smt.basicimpl.AbstractBitvectorFormulaManager;
+import scala.Int;
 
 public class Yices2BitvectorFormulaManager
     extends AbstractBitvectorFormulaManager<Integer, Integer, Long, Integer> {
@@ -189,6 +194,24 @@ public class Yices2BitvectorFormulaManager
   @Override
   protected Integer shiftLeft(Integer pNumber, Integer pToShift) {
     return yices_bvshl(pNumber, pToShift);
+  }
+
+  @Override
+  protected Integer rotateRight(Integer pNumber, Integer toRotate) {
+    // Yices2 does not support non-literal rotation, so we rewrite it to (bvor (bvlshr pNumber
+    // toRotate) (bvshl pNumber (bvsub size toRotate)))
+    final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
+    final Integer size = this.makeBitvectorImpl(bitsize, bitsize);
+    return or(shiftRight(pNumber, toRotate, false), shiftLeft(pNumber, subtract(size, toRotate)));
+  }
+
+  @Override
+  protected Integer rotateLeft(Integer pNumber, Integer toRotate) {
+    // Yices2 does not support non-literal rotation, so we rewrite it to (bvor (bvshl pNumber
+    // toRotate) (bvlshr pNumber (bvsub size toRotate)))
+    final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
+    final Integer size = this.makeBitvectorImpl(bitsize, bitsize);
+    return or(shiftLeft(pNumber, toRotate), shiftRight(pNumber, subtract(size, toRotate), false));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3BitvectorFormulaManager.java
@@ -83,6 +83,16 @@ class Z3BitvectorFormulaManager extends AbstractBitvectorFormulaManager<Long, Lo
   }
 
   @Override
+  protected Long rotateRight(Long pNumber, Long toRotate) {
+    return Native.mkExtRotateRight(z3context, pNumber, toRotate);
+  }
+
+  @Override
+  protected Long rotateLeft(Long pNumber, Long toRotate) {
+    return Native.mkExtRotateLeft(z3context, pNumber, toRotate);
+  }
+
+  @Override
   public Long not(Long pBits) {
     return Native.mkBvnot(z3context, pBits);
   }

--- a/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
@@ -397,4 +397,29 @@ public class BitvectorFormulaManagerTest extends SolverBasedTest0.ParameterizedS
     assertThatFormula(bvmgr.distinct(List.of(a, a))).isUnsatisfiable();
     assertThatFormula(bvmgr.distinct(List.of(num3, num3))).isUnsatisfiable();
   }
+
+  @Test
+  public void bvRotateLeft() throws SolverException, InterruptedException {
+    // (ROL 0001 0010) == 0100
+    // (ROL 0100 0010) == 0001
+    BitvectorFormula bf1 = bvmgr.makeBitvector(4, BigInteger.ONE);
+    BitvectorFormula bf2 = bvmgr.makeBitvector(4, BigInteger.TWO);
+    BitvectorFormula bf3 = bvmgr.makeBitvector(4, BigInteger.valueOf(4));
+
+    assertThatFormula(bvmgr.equal(bvmgr.rotateLeft(bf1, bf2), bf3)).isTautological();
+    assertThatFormula(bvmgr.equal(bvmgr.rotateLeft(bf3, bf2), bf1)).isTautological();
+  }
+
+  @Test
+  public void bvRotateRight() throws SolverException, InterruptedException {
+    // (ROR 0001 0011) == 0010
+    // (ROR 0010 0011) == 0100
+    BitvectorFormula bf1 = bvmgr.makeBitvector(4, BigInteger.ONE);
+    BitvectorFormula bf2 = bvmgr.makeBitvector(4, BigInteger.valueOf(3));
+    BitvectorFormula bf3 = bvmgr.makeBitvector(4, BigInteger.TWO);
+    BitvectorFormula bf4 = bvmgr.makeBitvector(4, BigInteger.valueOf(4));
+
+    assertThatFormula(bvmgr.equal(bvmgr.rotateRight(bf1, bf2), bf3)).isTautological();
+    assertThatFormula(bvmgr.equal(bvmgr.rotateRight(bf3, bf2), bf4)).isTautological();
+  }
 }


### PR DESCRIPTION
As discussed in #360, this PR adds the rotateRight and rotateLeft operations to the bitvector formula manager of JavaSMT.

I added some tests as well, they all pass.   