### PR TITLE
Add new floating point literal constructor using IEEE754 bitpattern

### DIFF
--- a/src/org/sosy_lab/java_smt/api/FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/FloatingPointFormulaManager.java
@@ -9,6 +9,7 @@
 package org.sosy_lab.java_smt.api;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.FormulaType.FloatingPointType;
 
@@ -40,6 +41,9 @@ public interface FloatingPointFormulaManager {
 
   FloatingPointFormula makeNumber(
       Rational n, FloatingPointType type, FloatingPointRoundingMode pFloatingPointRoundingMode);
+
+  FloatingPointFormula makeNumber(
+      BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type);
 
   /**
    * Creates a variable with exactly the given name.

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractFloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractFloatingPointFormulaManager.java
@@ -12,6 +12,7 @@ import static org.sosy_lab.java_smt.basicimpl.AbstractFormulaManager.checkVariab
 
 import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 import org.sosy_lab.common.rationals.Rational;
@@ -132,6 +133,15 @@ public abstract class AbstractFloatingPointFormulaManager<TFormulaInfo, TType, T
         return makeNumberAndRound(n, type, pFloatingPointRoundingMode);
     }
   }
+
+  @Override
+  public FloatingPointFormula makeNumber(
+      BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type) {
+    return wrap(makeNumberImpl(exponent, mantissa, signBit, type));
+  }
+
+  protected abstract TFormulaInfo makeNumberImpl(
+      BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type);
 
   protected static boolean isNegativeZero(Double pN) {
     Preconditions.checkNotNull(pN);
@@ -486,4 +496,12 @@ public abstract class AbstractFloatingPointFormulaManager<TFormulaInfo, TType, T
 
   protected abstract TFormulaInfo round(
       TFormulaInfo pFormula, FloatingPointRoundingMode pRoundingMode);
+
+  protected static String getBvRepresentation(BigInteger integer, int size) {
+    char[] values = new char[size];
+    for (int i = 0; i < size; i++) {
+      values[size - 1 - i] = integer.testBit(i) ? '1' : '0';
+    }
+    return String.copyValueOf(values);
+  }
 }

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsFloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsFloatingPointFormulaManager.java
@@ -11,6 +11,7 @@ package org.sosy_lab.java_smt.delegate.statistics;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -84,6 +85,13 @@ class StatisticsFloatingPointFormulaManager implements FloatingPointFormulaManag
       Rational pN, FloatingPointType pType, FloatingPointRoundingMode pFloatingPointRoundingMode) {
     stats.fpOperations.getAndIncrement();
     return delegate.makeNumber(pN, pType, pFloatingPointRoundingMode);
+  }
+
+  @Override
+  public FloatingPointFormula makeNumber(
+      BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type) {
+    stats.fpOperations.getAndIncrement();
+    return delegate.makeNumber(exponent, mantissa, signBit, type);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedFloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedFloatingPointFormulaManager.java
@@ -11,6 +11,7 @@ package org.sosy_lab.java_smt.delegate.synchronize;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -92,6 +93,14 @@ class SynchronizedFloatingPointFormulaManager implements FloatingPointFormulaMan
       Rational pN, FloatingPointType pType, FloatingPointRoundingMode pFloatingPointRoundingMode) {
     synchronized (sync) {
       return delegate.makeNumber(pN, pType, pFloatingPointRoundingMode);
+    }
+  }
+
+  @Override
+  public FloatingPointFormula makeNumber(
+      BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type) {
+    synchronized (sync) {
+      return delegate.makeNumber(exponent, mantissa, signBit, type);
     }
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FloatingPointFormulaManager.java
@@ -9,8 +9,8 @@
 package org.sosy_lab.java_smt.solvers.cvc4;
 
 import com.google.common.collect.ImmutableList;
-import edu.stanford.CVC4.BitVectorExtract;
 import edu.stanford.CVC4.BitVector;
+import edu.stanford.CVC4.BitVectorExtract;
 import edu.stanford.CVC4.Expr;
 import edu.stanford.CVC4.ExprManager;
 import edu.stanford.CVC4.FloatingPoint;

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FloatingPointFormulaManager.java
@@ -10,6 +10,7 @@ package org.sosy_lab.java_smt.solvers.cvc4;
 
 import com.google.common.collect.ImmutableList;
 import edu.stanford.CVC4.BitVectorExtract;
+import edu.stanford.CVC4.BitVector;
 import edu.stanford.CVC4.Expr;
 import edu.stanford.CVC4.ExprManager;
 import edu.stanford.CVC4.FloatingPoint;
@@ -80,6 +81,19 @@ public class CVC4FloatingPointFormulaManager
   @Override
   protected Expr makeNumberImpl(double pN, FloatingPointType pType, Expr pRoundingMode) {
     return makeNumberImpl(Double.toString(pN), pType, pRoundingMode);
+  }
+
+  @Override
+  protected Expr makeNumberImpl(
+      BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type) {
+    final String signStr = signBit ? "1" : "0";
+    final String exponentStr = getBvRepresentation(exponent, type.getExponentSize());
+    final String mantissaStr = getBvRepresentation(mantissa, type.getMantissaSize());
+    final String bitvecStr = signStr + exponentStr + mantissaStr;
+    final BitVector bitVector = new BitVector(bitvecStr, 2);
+    final FloatingPoint fp =
+        new FloatingPoint(type.getExponentSize(), type.getMantissaSize() + 1, bitVector);
+    return exprManager.mkConst(fp);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FloatingPointFormulaManager.java
@@ -17,6 +17,7 @@ import io.github.cvc5.Solver;
 import io.github.cvc5.Sort;
 import io.github.cvc5.Term;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingMode;
 import org.sosy_lab.java_smt.api.FormulaType;
@@ -64,6 +65,23 @@ public class CVC5FloatingPointFormulaManager
   @Override
   protected Term makeNumberImpl(double pN, FloatingPointType pType, Term pRoundingMode) {
     return makeNumberImpl(Double.toString(pN), pType, pRoundingMode);
+  }
+
+  @Override
+  protected Term makeNumberImpl(
+      BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type) {
+    try {
+      final String signStr = signBit ? "1" : "0";
+      final String exponentStr = getBvRepresentation(exponent, type.getExponentSize());
+      final String mantissaStr = getBvRepresentation(mantissa, type.getMantissaSize());
+      final String bitvecForm = signStr + exponentStr + mantissaStr;
+
+      final Term bv =
+          solver.mkBitVector(type.getExponentSize() + type.getMantissaSize() + 1, bitvecForm, 2);
+      return solver.mkFloatingPoint(type.getExponentSize(), type.getMantissaSize() + 1, bv);
+    } catch (CVC5ApiException e) {
+      throw new IllegalArgumentException("You tried creating a invalid bitvector", e);
+    }
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5FloatingPointFormulaManager.java
@@ -10,6 +10,7 @@ package org.sosy_lab.java_smt.solvers.mathsat5;
 
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_equal;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_fp_abs;
+import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_fp_bits_number;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_fp_cast;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_fp_div;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_fp_equal;
@@ -45,6 +46,7 @@ import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_term_get_type;
 
 import com.google.common.collect.ImmutableList;
+import java.math.BigInteger;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingMode;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.FloatingPointType;
@@ -92,6 +94,18 @@ class Mathsat5FloatingPointFormulaManager
   @Override
   protected Long makeNumberImpl(double pN, FloatingPointType pType, Long pRoundingMode) {
     return makeNumberImpl(Double.toString(pN), pType, pRoundingMode);
+  }
+
+  @Override
+  protected Long makeNumberImpl(
+      BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type) {
+    final String signStr = signBit ? "1" : "0";
+    final String exponentStr = getBvRepresentation(exponent, type.getExponentSize());
+    final String mantissaStr = getBvRepresentation(mantissa, type.getMantissaSize());
+    final String bitvecForm = signStr + exponentStr + mantissaStr;
+    final BigInteger bitvecValue = new BigInteger(bitvecForm, 2);
+    return msat_make_fp_bits_number(
+        mathsatEnv, bitvecValue.toString(), type.getExponentSize(), type.getMantissaSize());
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FloatingPointFormulaManager.java
@@ -83,7 +83,14 @@ class Z3FloatingPointFormulaManager
         Native.mkNumeral(
             z3context, mantissa.toString(), Native.mkBvSort(z3context, type.getMantissaSize()));
 
-    assert Native.getSort(z3context, signBv) != Native.getSort(z3context, mantBv);
+    assert Native.getBvSortSize(z3context, Native.getSort(z3context, signBv)) == 1
+        : "SignBV should be 1 bit long";
+    assert Native.getBvSortSize(z3context, Native.getSort(z3context, expoBv))
+            == type.getExponentSize()
+        : "ExpoBV should be " + type.getExponentSize() + " bits long";
+    assert Native.getBvSortSize(z3context, Native.getSort(z3context, mantBv))
+            == type.getMantissaSize()
+        : "MantBV should be " + type.getMantissaSize() + " bits long";
 
     return Native.mkFpaFp(z3context, signBv, expoBv, mantBv);
   }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FloatingPointFormulaManager.java
@@ -8,10 +8,8 @@
 
 package org.sosy_lab.java_smt.solvers.z3;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.microsoft.z3.Native;
-import com.microsoft.z3.Z3Exception;
 import java.math.BigInteger;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingMode;
 import org.sosy_lab.java_smt.api.FormulaType;
@@ -75,16 +73,15 @@ class Z3FloatingPointFormulaManager
 
   @Override
   protected Long makeNumberImpl(
-      BigInteger exponent,
-      BigInteger mantissa,
-      boolean signBit,
-      FloatingPointType type) {
+      BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type) {
 
-    long signBv = Native.mkBvNumeral(z3context, 1, new boolean[]{signBit});
-    long expoBv = Native.mkNumeral(z3context, exponent.toString(), Native.mkBvSort(z3context,
-        type.getExponentSize()));
-    long mantBv = Native.mkNumeral(z3context, mantissa.toString(), Native.mkBvSort(z3context,
-        type.getMantissaSize()));
+    long signBv = Native.mkBvNumeral(z3context, 1, new boolean[] {signBit});
+    long expoBv =
+        Native.mkNumeral(
+            z3context, exponent.toString(), Native.mkBvSort(z3context, type.getExponentSize()));
+    long mantBv =
+        Native.mkNumeral(
+            z3context, mantissa.toString(), Native.mkBvSort(z3context, type.getMantissaSize()));
 
     assert Native.getSort(z3context, signBv) != Native.getSort(z3context, mantBv);
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FloatingPointFormulaManager.java
@@ -8,8 +8,11 @@
 
 package org.sosy_lab.java_smt.solvers.z3;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.microsoft.z3.Native;
+import com.microsoft.z3.Z3Exception;
+import java.math.BigInteger;
 import org.sosy_lab.java_smt.api.FloatingPointRoundingMode;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.FloatingPointType;
@@ -68,6 +71,24 @@ class Z3FloatingPointFormulaManager
   @Override
   protected Long makeNumberImpl(double pN, FloatingPointType pType, Long pRoundingMode) {
     return makeNumberImpl(Double.toString(pN), pType, pRoundingMode);
+  }
+
+  @Override
+  protected Long makeNumberImpl(
+      BigInteger exponent,
+      BigInteger mantissa,
+      boolean signBit,
+      FloatingPointType type) {
+
+    long signBv = Native.mkBvNumeral(z3context, 1, new boolean[]{signBit});
+    long expoBv = Native.mkNumeral(z3context, exponent.toString(), Native.mkBvSort(z3context,
+        type.getExponentSize()));
+    long mantBv = Native.mkNumeral(z3context, mantissa.toString(), Native.mkBvSort(z3context,
+        type.getMantissaSize()));
+
+    assert Native.getSort(z3context, signBv) != Native.getSort(z3context, mantBv);
+
+    return Native.mkFpaFp(z3context, signBv, expoBv, mantBv);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FloatingPointFormulaManager.java
@@ -75,24 +75,22 @@ class Z3FloatingPointFormulaManager
   protected Long makeNumberImpl(
       BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type) {
 
-    long signBv = Native.mkBvNumeral(z3context, 1, new boolean[] {signBit});
-    long expoBv =
-        Native.mkNumeral(
-            z3context, exponent.toString(), Native.mkBvSort(z3context, type.getExponentSize()));
-    long mantBv =
-        Native.mkNumeral(
-            z3context, mantissa.toString(), Native.mkBvSort(z3context, type.getMantissaSize()));
+    final Long signSort = getFormulaCreator().getBitvectorType(1);
+    final Long expoSort = getFormulaCreator().getBitvectorType(type.getExponentSize());
+    final Long mantSort = getFormulaCreator().getBitvectorType(type.getMantissaSize());
 
-    assert Native.getBvSortSize(z3context, Native.getSort(z3context, signBv)) == 1
-        : "SignBV should be 1 bit long";
-    assert Native.getBvSortSize(z3context, Native.getSort(z3context, expoBv))
-            == type.getExponentSize()
-        : "ExpoBV should be " + type.getExponentSize() + " bits long";
-    assert Native.getBvSortSize(z3context, Native.getSort(z3context, mantBv))
-            == type.getMantissaSize()
-        : "MantBV should be " + type.getMantissaSize() + " bits long";
+    final Long signBv = Native.mkNumeral(z3context, signBit ? "1" : "0", signSort);
+    Native.incRef(z3context, signBv);
+    final Long expoBv = Native.mkNumeral(z3context, exponent.toString(), expoSort);
+    Native.incRef(z3context, expoBv);
+    final Long mantBv = Native.mkNumeral(z3context, mantissa.toString(), mantSort);
+    Native.incRef(z3context, mantBv);
 
-    return Native.mkFpaFp(z3context, signBv, expoBv, mantBv);
+    final Long fp = Native.mkFpaFp(z3context, signBv, expoBv, mantBv);
+    Native.decRef(z3context, mantBv);
+    Native.decRef(z3context, expoBv);
+    Native.decRef(z3context, signBv);
+    return fp;
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Random;
 import org.junit.Before;
@@ -948,5 +949,14 @@ public class FloatingPointFormulaManagerTest
   public void failOnInvalidString() {
     fpmgr.makeNumber("a", singlePrecType);
     assert_().fail();
+  }
+
+  @Test
+  public void fpFromBitPattern() throws SolverException, InterruptedException {
+    final FloatingPointFormula expr1 = fpmgr.makeNumber(-0.1, doublePrecType);
+    final FloatingPointFormula expr2 =
+        fpmgr.makeNumber(
+            BigInteger.valueOf(123), BigInteger.valueOf(5033165), true, doublePrecType);
+    assertThatFormula(fpmgr.assignment(expr1, expr2)).isTautological();
   }
 }

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -953,10 +953,10 @@ public class FloatingPointFormulaManagerTest
 
   @Test
   public void fpFromBitPattern() throws SolverException, InterruptedException {
-    final FloatingPointFormula expr1 = fpmgr.makeNumber(-0.1, doublePrecType);
+    final FloatingPointFormula expr1 = fpmgr.makeNumber(-0.1, singlePrecType);
     final FloatingPointFormula expr2 =
         fpmgr.makeNumber(
-            BigInteger.valueOf(123), BigInteger.valueOf(5033165), true, doublePrecType);
+            BigInteger.valueOf(123), BigInteger.valueOf(5033165), true, singlePrecType);
     assertThatFormula(fpmgr.assignment(expr1, expr2)).isTautological();
   }
 }


### PR DESCRIPTION
As discussed in #360, currently, floating point literals cannot be directly created if the user has access to the bit pattern of the value. Therefore, this PR adds support for this using the new `makeNumber(BigInteger exponent, BigInteger mantissa, boolean signBit, FloatingPointType type)` method.

I added a test to verify that no trivial mistakes were made. Let me know if I should add more.