### PR TITLE
Add fp.rem operation to FloatingPointFormulaManager

### DIFF
--- a/src/org/sosy_lab/java_smt/api/FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/FloatingPointFormulaManager.java
@@ -8,7 +8,6 @@
 
 package org.sosy_lab.java_smt.api;
 
-import com.microsoft.z3.Native;
 import java.math.BigDecimal;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.FormulaType.FloatingPointType;
@@ -203,11 +202,10 @@ public interface FloatingPointFormulaManager {
       FloatingPointRoundingMode pFloatingPointRoundingMode);
 
   /**
-   * remainder: x - y * n, where n in Z is nearest to x/y
+   * remainder: x - y * n, where n in Z is nearest to x/y. Can be negative even or two positive
+   * arguments (as opposed to integer modulo operators)
    */
-  FloatingPointFormula remainder(
-      FloatingPointFormula number1,
-      FloatingPointFormula number2);
+  FloatingPointFormula remainder(FloatingPointFormula number1, FloatingPointFormula number2);
 
   // ----------------- Numeric relations, return type BooleanFormula -----------------
 

--- a/src/org/sosy_lab/java_smt/api/FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/FloatingPointFormulaManager.java
@@ -202,10 +202,11 @@ public interface FloatingPointFormulaManager {
       FloatingPointRoundingMode pFloatingPointRoundingMode);
 
   /**
-   * remainder: x - y * n, where n in Z is nearest to x/y. Can be negative even or two positive
-   * arguments (as opposed to integer modulo operators)
+   * remainder: x - y * n, where n in Z is nearest to x/y. The result can be negative even for two
+   * positive arguments, e.g. "rem(5, 4) == 1" and "rem(5, 6) == -1", as opposed to integer modulo
+   * operators.
    */
-  FloatingPointFormula remainder(FloatingPointFormula number1, FloatingPointFormula number2);
+  FloatingPointFormula remainder(FloatingPointFormula dividend, FloatingPointFormula divisor);
 
   // ----------------- Numeric relations, return type BooleanFormula -----------------
 

--- a/src/org/sosy_lab/java_smt/api/FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/FloatingPointFormulaManager.java
@@ -8,6 +8,7 @@
 
 package org.sosy_lab.java_smt.api;
 
+import com.microsoft.z3.Native;
 import java.math.BigDecimal;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.FormulaType.FloatingPointType;
@@ -200,6 +201,13 @@ public interface FloatingPointFormulaManager {
       FloatingPointFormula number1,
       FloatingPointFormula number2,
       FloatingPointRoundingMode pFloatingPointRoundingMode);
+
+  /**
+   * remainder: x - y * n, where n in Z is nearest to x/y
+   */
+  FloatingPointFormula remainder(
+      FloatingPointFormula number1,
+      FloatingPointFormula number2);
 
   // ----------------- Numeric relations, return type BooleanFormula -----------------
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractFloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractFloatingPointFormulaManager.java
@@ -376,8 +376,7 @@ public abstract class AbstractFloatingPointFormulaManager<TFormulaInfo, TType, T
 
   @Override
   public FloatingPointFormula remainder(
-      FloatingPointFormula number1,
-      FloatingPointFormula number2) {
+      FloatingPointFormula number1, FloatingPointFormula number2) {
     return wrap(remainder(extractInfo(number1), extractInfo(number2)));
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractFloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractFloatingPointFormulaManager.java
@@ -375,6 +375,15 @@ public abstract class AbstractFloatingPointFormulaManager<TFormulaInfo, TType, T
       TFormulaInfo pParam1, TFormulaInfo pParam2, TFormulaInfo pFloatingPointRoundingMode);
 
   @Override
+  public FloatingPointFormula remainder(
+      FloatingPointFormula number1,
+      FloatingPointFormula number2) {
+    return wrap(remainder(extractInfo(number1), extractInfo(number2)));
+  }
+
+  protected abstract TFormulaInfo remainder(TFormulaInfo pParam1, TFormulaInfo pParam2);
+
+  @Override
   public BooleanFormula assignment(FloatingPointFormula pNumber1, FloatingPointFormula pNumber2) {
     TFormulaInfo param1 = extractInfo(pNumber1);
     TFormulaInfo param2 = extractInfo(pNumber2);

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsFloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsFloatingPointFormulaManager.java
@@ -264,6 +264,14 @@ class StatisticsFloatingPointFormulaManager implements FloatingPointFormulaManag
   }
 
   @Override
+  public FloatingPointFormula remainder(
+      FloatingPointFormula number1,
+      FloatingPointFormula number2) {
+    stats.fpOperations.getAndIncrement();
+    return delegate.remainder(number1, number2);
+  }
+
+  @Override
   public BooleanFormula assignment(FloatingPointFormula pNumber1, FloatingPointFormula pNumber2) {
     stats.fpOperations.getAndIncrement();
     return delegate.assignment(pNumber1, pNumber2);

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsFloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsFloatingPointFormulaManager.java
@@ -265,8 +265,7 @@ class StatisticsFloatingPointFormulaManager implements FloatingPointFormulaManag
 
   @Override
   public FloatingPointFormula remainder(
-      FloatingPointFormula number1,
-      FloatingPointFormula number2) {
+      FloatingPointFormula number1, FloatingPointFormula number2) {
     stats.fpOperations.getAndIncrement();
     return delegate.remainder(number1, number2);
   }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedFloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedFloatingPointFormulaManager.java
@@ -299,8 +299,7 @@ class SynchronizedFloatingPointFormulaManager implements FloatingPointFormulaMan
 
   @Override
   public FloatingPointFormula remainder(
-      FloatingPointFormula number1,
-      FloatingPointFormula number2) {
+      FloatingPointFormula number1, FloatingPointFormula number2) {
     synchronized (sync) {
       return delegate.remainder(number1, number2);
     }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedFloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedFloatingPointFormulaManager.java
@@ -298,6 +298,15 @@ class SynchronizedFloatingPointFormulaManager implements FloatingPointFormulaMan
   }
 
   @Override
+  public FloatingPointFormula remainder(
+      FloatingPointFormula number1,
+      FloatingPointFormula number2) {
+    synchronized (sync) {
+      return delegate.remainder(number1, number2);
+    }
+  }
+
+  @Override
   public BooleanFormula assignment(FloatingPointFormula pNumber1, FloatingPointFormula pNumber2) {
     synchronized (sync) {
       return delegate.assignment(pNumber1, pNumber2);

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FloatingPointFormulaManager.java
@@ -281,6 +281,11 @@ public class CVC4FloatingPointFormulaManager
   }
 
   @Override
+  protected Expr remainder(Expr pParam1, Expr pParam2) {
+    return exprManager.mkExpr(Kind.FLOATINGPOINT_REM, pParam1, pParam2);
+  }
+
+  @Override
   protected Expr assignment(Expr pParam1, Expr pParam2) {
     return exprManager.mkExpr(Kind.EQUAL, pParam1, pParam2);
   }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FloatingPointFormulaManager.java
@@ -318,6 +318,11 @@ public class CVC5FloatingPointFormulaManager
   }
 
   @Override
+  protected Term remainder(Term pParam1, Term pParam2) {
+    return solver.mkTerm(Kind.FLOATINGPOINT_REM, pParam1, pParam2);
+  }
+
+  @Override
   protected Term assignment(Term pParam1, Term pParam2) {
     return solver.mkTerm(Kind.EQUAL, pParam1, pParam2);
   }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5FloatingPointFormulaManager.java
@@ -249,6 +249,11 @@ class Mathsat5FloatingPointFormulaManager
   }
 
   @Override
+  protected Long remainder(Long pParam1, Long pParam2) {
+    throw new UnsupportedOperationException("MathSAT5 does not implement fp.rem");
+  }
+
+  @Override
   protected Long divide(Long pNumber1, Long pNumber2, Long pRoundingMode) {
     return msat_make_fp_div(mathsatEnv, pRoundingMode, pNumber1, pNumber2);
   }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FloatingPointFormulaManager.java
@@ -217,6 +217,11 @@ class Z3FloatingPointFormulaManager
   }
 
   @Override
+  protected Long remainder(Long pParam1, Long pParam2) {
+    return Native.mkFpaRem(z3context, pParam1, pParam2);
+  }
+
+  @Override
   protected Long divide(Long pNumber1, Long pNumber2, Long pRoundingMode) {
     return Native.mkFpaDiv(z3context, pRoundingMode, pNumber1, pNumber2);
   }

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -198,6 +198,83 @@ public class FloatingPointFormulaManagerTest
   }
 
   @Test
+  public void fpremNormal() throws SolverException, InterruptedException {
+    assume()
+        .withMessage("MathSAT5 does not implement fp.rem")
+        .that(solver == Solvers.MATHSAT5)
+        .isFalse();
+
+    for (FloatingPointType prec : new FloatingPointType[]{singlePrecType, doublePrecType,
+        FormulaType.getFloatingPointType(5, 6)}) {
+
+      final FloatingPointFormula five = fpmgr.makeNumber(5, prec);
+      final FloatingPointFormula four = fpmgr.makeNumber(4, prec);
+      final FloatingPointFormula six = fpmgr.makeNumber(6, prec);
+
+      final FloatingPointFormula one = fpmgr.makeNumber(1, prec);
+      final FloatingPointFormula minusOne = fpmgr.makeNumber(-1, prec);
+
+      final FloatingPointFormula expr1 = fpmgr.remainder(five, four);
+      final FloatingPointFormula expr2 = fpmgr.remainder(five, six);
+
+      assertThatFormula(fpmgr.assignment(expr1, one)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr2, minusOne)).isTautological();
+    }
+  }
+
+  @Test
+  public void fpremSpecial() throws SolverException, InterruptedException {
+    assume()
+        .withMessage("MathSAT5 does not implement fp.rem")
+        .that(solver == Solvers.MATHSAT5)
+        .isFalse();
+
+    for (FloatingPointType prec : new FloatingPointType[]{singlePrecType, doublePrecType,
+        FormulaType.getFloatingPointType(5, 6)}) {
+
+      final FloatingPointFormula num = fpmgr.makeNumber(42, prec);
+
+      final FloatingPointFormula nan = fpmgr.makeNumber("NaN", prec);
+      final FloatingPointFormula zero = fpmgr.makeNumber("0", prec);
+      final FloatingPointFormula inf = fpmgr.makePlusInfinity(prec);
+
+      final FloatingPointFormula minusNan = fpmgr.makeNumber("-NaN", prec);
+      final FloatingPointFormula minusZero = fpmgr.makeNumber("0", prec);
+      final FloatingPointFormula minusInf = fpmgr.makeMinusInfinity(prec);
+
+
+      final FloatingPointFormula expr1 = fpmgr.remainder(nan, nan);
+      final FloatingPointFormula expr2 = fpmgr.remainder(zero, zero);
+      final FloatingPointFormula expr3 = fpmgr.remainder(inf, inf);
+
+      final FloatingPointFormula expr4 = fpmgr.remainder(minusNan, minusNan);
+      final FloatingPointFormula expr5 = fpmgr.remainder(minusZero, minusZero);
+      final FloatingPointFormula expr6 = fpmgr.remainder(minusInf, minusInf);
+
+      final FloatingPointFormula expr7 = fpmgr.remainder(num, nan);
+      final FloatingPointFormula expr8 = fpmgr.remainder(num, zero);
+      final FloatingPointFormula expr9 = fpmgr.remainder(num, inf);
+
+      final FloatingPointFormula expr10 = fpmgr.remainder(num, minusNan);
+      final FloatingPointFormula expr11 = fpmgr.remainder(num, minusZero);
+      final FloatingPointFormula expr12 = fpmgr.remainder(num, minusInf);
+
+      assertThatFormula(fpmgr.assignment(expr1, nan)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr2, nan)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr3, nan)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr4, nan)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr5, nan)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr6, nan)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr7, nan)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr8, nan)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr9, num)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr10, nan)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr11, nan)).isTautological();
+      assertThatFormula(fpmgr.assignment(expr12, num)).isTautological();
+    }
+  }
+
+  @Test
   public void specialValueFunctions() throws SolverException, InterruptedException {
     assertThatFormula(fpmgr.isInfinity(posInf)).isTautological();
     assertThatFormula(fpmgr.isNormal(posInf)).isUnsatisfiable();

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -144,7 +144,7 @@ public class FloatingPointFormulaManagerTest
 
   @Test
   public void nanAssignedNanIsTrue() throws SolverException, InterruptedException {
-    assertEqualAsFormula(nan, nan);
+    assertEqualsAsFormula(nan, nan);
   }
 
   @Test
@@ -206,8 +206,8 @@ public class FloatingPointFormulaManagerTest
       final FloatingPointFormula numOne = fpmgr.makeNumber(1, prec);
       final FloatingPointFormula numMinusOne = fpmgr.makeNumber(-1, prec);
 
-      assertEqualAsFormula(fpmgr.remainder(numFive, numFour), numOne);
-      assertEqualAsFormula(fpmgr.remainder(numFive, numSix), numMinusOne);
+      assertEqualsAsFormula(fpmgr.remainder(numFive, numFour), numOne);
+      assertEqualsAsFormula(fpmgr.remainder(numFive, numSix), numMinusOne);
     }
   }
 
@@ -233,18 +233,18 @@ public class FloatingPointFormulaManagerTest
       final FloatingPointFormula minusZero = fpmgr.makeNumber("0", prec);
       final FloatingPointFormula minusInf = fpmgr.makeMinusInfinity(prec);
 
-      assertEqualAsFormula(fpmgr.remainder(fpNan, fpNan), fpNan);
-      assertEqualAsFormula(fpmgr.remainder(fpZero, fpZero), fpNan);
-      assertEqualAsFormula(fpmgr.remainder(fpInf, fpInf), fpNan);
-      assertEqualAsFormula(fpmgr.remainder(minusNan, minusNan), fpNan);
-      assertEqualAsFormula(fpmgr.remainder(minusZero, minusZero), fpNan);
-      assertEqualAsFormula(fpmgr.remainder(minusInf, minusInf), fpNan);
-      assertEqualAsFormula(fpmgr.remainder(num, fpNan), fpNan);
-      assertEqualAsFormula(fpmgr.remainder(num, fpZero), fpNan);
-      assertEqualAsFormula(fpmgr.remainder(num, fpInf), num);
-      assertEqualAsFormula(fpmgr.remainder(num, minusNan), fpNan);
-      assertEqualAsFormula(fpmgr.remainder(num, minusZero), fpNan);
-      assertEqualAsFormula(fpmgr.remainder(num, minusInf), num);
+      assertEqualsAsFormula(fpmgr.remainder(fpNan, fpNan), fpNan);
+      assertEqualsAsFormula(fpmgr.remainder(fpZero, fpZero), fpNan);
+      assertEqualsAsFormula(fpmgr.remainder(fpInf, fpInf), fpNan);
+      assertEqualsAsFormula(fpmgr.remainder(minusNan, minusNan), fpNan);
+      assertEqualsAsFormula(fpmgr.remainder(minusZero, minusZero), fpNan);
+      assertEqualsAsFormula(fpmgr.remainder(minusInf, minusInf), fpNan);
+      assertEqualsAsFormula(fpmgr.remainder(num, fpNan), fpNan);
+      assertEqualsAsFormula(fpmgr.remainder(num, fpZero), fpNan);
+      assertEqualsAsFormula(fpmgr.remainder(num, fpInf), num);
+      assertEqualsAsFormula(fpmgr.remainder(num, minusNan), fpNan);
+      assertEqualsAsFormula(fpmgr.remainder(num, minusZero), fpNan);
+      assertEqualsAsFormula(fpmgr.remainder(num, minusInf), num);
     }
   }
 
@@ -558,7 +558,7 @@ public class FloatingPointFormulaManagerTest
     assertThatFormula(fpmgr.equalWithFPSemantics(f1, f2)).isTautological();
   }
 
-  private void assertEqualAsFormula(FloatingPointFormula f1, FloatingPointFormula f2)
+  private void assertEqualsAsFormula(FloatingPointFormula f1, FloatingPointFormula f2)
       throws SolverException, InterruptedException {
     assertThatFormula(fpmgr.assignment(f1, f2)).isTautological();
   }

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -88,14 +88,13 @@ public class FloatingPointFormulaManagerTest
       FloatingPointFormula formula = fpmgr.makeNumber(d, singlePrecType);
       assertThatFormula(fpmgr.isNegative(formula)).isTautological();
       assertThatFormula(fpmgr.isNegative(fpmgr.negate(formula))).isUnsatisfiable();
-      assertThatFormula(fpmgr.equalWithFPSemantics(fpmgr.negate(formula), fpmgr.abs(formula)))
-          .isTautological();
+      assertEqualsAsFp(fpmgr.negate(formula), fpmgr.abs(formula));
     }
     for (double d : new double[] {1, 2, 0.0, Double.POSITIVE_INFINITY}) {
       FloatingPointFormula formula = fpmgr.makeNumber(d, singlePrecType);
       assertThatFormula(fpmgr.isNegative(formula)).isUnsatisfiable();
       assertThatFormula(fpmgr.isNegative(fpmgr.negate(formula))).isTautological();
-      assertThatFormula(fpmgr.equalWithFPSemantics(formula, fpmgr.abs(formula))).isTautological();
+      assertEqualsAsFp(formula, fpmgr.abs(formula));
     }
   }
 
@@ -105,20 +104,19 @@ public class FloatingPointFormulaManagerTest
       FloatingPointFormula formula = fpmgr.makeNumber(s, singlePrecType);
       assertThatFormula(fpmgr.isNegative(formula)).isTautological();
       assertThatFormula(fpmgr.isNegative(fpmgr.negate(formula))).isUnsatisfiable();
-      assertThatFormula(fpmgr.equalWithFPSemantics(fpmgr.negate(formula), fpmgr.abs(formula)))
-          .isTautological();
+      assertEqualsAsFp(fpmgr.negate(formula), fpmgr.abs(formula));
     }
     for (String s : new String[] {"1", "Infinity", "0", "0.0", "0.000"}) {
       FloatingPointFormula formula = fpmgr.makeNumber(s, singlePrecType);
       assertThatFormula(fpmgr.isNegative(formula)).isUnsatisfiable();
       assertThatFormula(fpmgr.isNegative(fpmgr.negate(formula))).isTautological();
-      assertThatFormula(fpmgr.equalWithFPSemantics(formula, fpmgr.abs(formula))).isTautological();
+      assertEqualsAsFp(formula, fpmgr.abs(formula));
     }
     for (String s : new String[] {"+1", "+Infinity", "+0", "+0.0", "+0.000"}) {
       FloatingPointFormula formula = fpmgr.makeNumber(s, singlePrecType);
       assertThatFormula(fpmgr.isNegative(formula)).isUnsatisfiable();
       assertThatFormula(fpmgr.isNegative(fpmgr.negate(formula))).isTautological();
-      assertThatFormula(fpmgr.equalWithFPSemantics(formula, fpmgr.abs(formula))).isTautological();
+      assertEqualsAsFp(formula, fpmgr.abs(formula));
     }
     // NaN is not positive and not negative.
     for (String s : new String[] {"NaN", "-NaN", "+NaN"}) {
@@ -146,7 +144,7 @@ public class FloatingPointFormulaManagerTest
 
   @Test
   public void nanAssignedNanIsTrue() throws SolverException, InterruptedException {
-    assertThatFormula(fpmgr.assignment(nan, nan)).isTautological();
+    assertEqualAsFormula(nan, nan);
   }
 
   @Test
@@ -157,15 +155,12 @@ public class FloatingPointFormulaManagerTest
 
     assertThatFormula(bmgr.and(order1, order2, order3)).isTautological();
 
-    assertThatFormula(fpmgr.equalWithFPSemantics(fpmgr.max(posInf, zero), posInf)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(fpmgr.max(posInf, negInf), posInf))
-        .isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(fpmgr.max(negInf, zero), zero)).isTautological();
-
-    assertThatFormula(fpmgr.equalWithFPSemantics(fpmgr.min(posInf, zero), zero)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(fpmgr.min(posInf, negInf), negInf))
-        .isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(fpmgr.min(negInf, zero), negInf)).isTautological();
+    assertEqualsAsFp(fpmgr.max(posInf, zero), posInf);
+    assertEqualsAsFp(fpmgr.max(posInf, negInf), posInf);
+    assertEqualsAsFp(fpmgr.max(negInf, zero), zero);
+    assertEqualsAsFp(fpmgr.min(posInf, zero), zero);
+    assertEqualsAsFp(fpmgr.min(posInf, negInf), negInf);
+    assertEqualsAsFp(fpmgr.min(negInf, zero), negInf);
   }
 
   @Test
@@ -182,54 +177,46 @@ public class FloatingPointFormulaManagerTest
   @Test
   public void sqrt() throws SolverException, InterruptedException {
     for (double d : new double[] {0.25, 1, 2, 4, 9, 15, 1234, 1000000}) {
-      assertThatFormula(
-              fpmgr.equalWithFPSemantics(
-                  fpmgr.sqrt(fpmgr.makeNumber(d * d, doublePrecType)),
-                  fpmgr.makeNumber(d, doublePrecType)))
-          .isTautological();
-      assertThatFormula(
-              fpmgr.equalWithFPSemantics(
-                  fpmgr.sqrt(fpmgr.makeNumber(d, doublePrecType)),
-                  fpmgr.makeNumber(Math.sqrt(d), doublePrecType)))
-          .isTautological();
+      assertEqualsAsFp(
+          fpmgr.sqrt(fpmgr.makeNumber(d * d, doublePrecType)), fpmgr.makeNumber(d, doublePrecType));
+      assertEqualsAsFp(
+          fpmgr.sqrt(fpmgr.makeNumber(d, doublePrecType)),
+          fpmgr.makeNumber(Math.sqrt(d), doublePrecType));
       assertThatFormula(fpmgr.isNaN(fpmgr.sqrt(fpmgr.makeNumber(-d, doublePrecType))))
           .isTautological();
     }
   }
 
   @Test
-  public void fpremNormal() throws SolverException, InterruptedException {
+  public void fpRemainderNormal() throws SolverException, InterruptedException {
     assume()
         .withMessage("MathSAT5 does not implement fp.rem")
-        .that(solver == Solvers.MATHSAT5)
-        .isFalse();
+        .that(solver)
+        .isNotEqualTo(Solvers.MATHSAT5);
 
     for (FloatingPointType prec :
         new FloatingPointType[] {
           singlePrecType, doublePrecType, FormulaType.getFloatingPointType(5, 6)
         }) {
 
-      final FloatingPointFormula five = fpmgr.makeNumber(5, prec);
-      final FloatingPointFormula four = fpmgr.makeNumber(4, prec);
-      final FloatingPointFormula six = fpmgr.makeNumber(6, prec);
+      final FloatingPointFormula numFive = fpmgr.makeNumber(5, prec);
+      final FloatingPointFormula numFour = fpmgr.makeNumber(4, prec);
+      final FloatingPointFormula numSix = fpmgr.makeNumber(6, prec);
 
-      final FloatingPointFormula one = fpmgr.makeNumber(1, prec);
-      final FloatingPointFormula minusOne = fpmgr.makeNumber(-1, prec);
+      final FloatingPointFormula numOne = fpmgr.makeNumber(1, prec);
+      final FloatingPointFormula numMinusOne = fpmgr.makeNumber(-1, prec);
 
-      final FloatingPointFormula expr1 = fpmgr.remainder(five, four);
-      final FloatingPointFormula expr2 = fpmgr.remainder(five, six);
-
-      assertThatFormula(fpmgr.assignment(expr1, one)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr2, minusOne)).isTautological();
+      assertEqualAsFormula(fpmgr.remainder(numFive, numFour), numOne);
+      assertEqualAsFormula(fpmgr.remainder(numFive, numSix), numMinusOne);
     }
   }
 
   @Test
-  public void fpremSpecial() throws SolverException, InterruptedException {
+  public void fpRemainderSpecial() throws SolverException, InterruptedException {
     assume()
         .withMessage("MathSAT5 does not implement fp.rem")
-        .that(solver == Solvers.MATHSAT5)
-        .isFalse();
+        .that(solver)
+        .isNotEqualTo(Solvers.MATHSAT5);
 
     for (FloatingPointType prec :
         new FloatingPointType[] {
@@ -238,42 +225,26 @@ public class FloatingPointFormulaManagerTest
 
       final FloatingPointFormula num = fpmgr.makeNumber(42, prec);
 
-      final FloatingPointFormula nan = fpmgr.makeNumber("NaN", prec);
-      final FloatingPointFormula zero = fpmgr.makeNumber("0", prec);
-      final FloatingPointFormula inf = fpmgr.makePlusInfinity(prec);
+      final FloatingPointFormula fpNan = fpmgr.makeNumber("NaN", prec);
+      final FloatingPointFormula fpZero = fpmgr.makeNumber("0", prec);
+      final FloatingPointFormula fpInf = fpmgr.makePlusInfinity(prec);
 
       final FloatingPointFormula minusNan = fpmgr.makeNumber("-NaN", prec);
       final FloatingPointFormula minusZero = fpmgr.makeNumber("0", prec);
       final FloatingPointFormula minusInf = fpmgr.makeMinusInfinity(prec);
 
-      final FloatingPointFormula expr1 = fpmgr.remainder(nan, nan);
-      final FloatingPointFormula expr2 = fpmgr.remainder(zero, zero);
-      final FloatingPointFormula expr3 = fpmgr.remainder(inf, inf);
-
-      final FloatingPointFormula expr4 = fpmgr.remainder(minusNan, minusNan);
-      final FloatingPointFormula expr5 = fpmgr.remainder(minusZero, minusZero);
-      final FloatingPointFormula expr6 = fpmgr.remainder(minusInf, minusInf);
-
-      final FloatingPointFormula expr7 = fpmgr.remainder(num, nan);
-      final FloatingPointFormula expr8 = fpmgr.remainder(num, zero);
-      final FloatingPointFormula expr9 = fpmgr.remainder(num, inf);
-
-      final FloatingPointFormula expr10 = fpmgr.remainder(num, minusNan);
-      final FloatingPointFormula expr11 = fpmgr.remainder(num, minusZero);
-      final FloatingPointFormula expr12 = fpmgr.remainder(num, minusInf);
-
-      assertThatFormula(fpmgr.assignment(expr1, nan)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr2, nan)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr3, nan)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr4, nan)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr5, nan)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr6, nan)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr7, nan)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr8, nan)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr9, num)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr10, nan)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr11, nan)).isTautological();
-      assertThatFormula(fpmgr.assignment(expr12, num)).isTautological();
+      assertEqualAsFormula(fpmgr.remainder(fpNan, fpNan), fpNan);
+      assertEqualAsFormula(fpmgr.remainder(fpZero, fpZero), fpNan);
+      assertEqualAsFormula(fpmgr.remainder(fpInf, fpInf), fpNan);
+      assertEqualAsFormula(fpmgr.remainder(minusNan, minusNan), fpNan);
+      assertEqualAsFormula(fpmgr.remainder(minusZero, minusZero), fpNan);
+      assertEqualAsFormula(fpmgr.remainder(minusInf, minusInf), fpNan);
+      assertEqualAsFormula(fpmgr.remainder(num, fpNan), fpNan);
+      assertEqualAsFormula(fpmgr.remainder(num, fpZero), fpNan);
+      assertEqualAsFormula(fpmgr.remainder(num, fpInf), num);
+      assertEqualAsFormula(fpmgr.remainder(num, minusNan), fpNan);
+      assertEqualAsFormula(fpmgr.remainder(num, minusZero), fpNan);
+      assertEqualAsFormula(fpmgr.remainder(num, minusInf), num);
     }
   }
 
@@ -357,9 +328,9 @@ public class FloatingPointFormulaManagerTest
     FloatingPointFormula i2 =
         fpmgr.makeNumber(BigDecimal.TEN.pow(50).multiply(BigDecimal.valueOf(1.002)), smallType);
     FloatingPointFormula inf = fpmgr.makePlusInfinity(smallType);
-    assertThatFormula(fpmgr.equalWithFPSemantics(i1, i2)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(i1, inf)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(i2, inf)).isTautological();
+    assertEqualsAsFp(i1, i2);
+    assertEqualsAsFp(i1, inf);
+    assertEqualsAsFp(i2, inf);
     assertThatFormula(fpmgr.isInfinity(i1)).isTautological();
     assertThatFormula(fpmgr.isInfinity(i2)).isTautological();
 
@@ -371,9 +342,9 @@ public class FloatingPointFormulaManagerTest
         fpmgr.makeNumber(
             BigDecimal.TEN.pow(50).multiply(BigDecimal.valueOf(1.002)).negate(), smallType);
     FloatingPointFormula ninf = fpmgr.makeMinusInfinity(smallType);
-    assertThatFormula(fpmgr.equalWithFPSemantics(ni1, ni2)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(ni1, ninf)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(ni2, ninf)).isTautological();
+    assertEqualsAsFp(ni1, ni2);
+    assertEqualsAsFp(ni1, ninf);
+    assertEqualsAsFp(ni2, ninf);
     assertThatFormula(fpmgr.isInfinity(ni1)).isTautological();
     assertThatFormula(fpmgr.isInfinity(ni2)).isTautological();
     assertThatFormula(fpmgr.isNegative(ni1)).isTautological();
@@ -386,9 +357,9 @@ public class FloatingPointFormulaManagerTest
     FloatingPointFormula j2 =
         fpmgr.makeNumber(BigDecimal.TEN.pow(500).multiply(BigDecimal.valueOf(1.002)), smallType2);
     FloatingPointFormula jnf = fpmgr.makePlusInfinity(smallType);
-    assertThatFormula(fpmgr.equalWithFPSemantics(j1, j2)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(j1, jnf)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(j2, jnf)).isTautological();
+    assertEqualsAsFp(j1, j2);
+    assertEqualsAsFp(j1, jnf);
+    assertEqualsAsFp(j2, jnf);
     assertThatFormula(fpmgr.isInfinity(j1)).isTautological();
     assertThatFormula(fpmgr.isInfinity(j2)).isTautological();
 
@@ -400,9 +371,9 @@ public class FloatingPointFormulaManagerTest
         fpmgr.makeNumber(
             BigDecimal.TEN.pow(500).multiply(BigDecimal.valueOf(1.002)).negate(), smallType2);
     FloatingPointFormula njnf = fpmgr.makeMinusInfinity(smallType);
-    assertThatFormula(fpmgr.equalWithFPSemantics(nj1, nj2)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(nj1, njnf)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(nj2, njnf)).isTautological();
+    assertEqualsAsFp(nj1, nj2);
+    assertEqualsAsFp(nj1, njnf);
+    assertEqualsAsFp(nj2, njnf);
     assertThatFormula(fpmgr.isInfinity(nj1)).isTautological();
     assertThatFormula(fpmgr.isInfinity(nj2)).isTautological();
     assertThatFormula(fpmgr.isNegative(nj1)).isTautological();
@@ -499,9 +470,8 @@ public class FloatingPointFormulaManagerTest
     FloatingPointFormula narrowedNumber = fpmgr.castTo(doublePrecNumber, true, singlePrecType);
     FloatingPointFormula widenedNumber = fpmgr.castTo(singlePrecNumber, true, doublePrecType);
 
-    assertThatFormula(fpmgr.equalWithFPSemantics(narrowedNumber, singlePrecNumber))
-        .isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(widenedNumber, doublePrecNumber)).isTautological();
+    assertEqualsAsFp(narrowedNumber, singlePrecNumber);
+    assertEqualsAsFp(widenedNumber, doublePrecNumber);
 
     FloatingPointFormula doublePrecSmallNumber =
         fpmgr.makeNumber(5.877471754111438E-39, doublePrecType);
@@ -509,8 +479,7 @@ public class FloatingPointFormulaManagerTest
         fpmgr.makeNumber(5.877471754111438E-39, singlePrecType);
     FloatingPointFormula widenedSmallNumber =
         fpmgr.castTo(singlePrecSmallNumber, true, doublePrecType);
-    assertThatFormula(fpmgr.equalWithFPSemantics(widenedSmallNumber, doublePrecSmallNumber))
-        .isTautological();
+    assertEqualsAsFp(widenedSmallNumber, doublePrecSmallNumber);
   }
 
   @Test
@@ -536,8 +505,8 @@ public class FloatingPointFormulaManagerTest
     FloatingPointFormula signedBvToFp = fpmgr.castFrom(bv, true, prec);
     FloatingPointFormula unsignedBvToFp = fpmgr.castFrom(bv, false, prec);
 
-    assertThatFormula(fpmgr.equalWithFPSemantics(fp, signedBvToFp)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(fp, unsignedBvToFp)).isTautological();
+    assertEqualsAsFp(fp, signedBvToFp);
+    assertEqualsAsFp(fp, unsignedBvToFp);
   }
 
   /** check whether rounded input is equal to result with rounding-mode. */
@@ -561,32 +530,37 @@ public class FloatingPointFormulaManagerTest
     }
 
     // check values
-    assertEquals(
+    assertEqualsAsFp(
         fpmgr.makeNumber(toZero, singlePrecType),
         fpmgr.round(f, FloatingPointRoundingMode.TOWARD_ZERO));
 
-    assertEquals(
+    assertEqualsAsFp(
         fpmgr.makeNumber(pos, singlePrecType),
         fpmgr.round(f, FloatingPointRoundingMode.TOWARD_POSITIVE));
 
-    assertEquals(
+    assertEqualsAsFp(
         fpmgr.makeNumber(neg, singlePrecType),
         fpmgr.round(f, FloatingPointRoundingMode.TOWARD_NEGATIVE));
 
-    assertEquals(
+    assertEqualsAsFp(
         fpmgr.makeNumber(tiesEven, singlePrecType),
         fpmgr.round(f, FloatingPointRoundingMode.NEAREST_TIES_TO_EVEN));
 
     if (solver != Solvers.MATHSAT5) { // Mathsat does not support NEAREST_TIES_AWAY
-      assertEquals(
+      assertEqualsAsFp(
           fpmgr.makeNumber(tiesAway, singlePrecType),
           fpmgr.round(f, FloatingPointRoundingMode.NEAREST_TIES_AWAY));
     }
   }
 
-  private void assertEquals(FloatingPointFormula f1, FloatingPointFormula f2)
+  private void assertEqualsAsFp(FloatingPointFormula f1, FloatingPointFormula f2)
       throws SolverException, InterruptedException {
     assertThatFormula(fpmgr.equalWithFPSemantics(f1, f2)).isTautological();
+  }
+
+  private void assertEqualAsFormula(FloatingPointFormula f1, FloatingPointFormula f2)
+      throws SolverException, InterruptedException {
+    assertThatFormula(fpmgr.assignment(f1, f2)).isTautological();
   }
 
   @Test
@@ -631,8 +605,8 @@ public class FloatingPointFormulaManagerTest
     FloatingPointFormula unsignedBvToFpOne = fpmgr.castFrom(bvOne, false, singlePrecType);
     FloatingPointFormula signedBvToFpOne = fpmgr.castFrom(bvOne, true, singlePrecType);
 
-    assertThatFormula(fpmgr.equalWithFPSemantics(fpOne, signedBvToFpOne)).isTautological();
-    assertThatFormula(fpmgr.equalWithFPSemantics(fpMinInt, unsignedBvToFpOne)).isTautological();
+    assertEqualsAsFp(fpOne, signedBvToFpOne);
+    assertEqualsAsFp(fpMinInt, unsignedBvToFpOne);
   }
 
   @Test
@@ -909,7 +883,7 @@ public class FloatingPointFormulaManagerTest
       throws SolverException, InterruptedException {
     FloatingPointFormula ieeeFp = fpmgr.fromIeeeBitvector(bv, type);
     assertThat(mgr.getFormulaType(ieeeFp)).isEqualTo(mgr.getFormulaType(flt));
-    assertThatFormula(fpmgr.equalWithFPSemantics(flt, ieeeFp)).isTautological();
+    assertEqualsAsFp(flt, ieeeFp);
   }
 
   private void checkFP2BV(FloatingPointType type, BitvectorFormula bv, FloatingPointFormula flt)

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -204,8 +204,10 @@ public class FloatingPointFormulaManagerTest
         .that(solver == Solvers.MATHSAT5)
         .isFalse();
 
-    for (FloatingPointType prec : new FloatingPointType[]{singlePrecType, doublePrecType,
-        FormulaType.getFloatingPointType(5, 6)}) {
+    for (FloatingPointType prec :
+        new FloatingPointType[] {
+          singlePrecType, doublePrecType, FormulaType.getFloatingPointType(5, 6)
+        }) {
 
       final FloatingPointFormula five = fpmgr.makeNumber(5, prec);
       final FloatingPointFormula four = fpmgr.makeNumber(4, prec);
@@ -229,8 +231,10 @@ public class FloatingPointFormulaManagerTest
         .that(solver == Solvers.MATHSAT5)
         .isFalse();
 
-    for (FloatingPointType prec : new FloatingPointType[]{singlePrecType, doublePrecType,
-        FormulaType.getFloatingPointType(5, 6)}) {
+    for (FloatingPointType prec :
+        new FloatingPointType[] {
+          singlePrecType, doublePrecType, FormulaType.getFloatingPointType(5, 6)
+        }) {
 
       final FloatingPointFormula num = fpmgr.makeNumber(42, prec);
 
@@ -241,7 +245,6 @@ public class FloatingPointFormulaManagerTest
       final FloatingPointFormula minusNan = fpmgr.makeNumber("-NaN", prec);
       final FloatingPointFormula minusZero = fpmgr.makeNumber("0", prec);
       final FloatingPointFormula minusInf = fpmgr.makeMinusInfinity(prec);
-
 
       final FloatingPointFormula expr1 = fpmgr.remainder(nan, nan);
       final FloatingPointFormula expr2 = fpmgr.remainder(zero, zero);


### PR DESCRIPTION
As discussed in https://github.com/sosy-lab/java-smt/issues/360, this PR adds the fp.rem operation in the floatingpoint formula manager.

I also added some light tests, as to prove that the operation behaves as expected. Let me know if I should add more.