### PR TITLE
Bitwuzla: Fix performance issues in FloatingPointFormulaManagerTest

### DIFF
--- a/src/org/sosy_lab/java_smt/api/FunctionDeclarationKind.java
+++ b/src/org/sosy_lab/java_smt/api/FunctionDeclarationKind.java
@@ -213,6 +213,9 @@ public enum FunctionDeclarationKind {
   /** Division over floating points. */
   FP_DIV,
 
+  /** Remainder of the floating point division */
+  FP_REM,
+
   /** Multiplication over floating points. */
   FP_MUL,
 

--- a/src/org/sosy_lab/java_smt/api/FunctionDeclarationKind.java
+++ b/src/org/sosy_lab/java_smt/api/FunctionDeclarationKind.java
@@ -213,7 +213,7 @@ public enum FunctionDeclarationKind {
   /** Division over floating points. */
   FP_DIV,
 
-  /** Remainder of the floating point division */
+  /** Remainder of the floating point division. */
   FP_REM,
 
   /** Multiplication over floating points. */

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFloatingPointManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFloatingPointManager.java
@@ -212,6 +212,16 @@ public class BitwuzlaFloatingPointManager
 
     Sort bvSort = termManager.mk_bv_sort(sizeExp + sizeSig);
 
+    // The following code creates a new variable that is returned as result.
+    // Additionally, we track constraints about the equality of the new variable and the FP number,
+    // which is added onto the prover stack whenever the new variable is used as assertion.
+
+    // TODO This internal implementation is a technical dept and should be removed.
+    //   The additional constraints are not transparent in all cases, e.g., when visiting a
+    //   formula, creating a model, or transferring the assertions onto another prover stack.
+    //   A better way would be a direct implementation of this in Bitwuzla, without interfering
+    //   with JavaSMT.
+
     // Note that NaN is handled as a special case in this method. This is not strictly necessary,
     // but if we just use "fpTerm = to_fp(bvVar)" the NaN will be given a random payload (and
     // sign). Since NaN payloads are not preserved here anyway we might as well pick a canonical
@@ -231,7 +241,7 @@ public class BitwuzlaFloatingPointManager
                 termManager.mk_term(Kind.FP_TO_FP_FROM_BV, bvVar, sizeExp, sizeSig),
                 pNumber));
 
-    bitwuzlaCreator.addVariableCast(newVariable, equal);
+    bitwuzlaCreator.addConstraintForVariable(newVariable, equal);
     return bvVar;
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFloatingPointManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFloatingPointManager.java
@@ -201,10 +201,6 @@ public class BitwuzlaFloatingPointManager
         pTargetType.getMantissaSize() + 1);
   }
 
-  private String newVariable() {
-    return "__CAST_FROM_BV_" + counter++;
-  }
-
   @Override
   protected Term toIeeeBitvectorImpl(Term pNumber) {
     int sizeExp = pNumber.sort().fp_exp_size();
@@ -225,11 +221,13 @@ public class BitwuzlaFloatingPointManager
     // Note that NaN is handled as a special case in this method. This is not strictly necessary,
     // but if we just use "fpTerm = to_fp(bvVar)" the NaN will be given a random payload (and
     // sign). Since NaN payloads are not preserved here anyway we might as well pick a canonical
-    // representation.
-    Term bvNaN =
-        termManager.mk_bv_value(bvSort, "0" + "1".repeat(sizeExp + 1) + "0".repeat(sizeSig - 2));
+    // representation, e.g., which is "0 11111111 10000000000000000000000" for single precision.
+    String nanRepr = "0" + "1".repeat(sizeExp + 1) + "0".repeat(sizeSig - 2);
+    Term bvNaN = termManager.mk_bv_value(bvSort, nanRepr);
 
-    String newVariable = newVariable();
+    // TODO creating our own utility variables might eb unexpected from the user.
+    //   We might need to exclude such variables in models and formula traversal.
+    String newVariable = "__JAVASMT__CAST_FROM_BV_" + counter++;
     Term bvVar = termManager.mk_const(bvSort, newVariable);
     Term equal =
         termManager.mk_term(

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFloatingPointManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFloatingPointManager.java
@@ -231,7 +231,7 @@ public class BitwuzlaFloatingPointManager
                 termManager.mk_term(Kind.FP_TO_FP_FROM_BV, bvVar, sizeExp, sizeSig),
                 pNumber));
 
-    bitwuzlaCreator.addVariableCast(equal);
+    bitwuzlaCreator.addVariableCast(newVariable, equal);
     return bvVar;
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFloatingPointManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFloatingPointManager.java
@@ -28,6 +28,9 @@ public class BitwuzlaFloatingPointManager
   private final TermManager termManager;
   private final Term roundingMode;
 
+  // Keeps track of the temporary variables that are created for fp-to-bv casts
+  private static int counter = 0;
+
   protected BitwuzlaFloatingPointManager(
       BitwuzlaFormulaCreator pCreator, FloatingPointRoundingMode pFloatingPointRoundingMode) {
     super(pCreator);
@@ -198,9 +201,12 @@ public class BitwuzlaFloatingPointManager
         pTargetType.getMantissaSize() + 1);
   }
 
+  private String newVariable() {
+    return "__CAST_FROM_BV_" + counter++;
+  }
+
   @Override
   protected Term toIeeeBitvectorImpl(Term pNumber) {
-    // FIXME: We should use a reserved symbol for the fresh variables
     int sizeExp = pNumber.sort().fp_exp_size();
     int sizeSig = pNumber.sort().fp_sig_size();
 
@@ -213,7 +219,8 @@ public class BitwuzlaFloatingPointManager
     Term bvNaN =
         termManager.mk_bv_value(bvSort, "0" + "1".repeat(sizeExp + 1) + "0".repeat(sizeSig - 2));
 
-    Term bvVar = termManager.mk_const(bvSort, pNumber.symbol() + "_toIeeeBitvector");
+    String newVariable = newVariable();
+    Term bvVar = termManager.mk_const(bvSort, newVariable);
     Term equal =
         termManager.mk_term(
             Kind.ITE,

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
@@ -221,6 +221,8 @@ public class BitwuzlaFormulaCreator extends FormulaCreator<Term, Sort, Void, Bit
       return FunctionDeclarationKind.BV_SGT;
     } else if (kind.equals(Kind.BV_SHL)) {
       return FunctionDeclarationKind.BV_SHL;
+    } else if (kind.equals(Kind.BV_SHR)) {
+      return FunctionDeclarationKind.BV_LSHR;
     } else if (kind.equals(Kind.BV_SLE)) {
       return FunctionDeclarationKind.BV_SLE;
     } else if (kind.equals(Kind.BV_SLT)) {

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
@@ -326,10 +326,6 @@ public class BitwuzlaFormulaCreator extends FormulaCreator<Term, Sort, Void, Bit
       return FunctionDeclarationKind.FP_CASTTO_UBV;
     } else if (kind.equals(Kind.BV_XOR)) {
       return FunctionDeclarationKind.BV_XOR;
-    } else if (ImmutableList.of(Kind.BV_ROL, Kind.BV_ROLI, Kind.BV_ROR, Kind.BV_RORI)
-        .contains(kind)) {
-      // Rotations are not yet supported by FunctionDeclarationKind
-      return FunctionDeclarationKind.OTHER;
     }
     throw new UnsupportedOperationException("Can not discern formula kind " + kind);
   }

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
@@ -283,6 +283,8 @@ public class BitwuzlaFormulaCreator extends FormulaCreator<Term, Sort, Void, Bit
       return FunctionDeclarationKind.FP_MIN;
     } else if (kind.equals(Kind.FP_MUL)) {
       return FunctionDeclarationKind.FP_MUL;
+    } else if (kind.equals(Kind.FP_REM)) {
+      return FunctionDeclarationKind.FP_REM;
     } else if (kind.equals(Kind.FP_NEG)) {
       return FunctionDeclarationKind.FP_NEG;
     } else if (kind.equals(Kind.FP_RTI)) {

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
@@ -313,6 +313,10 @@ public class BitwuzlaFormulaCreator extends FormulaCreator<Term, Sort, Void, Bit
       return FunctionDeclarationKind.FP_CASTTO_UBV;
     } else if (kind.equals(Kind.BV_XOR)) {
       return FunctionDeclarationKind.BV_XOR;
+    } else if (ImmutableList.of(Kind.BV_ROL, Kind.BV_ROLI, Kind.BV_ROR, Kind.BV_RORI)
+        .contains(kind)) {
+      // Rotations are not yet supported by FunctionDeclarationKind
+      return FunctionDeclarationKind.OTHER;
     }
     throw new UnsupportedOperationException("Can not discern formula kind " + kind);
   }

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
@@ -191,7 +191,7 @@ public final class BitwuzlaFormulaManager
           return;
         }
         Bitwuzla bitwuzla = new Bitwuzla(creator.getTermManager());
-        for (Term t : creator.getVariableCasts(ImmutableList.of(pTerm))) {
+        for (Term t : creator.getConstraintsForTerm(pTerm)) {
           bitwuzla.assert_formula(t);
         }
         bitwuzla.assert_formula(pTerm);

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
@@ -191,7 +191,7 @@ public final class BitwuzlaFormulaManager
           return;
         }
         Bitwuzla bitwuzla = new Bitwuzla(creator.getTermManager());
-        for (Term t : creator.getVariableCasts()) {
+        for (Term t : creator.getVariableCasts(ImmutableList.of(pTerm))) {
           bitwuzla.assert_formula(t);
         }
         bitwuzla.assert_formula(pTerm);

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
@@ -186,6 +186,10 @@ public final class BitwuzlaFormulaManager
     return new Appenders.AbstractAppender() {
       @Override
       public void appendTo(Appendable out) throws IOException {
+        if (pTerm.is_value()) {
+          out.append("(assert " + pTerm + ")");
+          return;
+        }
         Bitwuzla bitwuzla = new Bitwuzla(creator.getTermManager());
         for (Term t : creator.getVariableCasts()) {
           bitwuzla.assert_formula(t);

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
@@ -487,6 +487,7 @@ public class CVC4FormulaCreator extends FormulaCreator<Expr, Type, ExprManager, 
           .put(Kind.FLOATINGPOINT_SUB, FunctionDeclarationKind.FP_SUB)
           .put(Kind.FLOATINGPOINT_MULT, FunctionDeclarationKind.FP_MUL)
           .put(Kind.FLOATINGPOINT_DIV, FunctionDeclarationKind.FP_DIV)
+          .put(Kind.FLOATINGPOINT_REM, FunctionDeclarationKind.FP_REM)
           .put(Kind.FLOATINGPOINT_LT, FunctionDeclarationKind.FP_LT)
           .put(Kind.FLOATINGPOINT_LEQ, FunctionDeclarationKind.FP_LE)
           .put(Kind.FLOATINGPOINT_GT, FunctionDeclarationKind.FP_GT)

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
@@ -600,6 +600,7 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, Solver, Term>
           .put(Kind.FLOATINGPOINT_ADD, FunctionDeclarationKind.FP_ADD)
           .put(Kind.FLOATINGPOINT_SUB, FunctionDeclarationKind.FP_SUB)
           .put(Kind.FLOATINGPOINT_MULT, FunctionDeclarationKind.FP_MUL)
+          .put(Kind.FLOATINGPOINT_REM, FunctionDeclarationKind.FP_REM)
           .put(Kind.FLOATINGPOINT_DIV, FunctionDeclarationKind.FP_DIV)
           .put(Kind.FLOATINGPOINT_NEG, FunctionDeclarationKind.FP_NEG)
           .put(Kind.FLOATINGPOINT_LT, FunctionDeclarationKind.FP_LT)

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
@@ -726,6 +726,8 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
         return FunctionDeclarationKind.FP_DIV;
       case Z3_OP_FPA_MUL:
         return FunctionDeclarationKind.FP_MUL;
+      case Z3_OP_FPA_REM:
+        return FunctionDeclarationKind.FP_REM;
       case Z3_OP_FPA_LT:
         return FunctionDeclarationKind.FP_LT;
       case Z3_OP_FPA_LE:

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -783,6 +783,11 @@ public class FloatingPointFormulaManagerTest
   private <T> void proveForAll(Function<T, BooleanFormula> f, List<T> args)
       throws InterruptedException, SolverException {
     try (ProverEnvironment prover = context.newProverEnvironment()) {
+      if (solverToUse().equals(Solvers.BITWUZLA)) {
+        // Adding this line speeds up performance in checkIeeeBv2FpConversion32 by a factor of 10
+        // FIXME: I've no idea why this would work
+        prover.addConstraint(bmgr.makeTrue());
+      }
       for (T value : args) {
         prover.push();
         prover.addConstraint(f.apply(value));

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -935,22 +935,6 @@ public class FloatingPointFormulaManagerTest
     return dbls;
   }
 
-  private void checkBV2FP(FloatingPointType type, BitvectorFormula bv, FloatingPointFormula flt)
-      throws SolverException, InterruptedException {
-    FloatingPointFormula ieeeFp = fpmgr.fromIeeeBitvector(bv, type);
-    assertThat(mgr.getFormulaType(ieeeFp)).isEqualTo(mgr.getFormulaType(flt));
-    assertEqualsAsFp(flt, ieeeFp);
-  }
-
-  private void checkFP2BV(FloatingPointType type, BitvectorFormula bv, FloatingPointFormula flt)
-      throws SolverException, InterruptedException {
-    BitvectorFormula var = bvmgr.makeVariable(type.getTotalSize(), "x");
-    BitvectorFormula ieeeBv = fpmgr.toIeeeBitvector(flt);
-    assertThat(mgr.getFormulaType(ieeeBv)).isEqualTo(mgr.getFormulaType(var));
-    assertThatFormula(bvmgr.equal(bv, ieeeBv)).isTautological();
-    assertThatFormula(bmgr.and(bvmgr.equal(bv, var), bvmgr.equal(var, ieeeBv))).isSatisfiable();
-  }
-
   @Test
   public void fpModelContent() throws SolverException, InterruptedException {
     FloatingPointFormula zeroVar = fpmgr.makeVariable("zero", singlePrecType);

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -828,6 +828,12 @@ public class FloatingPointFormulaManagerTest
         .that(solverToUse())
         .isNoneOf(Solvers.CVC4, Solvers.CVC5);
 
+    // FIXME: This test is still painfully slow in Bitwuzla. Both fp2bv and bv2fp ultimately map
+    //  to the same operation in Bitwuzla as we define "b = fp2bv(f)" by adding the
+    //  side-condition "f = bv2fp(b)" to the constraints and then simply returning the new bitvector
+    //  variable `b`. The slow down here seems to be related the side-conditions that have to be
+    //  added to the assertions whenever isUnsat() is called.
+
     proveForAll(
         // makeBV(value.bits) == fromFP(makeFP(value.float))
         pFloat ->

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -869,17 +869,15 @@ public class FloatingPointFormulaManagerTest
       flts.add(-0.0f); // MathSat5 fails for NEGATIVE_ZERO
     }
 
-    final int stepSize = solverToUse() == Solvers.BITWUZLA ? 10 : 1;
-    for (int i = 1; i < 20; i += stepSize) {
-      for (int j = 1; j < 20; j += stepSize) {
+    for (int i = 1; i < 20; i++) {
+      for (int j = 1; j < 20; j++) {
         flts.add((float) (i * Math.pow(10, j)));
         flts.add((float) (-i * Math.pow(10, j)));
       }
     }
 
-    final int numRandom = solverToUse() == Solvers.BITWUZLA ? 5 : NUM_RANDOM_TESTS;
     Random rand = new Random(0);
-    for (int i = 0; i < numRandom; i++) {
+    for (int i = 0; i < NUM_RANDOM_TESTS; i++) {
       float flt = Float.intBitsToFloat(rand.nextInt());
       if (!Float.isNaN(flt)) {
         flts.add(flt);
@@ -908,17 +906,15 @@ public class FloatingPointFormulaManagerTest
       dbls.add(-0.0); // MathSat5 fails for NEGATIVE_ZERO
     }
 
-    final int stepSize = solverToUse() == Solvers.BITWUZLA ? 10 : 1;
-    for (int i = 1; i < 20; i += stepSize) {
-      for (int j = 1; j < 20; j += stepSize) {
+    for (int i = 1; i < 20; i++) {
+      for (int j = 1; j < 20; j++) {
         dbls.add(i * Math.pow(10, j));
         dbls.add(-i * Math.pow(10, j));
       }
     }
 
-    final int numRandom = solverToUse() == Solvers.BITWUZLA ? 5 : NUM_RANDOM_TESTS;
     Random rand = new Random(0);
-    for (int i = 0; i < numRandom; i++) {
+    for (int i = 0; i < NUM_RANDOM_TESTS; i++) {
       double d = Double.longBitsToDouble(rand.nextLong());
       if (!Double.isNaN(d)) {
         dbls.add(d);

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -828,12 +828,6 @@ public class FloatingPointFormulaManagerTest
         .that(solverToUse())
         .isNoneOf(Solvers.CVC4, Solvers.CVC5);
 
-    // FIXME: This test is still painfully slow in Bitwuzla. Both fp2bv and bv2fp ultimately map
-    //  to the same operation in Bitwuzla as we define "b = fp2bv(f)" by adding the
-    //  side-condition "f = bv2fp(b)" to the constraints and then simply returning the new bitvector
-    //  variable `b`. The slow down here seems to be related the side-conditions that have to be
-    //  added to the assertions whenever isUnsat() is called.
-
     proveForAll(
         // makeBV(value.bits) == fromFP(makeFP(value.float))
         pFloat ->

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -783,16 +783,9 @@ public class FloatingPointFormulaManagerTest
   private <T> void proveForAll(Function<T, BooleanFormula> f, List<T> args)
       throws InterruptedException, SolverException {
     try (ProverEnvironment prover = context.newProverEnvironment()) {
-      if (solverToUse().equals(Solvers.BITWUZLA)) {
-        // Adding this line speeds up performance in checkIeeeBv2FpConversion32 by a factor of 10
-        // FIXME: I've no idea why this would work
-        prover.addConstraint(bmgr.makeTrue());
-      }
       for (T value : args) {
-        prover.push();
         prover.addConstraint(f.apply(value));
         assertThat(prover).isSatisfiable();
-        prover.pop();
       }
     }
   }

--- a/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/FloatingPointFormulaManagerTest.java
@@ -777,10 +777,10 @@ public class FloatingPointFormulaManagerTest
   /**
    * Map the function over the input list and prove the returned assertions.
    *
-   * @param f A function that takes values from the list and returns assertions
    * @param args A list of arguments to the function
+   * @param f A function that takes values from the list and returns assertions
    */
-  private <T> void proveForAll(Function<T, BooleanFormula> f, List<T> args)
+  private <T> void proveForAll(List<T> args, Function<T, BooleanFormula> f)
       throws InterruptedException, SolverException {
     try (ProverEnvironment prover = context.newProverEnvironment()) {
       for (T value : args) {
@@ -794,24 +794,24 @@ public class FloatingPointFormulaManagerTest
   public void checkIeeeBv2FpConversion32() throws SolverException, InterruptedException {
     proveForAll(
         // makeFP(value.float) == fromBV(makeBV(value.bits))
+        getListOfFloats(),
         pFloat ->
             fpmgr.equalWithFPSemantics(
                 fpmgr.makeNumber(pFloat, singlePrecType),
                 fpmgr.fromIeeeBitvector(
-                    bvmgr.makeBitvector(32, Float.floatToRawIntBits(pFloat)), singlePrecType)),
-        getListOfFloats());
+                    bvmgr.makeBitvector(32, Float.floatToRawIntBits(pFloat)), singlePrecType)));
   }
 
   @Test
   public void checkIeeeBv2FpConversion64() throws SolverException, InterruptedException {
     proveForAll(
         // makeFP(value.float) == fromBV(makeBV(value.bits))
+        getListOfDoubles(),
         pDouble ->
             fpmgr.equalWithFPSemantics(
                 fpmgr.makeNumber(pDouble, doublePrecType),
                 fpmgr.fromIeeeBitvector(
-                    bvmgr.makeBitvector(64, Double.doubleToRawLongBits(pDouble)), doublePrecType)),
-        getListOfDoubles());
+                    bvmgr.makeBitvector(64, Double.doubleToRawLongBits(pDouble)), doublePrecType)));
   }
 
   @Test
@@ -823,11 +823,11 @@ public class FloatingPointFormulaManagerTest
 
     proveForAll(
         // makeBV(value.bits) == fromFP(makeFP(value.float))
+        getListOfFloats(),
         pFloat ->
             bvmgr.equal(
                 bvmgr.makeBitvector(32, Float.floatToRawIntBits(pFloat)),
-                fpmgr.toIeeeBitvector(fpmgr.makeNumber(pFloat, singlePrecType))),
-        getListOfFloats());
+                fpmgr.toIeeeBitvector(fpmgr.makeNumber(pFloat, singlePrecType))));
   }
 
   @Test
@@ -839,11 +839,11 @@ public class FloatingPointFormulaManagerTest
 
     proveForAll(
         // makeBV(value.bits) == fromFP(makeFP(value.float))
+        getListOfFloats(),
         pDouble ->
             bvmgr.equal(
                 bvmgr.makeBitvector(64, Double.doubleToRawLongBits(pDouble)),
-                fpmgr.toIeeeBitvector(fpmgr.makeNumber(pDouble, doublePrecType))),
-        getListOfFloats());
+                fpmgr.toIeeeBitvector(fpmgr.makeNumber(pDouble, doublePrecType))));
   }
 
   private List<Float> getListOfFloats() {
@@ -1034,6 +1034,7 @@ public class FloatingPointFormulaManagerTest
   @Test
   public void fpFrom32BitPattern() throws SolverException, InterruptedException {
     proveForAll(
+        getListOfFloats(),
         pFloat -> {
           // makeFP(value.bits.sign, value.bits.exponent, value.bits.mantissa) = makeFP(value.float)
           int bits = Float.floatToRawIntBits(pFloat);
@@ -1045,14 +1046,14 @@ public class FloatingPointFormulaManagerTest
                   BigInteger.valueOf(exponent), BigInteger.valueOf(mantissa), sign, singlePrecType);
           final FloatingPointFormula fp = fpmgr.makeNumber(pFloat, singlePrecType);
           return fpmgr.assignment(fpFromBv, fp);
-        },
-        getListOfFloats());
+        });
   }
 
   @Test
   public void fpFrom64BitPattern() throws SolverException, InterruptedException {
     proveForAll(
         // makeFP(value.bits.sign, value.bits.exponent, value.bits.mantissa) = makeFP(value.float)
+        getListOfDoubles(),
         pDouble -> {
           long bits = Double.doubleToRawLongBits(pDouble);
           long exponent = (bits >>> 52) & 0x7FF;
@@ -1063,8 +1064,7 @@ public class FloatingPointFormulaManagerTest
                   BigInteger.valueOf(exponent), BigInteger.valueOf(mantissa), sign, doublePrecType);
           final FloatingPointFormula fp = fpmgr.makeNumber(pDouble, doublePrecType);
           return fpmgr.assignment(fpFromBv, fp);
-        },
-        getListOfDoubles());
+        });
   }
 
   @Test


### PR DESCRIPTION
Hello,
this MR aims to fix the performance issues described in #371. The problem was not about the conversion operation itself, but about the large number of ProverEnvironments that would be created, one for each test input. We solve this by reusing the same ProverEnvironment for all inputs of the test. This also improves the performance of Z3 for those same tests.

In addition to that the MR includes a number of minor fixes:
- Bitwuzla does not support float-to-bitvector conversions and we are using a work-around that introduces new side-conditions for the casts. We now make sure that side-conditions are only pushed onto the stack when needed. The old version would simply include everything in the query, even for variables that don't occur in the assertions, which can cause significant overhead
- We fixed the names that are used for the variables in these side-conditions to make sure that there are no clashes
- `FunctionDeclarationKind` gets a new Symbol `FP_REM` which was missing
- We also added support for `BV_SHR` and `BV_ROL`, `BV_ROLI`, `BV_ROR`, `BV_RORI` to the Bitwuzla `FormulaCreator`
