### PR TITLE
Fix ivy dependency org name

### DIFF
--- a/doc/Getting-started.md
+++ b/doc/Getting-started.md
@@ -22,7 +22,7 @@ which would automatically fetch `JavaSMT` and all of its dependencies.
 After the repository URL is configured, you only need to add the following dependency:
 
 ```xml
-<dependency org="org.sosy_lab" name="java-smt" rev="3.7.0"/>
+<dependency org="org.sosy-lab" name="java-smt" rev="5.0.1"/>
 ```
 
 ### Automatic Installation from Maven Central (possibly outdated)


### PR DESCRIPTION
Note the org name here
`https://mvnrepository.com/artifact/org.sosy-lab`

Otherwise perhaps I can add a note to use different org names depending on mvn vs sosy-lab repo usage?

Also bumps version to 5.0.1