### PR TITLE
Add rotation operations to BitvectorFormulaManager

### DIFF
--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
@@ -352,28 +352,6 @@ public abstract class AbstractBitvectorFormulaManager<TFormulaInfo, TType, TEnv,
     throw new UnsupportedOperationException("Solver does not support BV rotation.");
   }
 
-  /** Return a term representing the right rotation of number by toRotate. */
-  @Override
-  public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula toRotate) {
-    TFormulaInfo param1 = extractInfo(pNumber);
-    TFormulaInfo param2 = extractInfo(toRotate);
-
-    return wrap(rotateRight(param1, param2));
-  }
-
-  protected abstract TFormulaInfo rotateRight(TFormulaInfo pNumber, TFormulaInfo toRotate);
-
-  /** Return a term representing the left rotation of number by toRotate. */
-  @Override
-  public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula toRotate) {
-    TFormulaInfo param1 = extractInfo(pNumber);
-    TFormulaInfo param2 = extractInfo(toRotate);
-
-    return wrap(rotateLeft(param1, param2));
-  }
-
-  protected abstract TFormulaInfo rotateLeft(TFormulaInfo pNumber, TFormulaInfo toRotate);
-
   @Override
   public final BitvectorFormula concat(BitvectorFormula pNumber, BitvectorFormula pAppend) {
     return wrap(concat(extractInfo(pNumber), extractInfo(pAppend)));

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
@@ -352,6 +352,32 @@ public abstract class AbstractBitvectorFormulaManager<TFormulaInfo, TType, TEnv,
     throw new UnsupportedOperationException("Solver does not support BV rotation.");
   }
 
+  /**
+   * Return a term representing the right rotation of number by toRotate.
+   */
+  @Override
+  public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula toShift) {
+    TFormulaInfo param1 = extractInfo(pNumber);
+    TFormulaInfo param2 = extractInfo(toShift);
+
+    return wrap(rotateRight(param1, param2));
+  }
+
+  protected abstract TFormulaInfo rotateRight(TFormulaInfo pNumber, TFormulaInfo toShift);
+
+  /**
+   * Return a term representing the left rotation of number by toRotate.
+   */
+  @Override
+  public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula toShift) {
+    TFormulaInfo param1 = extractInfo(pNumber);
+    TFormulaInfo param2 = extractInfo(toShift);
+
+    return wrap(rotateLeft(param1, param2));
+  }
+
+  protected abstract TFormulaInfo rotateLeft(TFormulaInfo pExtract, TFormulaInfo pExtract2);
+
   @Override
   public final BitvectorFormula concat(BitvectorFormula pNumber, BitvectorFormula pAppend) {
     return wrap(concat(extractInfo(pNumber), extractInfo(pAppend)));

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
@@ -352,9 +352,7 @@ public abstract class AbstractBitvectorFormulaManager<TFormulaInfo, TType, TEnv,
     throw new UnsupportedOperationException("Solver does not support BV rotation.");
   }
 
-  /**
-   * Return a term representing the right rotation of number by toRotate.
-   */
+  /** Return a term representing the right rotation of number by toRotate. */
   @Override
   public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula toRotate) {
     TFormulaInfo param1 = extractInfo(pNumber);
@@ -365,9 +363,7 @@ public abstract class AbstractBitvectorFormulaManager<TFormulaInfo, TType, TEnv,
 
   protected abstract TFormulaInfo rotateRight(TFormulaInfo pNumber, TFormulaInfo toRotate);
 
-  /**
-   * Return a term representing the left rotation of number by toRotate.
-   */
+  /** Return a term representing the left rotation of number by toRotate. */
   @Override
   public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula toRotate) {
     TFormulaInfo param1 = extractInfo(pNumber);

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractBitvectorFormulaManager.java
@@ -356,27 +356,27 @@ public abstract class AbstractBitvectorFormulaManager<TFormulaInfo, TType, TEnv,
    * Return a term representing the right rotation of number by toRotate.
    */
   @Override
-  public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula toShift) {
+  public BitvectorFormula rotateRight(BitvectorFormula pNumber, BitvectorFormula toRotate) {
     TFormulaInfo param1 = extractInfo(pNumber);
-    TFormulaInfo param2 = extractInfo(toShift);
+    TFormulaInfo param2 = extractInfo(toRotate);
 
     return wrap(rotateRight(param1, param2));
   }
 
-  protected abstract TFormulaInfo rotateRight(TFormulaInfo pNumber, TFormulaInfo toShift);
+  protected abstract TFormulaInfo rotateRight(TFormulaInfo pNumber, TFormulaInfo toRotate);
 
   /**
    * Return a term representing the left rotation of number by toRotate.
    */
   @Override
-  public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula toShift) {
+  public BitvectorFormula rotateLeft(BitvectorFormula pNumber, BitvectorFormula toRotate) {
     TFormulaInfo param1 = extractInfo(pNumber);
-    TFormulaInfo param2 = extractInfo(toShift);
+    TFormulaInfo param2 = extractInfo(toRotate);
 
     return wrap(rotateLeft(param1, param2));
   }
 
-  protected abstract TFormulaInfo rotateLeft(TFormulaInfo pExtract, TFormulaInfo pExtract2);
+  protected abstract TFormulaInfo rotateLeft(TFormulaInfo pNumber, TFormulaInfo toRotate);
 
   @Override
   public final BitvectorFormula concat(BitvectorFormula pNumber, BitvectorFormula pAppend) {

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4BitvectorFormulaManager.java
@@ -99,6 +99,24 @@ public class CVC4BitvectorFormulaManager
   }
 
   @Override
+  protected Expr rotateRight(Expr pNumber, Expr toRotate) {
+    // cvc4 does not support non-literal rotation, so we rewrite it to (bvor (bvlshr pNumber
+    // toRotate) (bvshl pNumber (bvsub size toRotate)))
+    final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
+    final Expr size = this.makeBitvectorImpl(bitsize, bitsize);
+    return or(shiftRight(pNumber, toRotate, false), shiftLeft(pNumber, subtract(size, toRotate)));
+  }
+
+  @Override
+  protected Expr rotateLeft(Expr pNumber, Expr toRotate) {
+    // cvc4 does not support non-literal rotation, so we rewrite it to (bvor (bvshl pNumber
+    // toRotate) (bvlshr pNumber (bvsub size toRotate)))
+    final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
+    final Expr size = this.makeBitvectorImpl(bitsize, bitsize);
+    return or(shiftLeft(pNumber, toRotate), shiftRight(pNumber, subtract(size, toRotate), false));
+  }
+
+  @Override
   protected Expr not(Expr pParam1) {
     return exprManager.mkExpr(Kind.BITVECTOR_NOT, pParam1);
   }

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4BitvectorFormulaManager.java
@@ -104,7 +104,10 @@ public class CVC4BitvectorFormulaManager
     // toRotate) (bvshl pNumber (bvsub size toRotate)))
     final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
     final Expr size = this.makeBitvectorImpl(bitsize, bitsize);
-    return or(shiftRight(pNumber, toRotate, false), shiftLeft(pNumber, subtract(size, toRotate)));
+    final Expr toRotateInRange = exprManager.mkExpr(Kind.BITVECTOR_UREM, toRotate, size);
+    return or(
+        shiftRight(pNumber, toRotateInRange, false),
+        shiftLeft(pNumber, subtract(size, toRotateInRange)));
   }
 
   @Override
@@ -113,7 +116,10 @@ public class CVC4BitvectorFormulaManager
     // toRotate) (bvlshr pNumber (bvsub size toRotate)))
     final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
     final Expr size = this.makeBitvectorImpl(bitsize, bitsize);
-    return or(shiftLeft(pNumber, toRotate), shiftRight(pNumber, subtract(size, toRotate), false));
+    final Expr toRotateInRange = exprManager.mkExpr(Kind.BITVECTOR_UREM, toRotate, size);
+    return or(
+        shiftLeft(pNumber, toRotateInRange),
+        shiftRight(pNumber, subtract(size, toRotateInRange), false));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5BitvectorFormulaManager.java
@@ -166,7 +166,10 @@ public class CVC5BitvectorFormulaManager
     // toRotate) (bvlshr pNumber (bvsub size toRotate)))
     final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
     final Term size = this.makeBitvectorImpl(bitsize, bitsize);
-    return or(shiftLeft(pNumber, toRotate), shiftRight(pNumber, subtract(size, toRotate), false));
+    final Term toRotateInRange = solver.mkTerm(Kind.BITVECTOR_UREM, toRotate, size);
+    return or(
+        shiftLeft(pNumber, toRotateInRange),
+        shiftRight(pNumber, subtract(size, toRotateInRange), false));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5BitvectorFormulaManager.java
@@ -146,12 +146,18 @@ public class CVC5BitvectorFormulaManager
       throw new IllegalArgumentException(
           String.format("You tried rotation a bitvector %s with shift %d", pNumber, pToRotate), e);
     }
+  }
+
+  @Override
   protected Term rotateRight(Term pNumber, Term toRotate) {
     // cvc5 does not support non-literal rotation, so we rewrite it to (bvor (bvlshr pNumber
     // toRotate) (bvshl pNumber (bvsub size toRotate)))
     final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
     final Term size = this.makeBitvectorImpl(bitsize, bitsize);
-    return or(shiftRight(pNumber, toRotate, false), shiftLeft(pNumber, subtract(size, toRotate)));
+    final Term toRotateInRange = solver.mkTerm(Kind.BITVECTOR_UREM, toRotate, size);
+    return or(
+        shiftRight(pNumber, toRotateInRange, false),
+        shiftLeft(pNumber, subtract(size, toRotateInRange)));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5BitvectorFormulaManager.java
@@ -8,7 +8,6 @@
 
 package org.sosy_lab.java_smt.solvers.cvc5;
 
-import edu.stanford.CVC4.Expr;
 import io.github.cvc5.CVC5ApiException;
 import io.github.cvc5.Kind;
 import io.github.cvc5.Op;

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5BitvectorFormulaManager.java
@@ -8,6 +8,7 @@
 
 package org.sosy_lab.java_smt.solvers.cvc5;
 
+import edu.stanford.CVC4.Expr;
 import io.github.cvc5.CVC5ApiException;
 import io.github.cvc5.Kind;
 import io.github.cvc5.Op;
@@ -16,6 +17,7 @@ import io.github.cvc5.Sort;
 import io.github.cvc5.Term;
 import java.math.BigInteger;
 import java.util.List;
+import org.sosy_lab.java_smt.api.FormulaType.BitvectorType;
 import org.sosy_lab.java_smt.basicimpl.AbstractBitvectorFormulaManager;
 
 public class CVC5BitvectorFormulaManager
@@ -145,6 +147,21 @@ public class CVC5BitvectorFormulaManager
       throw new IllegalArgumentException(
           String.format("You tried rotation a bitvector %s with shift %d", pNumber, pToRotate), e);
     }
+  protected Term rotateRight(Term pNumber, Term toRotate) {
+    // cvc5 does not support non-literal rotation, so we rewrite it to (bvor (bvlshr pNumber
+    // toRotate) (bvshl pNumber (bvsub size toRotate)))
+    final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
+    final Term size = this.makeBitvectorImpl(bitsize, bitsize);
+    return or(shiftRight(pNumber, toRotate, false), shiftLeft(pNumber, subtract(size, toRotate)));
+  }
+
+  @Override
+  protected Term rotateLeft(Term pNumber, Term toRotate) {
+    // cvc5 does not support non-literal rotation, so we rewrite it to (bvor (bvshl pNumber
+    // toRotate) (bvlshr pNumber (bvsub size toRotate)))
+    final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
+    final Term size = this.makeBitvectorImpl(bitsize, bitsize);
+    return or(shiftLeft(pNumber, toRotate), shiftRight(pNumber, subtract(size, toRotate), false));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5BitvectorFormulaManager.java
@@ -39,7 +39,6 @@ import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_int_from_ubv;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_int_to_bv;
 
-import edu.stanford.CVC4.Expr;
 import java.math.BigInteger;
 import org.sosy_lab.java_smt.api.FormulaType.BitvectorType;
 import org.sosy_lab.java_smt.basicimpl.AbstractBitvectorFormulaManager;

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5BitvectorFormulaManager.java
@@ -136,12 +136,18 @@ class Mathsat5BitvectorFormulaManager
   @Override
   public Long rotateRightByConstant(Long number, int toRotate) {
     return msat_make_bv_ror(mathsatEnv, toRotate, number);
+  }
+
+  @Override
   protected Long rotateRight(Long pNumber, Long toRotate) {
     // MathSAT5 does not support non-literal rotation, so we rewrite it to (bvor (bvlshr pNumber
     // toRotate) (bvshl pNumber (bvsub size toRotate)))
     final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
-    final Long size = this.makeBitvectorImpl(bitsize, bitsize);
-    return or(shiftRight(pNumber, toRotate, false), shiftLeft(pNumber, subtract(size, toRotate)));
+    final Long size = makeBitvectorImpl(bitsize, bitsize);
+    final Long toRotateInRange = msat_make_bv_urem(mathsatEnv, toRotate, size);
+    return or(
+        shiftRight(pNumber, toRotateInRange, false),
+        shiftLeft(pNumber, subtract(size, toRotateInRange)));
   }
 
   @Override
@@ -150,7 +156,10 @@ class Mathsat5BitvectorFormulaManager
     // toRotate) (bvlshr pNumber (bvsub size toRotate)))
     final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
     final Long size = this.makeBitvectorImpl(bitsize, bitsize);
-    return or(shiftLeft(pNumber, toRotate), shiftRight(pNumber, subtract(size, toRotate), false));
+    final Long toRotateInRange = msat_make_bv_urem(mathsatEnv, toRotate, size);
+    return or(
+        shiftLeft(pNumber, toRotateInRange),
+        shiftRight(pNumber, subtract(size, toRotateInRange), false));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessBitvectorFormulaManager.java
@@ -15,7 +15,6 @@ import ap.theories.bitvectors.ModuloArithmetic$;
 import ap.types.Sort;
 import ap.types.Sort$;
 import com.google.common.base.Preconditions;
-import edu.stanford.CVC4.Expr;
 import java.math.BigInteger;
 import org.sosy_lab.java_smt.api.FormulaType.BitvectorType;
 import org.sosy_lab.java_smt.basicimpl.AbstractBitvectorFormulaManager;

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessBitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessBitvectorFormulaManager.java
@@ -184,7 +184,11 @@ class PrincessBitvectorFormulaManager
     // toRotate) (bvshl pNumber (bvsub size toRotate)))
     final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
     final IExpression size = this.makeBitvectorImpl(bitsize, bitsize);
-    return or(shiftRight(pNumber, toRotate, false), shiftLeft(pNumber, subtract(size, toRotate)));
+    final IExpression toRotateInRange =
+        ModuloArithmetic$.MODULE$.bvurem((ITerm) toRotate, (ITerm) size);
+    return or(
+        shiftRight(pNumber, toRotateInRange, false),
+        shiftLeft(pNumber, subtract(size, toRotateInRange)));
   }
 
   @Override
@@ -193,7 +197,11 @@ class PrincessBitvectorFormulaManager
     // toRotate) (bvlshr pNumber (bvsub size toRotate)))
     final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
     final IExpression size = this.makeBitvectorImpl(bitsize, bitsize);
-    return or(shiftLeft(pNumber, toRotate), shiftRight(pNumber, subtract(size, toRotate), false));
+    final IExpression toRotateInRange =
+        ModuloArithmetic$.MODULE$.bvurem((ITerm) toRotate, (ITerm) size);
+    return or(
+        shiftLeft(pNumber, toRotateInRange),
+        shiftRight(pNumber, subtract(size, toRotateInRange), false));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2BitvectorFormulaManager.java
@@ -35,18 +35,14 @@ import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvsrem;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvsub;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_bvxor2;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_parse_bvbin;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_rotate_left;
-import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_rotate_right;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_sign_extend;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_zero_extend;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import edu.stanford.CVC4.Expr;
 import java.math.BigInteger;
 import org.sosy_lab.java_smt.api.FormulaType.BitvectorType;
 import org.sosy_lab.java_smt.basicimpl.AbstractBitvectorFormulaManager;
-import scala.Int;
 
 public class Yices2BitvectorFormulaManager
     extends AbstractBitvectorFormulaManager<Integer, Integer, Long, Integer> {

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2BitvectorFormulaManager.java
@@ -210,7 +210,7 @@ public class Yices2BitvectorFormulaManager
     // toRotate) (bvshl pNumber (bvsub size toRotate)))
     final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
     final Integer size = this.makeBitvectorImpl(bitsize, bitsize);
-    final Integer toRotateInRange = yices_bvrem(pNumber, toRotate);
+    final Integer toRotateInRange = yices_bvrem(toRotate, size);
     return or(
         shiftRight(pNumber, toRotateInRange, false),
         shiftLeft(pNumber, subtract(size, toRotateInRange)));
@@ -222,7 +222,7 @@ public class Yices2BitvectorFormulaManager
     // toRotate) (bvlshr pNumber (bvsub size toRotate)))
     final int bitsize = ((BitvectorType) formulaCreator.getFormulaType(pNumber)).getSize();
     final Integer size = this.makeBitvectorImpl(bitsize, bitsize);
-    final Integer toRotateInRange = yices_bvrem(pNumber, toRotate);
+    final Integer toRotateInRange = yices_bvrem(toRotate, size);
     return or(
         shiftLeft(pNumber, toRotateInRange),
         shiftRight(pNumber, subtract(size, toRotateInRange), false));

--- a/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
@@ -466,8 +466,6 @@ public class BitvectorFormulaManagerTest extends SolverBasedTest0.ParameterizedS
 
   @Test
   public void bvRotateByBV() throws SolverException, InterruptedException {
-    requireBitvectorRotation();
-
     for (int bitsize : new int[] {8, 13, 25, 31}) {
       BitvectorFormula zero = bvmgr.makeBitvector(bitsize, 0);
       BitvectorFormula a = bvmgr.makeVariable(bitsize, "a" + bitsize);

--- a/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
@@ -466,6 +466,10 @@ public class BitvectorFormulaManagerTest extends SolverBasedTest0.ParameterizedS
 
   @Test
   public void bvRotateByBV() throws SolverException, InterruptedException {
+    assume()
+        .withMessage("Princess seems to be way too slow for this test")
+        .that(solver)
+        .isNotEqualTo(Solvers.PRINCESS);
     for (int bitsize : new int[] {8, 13, 25, 31}) {
       BitvectorFormula zero = bvmgr.makeBitvector(bitsize, 0);
       BitvectorFormula a = bvmgr.makeVariable(bitsize, "a" + bitsize);

--- a/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
@@ -500,8 +500,6 @@ public class BitvectorFormulaManagerTest extends SolverBasedTest0.ParameterizedS
 
   @Test
   public void bvIsIdenticalAfterFullRotation() throws SolverException, InterruptedException {
-    requireBitvectorRotation();
-
     for (int bitsize : new int[] {2, 4, 8, 16, 32, 55}) {
       BitvectorFormula number = bvmgr.makeVariable(bitsize, "NUM_ROT_" + bitsize);
       for (int multiplier : new int[] {0, 1, 2, 5, 17, 37, 111, 1111}) {

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -233,15 +233,6 @@ public abstract class SolverBasedTest0 {
         .isNotEqualTo(Solvers.YICES2);
   }
 
-  protected final void requireBitvectorRotation() {
-    assume()
-        .withMessage(
-            "Solver %s does not yet support the rotation of bitvectors by arbitrary shift",
-            solverToUse())
-        .that(solverToUse())
-        .isNoneOf(Solvers.CVC4, Solvers.CVC5, Solvers.MATHSAT5, Solvers.PRINCESS, Solvers.YICES2);
-  }
-
   /** Skip test if the solver does not support quantifiers. */
   protected final void requireQuantifiers() {
     assume()


### PR DESCRIPTION
As discussed in https://github.com/sosy-lab/java-smt/issues/360, this PR ~adds~ enhances the rotateRight and rotateLeft operations in the bitvector formula manager. 

I added implementations for solvers that do not directly support rotation-by-bitvector, by using shift operations. Therefore, all bitvector-supporting solvers can also use rotation now. 