### PR TITLE
Fix a problem with Z3 and CVC4 where the visitor.visitConstant received a wrong result

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
@@ -318,7 +318,7 @@ public class CVC4FormulaCreator extends FormulaCreator<Expr, Type, ExprManager, 
             formula, new BigInteger(f.getConstBitVector().getValue().toString(10)));
       } else if (type.isFloatingPoint()) {
         // TODO is this correct?
-        return visitor.visitConstant(formula, f.getConstFloatingPoint());
+        return visitor.visitConstant(formula, convertFloatingPoint(f));
       } else if (type.isRoundingMode()) {
         // TODO is this correct?
         return visitor.visitConstant(formula, f.getConstRoundingMode());


### PR DESCRIPTION
The `FormulaVisitor.visitConstant(Formula f, Object value)` method received `null` in some edge cases with Z3, where the backend did not handle `(fp #b0 #b... #b..)` as floating point constant; and a CVC4-dependent type with CVC4 instead of the common `FloatingPointNumber` type. This PR aims to fix both. I also added some tests to this end.
