### PR TITLE
Added array literal creation to API and implementation

### DIFF
--- a/src/org/sosy_lab/java_smt/api/ArrayFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/ArrayFormulaManager.java
@@ -61,6 +61,30 @@ public interface ArrayFormulaManager {
   <TI extends Formula, TE extends Formula> ArrayFormula<TI, TE> makeArray(
       String pName, ArrayFormulaType<TI, TE> type);
 
+  /** Create a new array constant with uninitialized values. */
+  <TI extends Formula, TE extends Formula, FTI extends FormulaType<TI>, FTE extends FormulaType<TE>>
+      ArrayFormula<TI, TE> makeArray(FTI pIndexType, FTE pElementType);
+
+  /** Create a new array constant with uninitialized values. */
+  <TI extends Formula, TE extends Formula> ArrayFormula<TI, TE> makeArray(
+      ArrayFormulaType<TI, TE> type);
+
+  /**
+   * Create a new array constant with uninitialized values.
+   *
+   * @param elseElem: The default value of all entries in the array.
+   */
+  <TI extends Formula, TE extends Formula, FTI extends FormulaType<TI>, FTE extends FormulaType<TE>>
+      ArrayFormula<TI, TE> makeArray(TE elseElem, FTI pIndexType, FTE pElementType);
+
+  /**
+   * Create a new array constant with values initialized to elseElem.
+   *
+   * @param elseElem: The default value of all entries in the array.
+   */
+  <TI extends Formula, TE extends Formula> ArrayFormula<TI, TE> makeArray(
+      TE elseElem, ArrayFormulaType<TI, TE> type);
+
   /** Make a {@link BooleanFormula} that represents the equality of two {@link ArrayFormula}. */
   <TI extends Formula, TE extends Formula> BooleanFormula equivalence(
       ArrayFormula<TI, TE> pArray1, ArrayFormula<TI, TE> pArray2);

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractArrayFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractArrayFormulaManager.java
@@ -81,6 +81,56 @@ public abstract class AbstractArrayFormulaManager<TFormulaInfo, TType, TEnv, TFu
       String pName, FormulaType<TI> pIndexType, FormulaType<TE> pElementType);
 
   @Override
+  public <
+          TI extends Formula,
+          TE extends Formula,
+          FTI extends FormulaType<TI>,
+          FTE extends FormulaType<TE>>
+      ArrayFormula<TI, TE> makeArray(FTI pIndexType, FTE pElementType) {
+    final TFormulaInfo arrayConst = internalMakeArray(pIndexType, pElementType);
+    return getFormulaCreator().encapsulateArray(arrayConst, pIndexType, pElementType);
+  }
+
+  @Override
+  public <TI extends Formula, TE extends Formula> ArrayFormula<TI, TE> makeArray(
+      ArrayFormulaType<TI, TE> type) {
+    final TFormulaInfo arrayConst = internalMakeArray(type.getIndexType(), type.getElementType());
+    return getFormulaCreator()
+        .encapsulateArray(arrayConst, type.getIndexType(), type.getElementType());
+  }
+
+  @Override
+  public <
+          TI extends Formula,
+          TE extends Formula,
+          FTI extends FormulaType<TI>,
+          FTE extends FormulaType<TE>>
+      ArrayFormula<TI, TE> makeArray(TE elseElem, FTI pIndexType, FTE pElementType) {
+    final TFormulaInfo arrayConst =
+        internalMakeArray(extractInfo(elseElem), pIndexType, pElementType);
+    return getFormulaCreator().encapsulateArray(arrayConst, pIndexType, pElementType);
+  }
+
+  @Override
+  public <TI extends Formula, TE extends Formula> ArrayFormula<TI, TE> makeArray(
+      TE elseElem, ArrayFormulaType<TI, TE> type) {
+    final TFormulaInfo arrayConst =
+        internalMakeArray(extractInfo(elseElem), type.getIndexType(), type.getElementType());
+    return getFormulaCreator()
+        .encapsulateArray(arrayConst, type.getIndexType(), type.getElementType());
+  }
+
+  protected <TI extends Formula, TE extends Formula> TFormulaInfo internalMakeArray(
+      FormulaType<TI> pIndexType, FormulaType<TE> pElementType) {
+    return internalMakeArray("__unnamed_array", pIndexType, pElementType);
+  }
+
+  protected <TI extends Formula, TE extends Formula> TFormulaInfo internalMakeArray(
+      TFormulaInfo elseElem, FormulaType<TI> pIndexType, FormulaType<TE> pElementType) {
+    throw new UnsupportedOperationException("Initialized arrays are not supported.");
+  }
+
+  @Override
   public <TI extends Formula> FormulaType<TI> getIndexType(ArrayFormula<TI, ?> pArray) {
     return getFormulaCreator().getArrayFormulaIndexType(pArray);
   }

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsArrayFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsArrayFormulaManager.java
@@ -61,6 +61,42 @@ class StatisticsArrayFormulaManager implements ArrayFormulaManager {
   }
 
   @Override
+  public <
+          TI extends Formula,
+          TE extends Formula,
+          FTI extends FormulaType<TI>,
+          FTE extends FormulaType<TE>>
+      ArrayFormula<TI, TE> makeArray(FTI pIndexType, FTE pElementType) {
+    stats.arrayOperations.getAndIncrement();
+    return delegate.makeArray(pIndexType, pElementType);
+  }
+
+  @Override
+  public <TI extends Formula, TE extends Formula> ArrayFormula<TI, TE> makeArray(
+      ArrayFormulaType<TI, TE> type) {
+    stats.arrayOperations.getAndIncrement();
+    return delegate.makeArray(type);
+  }
+
+  @Override
+  public <
+          TI extends Formula,
+          TE extends Formula,
+          FTI extends FormulaType<TI>,
+          FTE extends FormulaType<TE>>
+      ArrayFormula<TI, TE> makeArray(TE elseElem, FTI pIndexType, FTE pElementType) {
+    stats.arrayOperations.getAndIncrement();
+    return delegate.makeArray(elseElem, pIndexType, pElementType);
+  }
+
+  @Override
+  public <TI extends Formula, TE extends Formula> ArrayFormula<TI, TE> makeArray(
+      TE elseElem, ArrayFormulaType<TI, TE> type) {
+    stats.arrayOperations.getAndIncrement();
+    return delegate.makeArray(elseElem, type);
+  }
+
+  @Override
   public <TI extends Formula, TE extends Formula> BooleanFormula equivalence(
       ArrayFormula<TI, TE> pArray1, ArrayFormula<TI, TE> pArray2) {
     stats.arrayOperations.getAndIncrement();

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedArrayFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedArrayFormulaManager.java
@@ -66,6 +66,46 @@ class SynchronizedArrayFormulaManager implements ArrayFormulaManager {
   }
 
   @Override
+  public <
+          TI extends Formula,
+          TE extends Formula,
+          FTI extends FormulaType<TI>,
+          FTE extends FormulaType<TE>>
+      ArrayFormula<TI, TE> makeArray(FTI pIndexType, FTE pElementType) {
+    synchronized (sync) {
+      return delegate.makeArray(pIndexType, pElementType);
+    }
+  }
+
+  @Override
+  public <TI extends Formula, TE extends Formula> ArrayFormula<TI, TE> makeArray(
+      ArrayFormulaType<TI, TE> type) {
+    synchronized (sync) {
+      return delegate.makeArray(type);
+    }
+  }
+
+  @Override
+  public <
+          TI extends Formula,
+          TE extends Formula,
+          FTI extends FormulaType<TI>,
+          FTE extends FormulaType<TE>>
+      ArrayFormula<TI, TE> makeArray(TE elseElem, FTI pIndexType, FTE pElementType) {
+    synchronized (sync) {
+      return delegate.makeArray(elseElem, pIndexType, pElementType);
+    }
+  }
+
+  @Override
+  public <TI extends Formula, TE extends Formula> ArrayFormula<TI, TE> makeArray(
+      TE elseElem, ArrayFormulaType<TI, TE> type) {
+    synchronized (sync) {
+      return delegate.makeArray(elseElem, type);
+    }
+  }
+
+  @Override
   public <TI extends Formula, TE extends Formula> BooleanFormula equivalence(
       ArrayFormula<TI, TE> pArray1, ArrayFormula<TI, TE> pArray2) {
     synchronized (sync) {

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5ArrayFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5ArrayFormulaManager.java
@@ -47,6 +47,15 @@ public class CVC5ArrayFormulaManager extends AbstractArrayFormulaManager<Term, S
   }
 
   @Override
+  protected <TI extends Formula, TE extends Formula> Term internalMakeArray(
+      Term elseElem, FormulaType<TI> pIndexType, FormulaType<TE> pElementType) {
+    final ArrayFormulaType<TI, TE> arrayFormulaType =
+        FormulaType.getArrayType(pIndexType, pElementType);
+    final Sort cvc5ArrayType = toSolverType(arrayFormulaType);
+    return solver.mkConstArray(cvc5ArrayType, elseElem);
+  }
+
+  @Override
   protected Term equivalence(Term pArray1, Term pArray2) {
     return solver.mkTerm(Kind.EQUAL, pArray1, pArray2);
   }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5ArrayFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5ArrayFormulaManager.java
@@ -8,6 +8,7 @@
 
 package org.sosy_lab.java_smt.solvers.mathsat5;
 
+import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_array_const;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_array_read;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_array_write;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_make_equal;
@@ -46,6 +47,15 @@ class Mathsat5ArrayFormulaManager extends AbstractArrayFormulaManager<Long, Long
     final Long mathsatArrayType = toSolverType(arrayFormulaType);
 
     return getFormulaCreator().makeVariable(mathsatArrayType, pName);
+  }
+
+  @Override
+  protected <TI extends Formula, TE extends Formula> Long internalMakeArray(
+      Long elseElem, FormulaType<TI> pIndexType, FormulaType<TE> pElementType) {
+    final ArrayFormulaType<TI, TE> arrayFormulaType =
+        FormulaType.getArrayType(pIndexType, pElementType);
+    final Long mathsatArrayType = toSolverType(arrayFormulaType);
+    return msat_make_array_const(mathsatEnv, mathsatArrayType, elseElem);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3ArrayFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3ArrayFormulaManager.java
@@ -9,6 +9,7 @@
 package org.sosy_lab.java_smt.solvers.z3;
 
 import com.microsoft.z3.Native;
+import java.util.List;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.ArrayFormulaType;
@@ -43,6 +44,22 @@ class Z3ArrayFormulaManager extends AbstractArrayFormulaManager<Long, Long, Long
     final Long z3ArrayType = toSolverType(arrayFormulaType);
 
     return getFormulaCreator().makeVariable(z3ArrayType, pName);
+  }
+
+  @Override
+  protected <TI extends Formula, TE extends Formula> Long internalMakeArray(
+      FormulaType<TI> pIndexType, FormulaType<TE> pElementType) {
+    long func =
+        getFormulaCreator()
+            .declareUFImpl(
+                "__unnamed_arr", toSolverType(pElementType), List.of(toSolverType(pIndexType)));
+    return Native.mkAsArray(z3context, func);
+  }
+
+  @Override
+  protected <TI extends Formula, TE extends Formula> Long internalMakeArray(
+      Long elseElem, FormulaType<TI> pIndexType, FormulaType<TE> pElementType) {
+    return Native.mkConstArray(z3context, toSolverType(pIndexType), elseElem);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/test/ArrayFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/ArrayFormulaManagerTest.java
@@ -180,4 +180,102 @@ public class ArrayFormulaManagerTest extends SolverBasedTest0.ParameterizedSolve
             bmgr.not(fpmgr.equalWithFPSemantics(num2, amgr.select(arr2, num4))));
     assertThatFormula(query).isUnsatisfiable();
   }
+
+  @Test
+  public void testArrayConst() throws SolverException, InterruptedException {
+    requireIntegers();
+
+    ArrayFormulaType<IntegerFormula, IntegerFormula> type =
+        FormulaType.getArrayType(IntegerType, IntegerType);
+    ArrayFormula<IntegerFormula, IntegerFormula> arr = amgr.makeArray(type);
+
+    IntegerFormula num2 = imgr.makeNumber(2);
+    IntegerFormula num4 = imgr.makeNumber(4);
+    IntegerFormula num5 = imgr.makeNumber(5);
+    IntegerFormula numM1 = imgr.makeNumber(-1);
+
+    // select(store(arr, i, j)) == j
+    assertThatFormula(imgr.equal(num4, amgr.select(amgr.store(arr, num2, num4), num2)))
+        .isTautological();
+    // same, but checking whether unnamed arrays work well (i.e., not global)
+    assertThatFormula(imgr.equal(num5, amgr.select(amgr.store(arr, num2, num5), num2)))
+        .isTautological();
+    // uninit array can read any value
+    assertThatFormula(imgr.equal(numM1, amgr.select(arr, num2))).isSatisfiable();
+  }
+
+  @Test
+  public void testArrayConstBv() throws SolverException, InterruptedException {
+    requireBitvectors();
+
+    ArrayFormulaType<BitvectorFormula, BitvectorFormula> type =
+        FormulaType.getArrayType(getBitvectorTypeWithSize(4), getBitvectorTypeWithSize(4));
+    ArrayFormula<BitvectorFormula, BitvectorFormula> arr = amgr.makeArray(type);
+
+    BitvectorFormula num2 = bvmgr.makeBitvector(4, 2);
+    BitvectorFormula num4 = bvmgr.makeBitvector(4, 4);
+    BitvectorFormula num5 = bvmgr.makeBitvector(4, 5);
+    BitvectorFormula numM1 = bvmgr.makeBitvector(4, -1);
+
+    // select(store(arr, i, j)) == j
+    assertThatFormula(bvmgr.equal(num4, amgr.select(amgr.store(arr, num2, num4), num2)))
+        .isTautological();
+    // same, but checking whether unnamed arrays work well (i.e., not global)
+    assertThatFormula(bvmgr.equal(num5, amgr.select(amgr.store(arr, num2, num5), num2)))
+        .isTautological();
+    // uninit array can read any value
+    assertThatFormula(bvmgr.equal(numM1, amgr.select(arr, num2))).isSatisfiable();
+  }
+
+  @Test
+  public void testArrayConstWithDefault() throws SolverException, InterruptedException {
+    requireIntegers();
+    requireArraysWithDefaultValue();
+
+    ArrayFormulaType<IntegerFormula, IntegerFormula> type =
+        FormulaType.getArrayType(IntegerType, IntegerType);
+    IntegerFormula num0 = imgr.makeNumber(0);
+    ArrayFormula<IntegerFormula, IntegerFormula> arr = amgr.makeArray(num0, type);
+
+    IntegerFormula num2 = imgr.makeNumber(2);
+    IntegerFormula num4 = imgr.makeNumber(4);
+    IntegerFormula num5 = imgr.makeNumber(5);
+    IntegerFormula numM1 = imgr.makeNumber(-1);
+
+    // select(store(arr, i, j)) == j
+    assertThatFormula(imgr.equal(num4, amgr.select(amgr.store(arr, num2, num4), num2)))
+        .isTautological();
+    // same, but checking whether unnamed arrays work well (i.e., not global)
+    assertThatFormula(imgr.equal(num5, amgr.select(amgr.store(arr, num2, num5), num2)))
+        .isTautological();
+    // init array cannot read any value besides default
+    assertThatFormula(imgr.equal(numM1, amgr.select(arr, num2))).isUnsatisfiable();
+    assertThatFormula(imgr.equal(num0, amgr.select(arr, num2))).isTautological();
+  }
+
+  @Test
+  public void testArrayConstBvWithDefault() throws SolverException, InterruptedException {
+    requireBitvectors();
+    requireArraysWithDefaultValue();
+
+    ArrayFormulaType<BitvectorFormula, BitvectorFormula> type =
+        FormulaType.getArrayType(getBitvectorTypeWithSize(4), getBitvectorTypeWithSize(4));
+    BitvectorFormula num0 = bvmgr.makeBitvector(4, 0);
+    ArrayFormula<BitvectorFormula, BitvectorFormula> arr = amgr.makeArray(num0, type);
+
+    BitvectorFormula num2 = bvmgr.makeBitvector(4, 2);
+    BitvectorFormula num4 = bvmgr.makeBitvector(4, 4);
+    BitvectorFormula num5 = bvmgr.makeBitvector(4, 5);
+    BitvectorFormula numM1 = bvmgr.makeBitvector(4, -1);
+
+    // select(store(arr, i, j)) == j
+    assertThatFormula(bvmgr.equal(num4, amgr.select(amgr.store(arr, num2, num4), num2)))
+        .isTautological();
+    // same, but checking whether unnamed arrays work well (i.e., not global)
+    assertThatFormula(bvmgr.equal(num5, amgr.select(amgr.store(arr, num2, num5), num2)))
+        .isTautological();
+    // init array cannot read any value besides default
+    assertThatFormula(bvmgr.equal(numM1, amgr.select(arr, num2))).isUnsatisfiable();
+    assertThatFormula(bvmgr.equal(num0, amgr.select(arr, num2))).isTautological();
+  }
 }

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -258,6 +258,19 @@ public abstract class SolverBasedTest0 {
         .isNotNull();
   }
 
+  /** Skip test if the solver does not support initialized arrays. */
+  protected /*final*/ void requireArraysWithDefaultValue() {
+    assume()
+        .withMessage("Solver %s does not support arrays with default values", solverToUse())
+        .that(solverToUse())
+        .isNoneOf(
+            Solvers.OPENSMT,
+            Solvers.SMTINTERPOL,
+            Solvers.PRINCESS,
+            Solvers.CVC4,
+            Solvers.BOOLECTOR);
+  }
+
   protected final void requireFloats() {
     assume()
         .withMessage("Solver %s does not support the theory of floats", solverToUse())


### PR DESCRIPTION
As mentioned in #360, currently, array literals are not supported by the API. This PR adds two new methods to this end, one without a default value, and one with a default (else) value. I also added some tests to verify that these work normally. 