### PR TITLE
#407: Revert API changes from introducing InterruptedException in more methods

### DIFF
--- a/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
@@ -32,7 +32,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    */
   @Nullable
   @CanIgnoreReturnValue
-  default T push(BooleanFormula f) throws InterruptedException, SolverException {
+  default T push(BooleanFormula f) throws InterruptedException {
     push();
     return addConstraint(f);
   }
@@ -46,7 +46,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
   /** Add a constraint to the latest backtracking point. */
   @Nullable
   @CanIgnoreReturnValue
-  T addConstraint(BooleanFormula constraint) throws InterruptedException, SolverException;
+  T addConstraint(BooleanFormula constraint) throws InterruptedException;
 
   /**
    * Create a new backtracking point, i.e., a new level on the assertion stack. Each level can hold
@@ -55,7 +55,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    * <p>If formulas are added before creating the first backtracking point, they can not be removed
    * via a POP-operation.
    */
-  void push() throws InterruptedException, SolverException;
+  void push() throws InterruptedException;
 
   /**
    * Get the number of backtracking points/levels on the current stack.
@@ -87,7 +87,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    * <p>A model might contain additional symbols with their evaluation, if a solver uses its own
    * temporary symbols. There should be at least a value-assignment for each free symbol.
    */
-  Model getModel() throws SolverException, InterruptedException;
+  Model getModel() throws SolverException;
 
   /**
    * Get a temporary view on the current satisfying assignment. This should be called only
@@ -95,7 +95,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    * should no longer be used as soon as any constraints are added to, pushed, or popped from the
    * prover stack.
    */
-  default Evaluator getEvaluator() throws InterruptedException, SolverException {
+  default Evaluator getEvaluator() throws SolverException {
     return getModel();
   }
 
@@ -107,8 +107,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    * <p>Note that if you need to iterate multiple times over the model it may be more efficient to
    * use this method instead of {@link #getModel()} (depending on the solver).
    */
-  default ImmutableList<Model.ValueAssignment> getModelAssignments()
-      throws SolverException, InterruptedException {
+  default ImmutableList<Model.ValueAssignment> getModelAssignments() throws SolverException {
     try (Model model = getModel()) {
       return model.asList();
     }

--- a/src/org/sosy_lab/java_smt/api/Evaluator.java
+++ b/src/org/sosy_lab/java_smt/api/Evaluator.java
@@ -47,7 +47,7 @@ public interface Evaluator extends AutoCloseable {
    * @return evaluation of the given formula or <code>null</code> if the solver does not provide a
    *     better evaluation.
    */
-  @Nullable <T extends Formula> T eval(T formula) throws InterruptedException, SolverException;
+  @Nullable <T extends Formula> T eval(T formula);
 
   /**
    * Evaluate a given formula substituting the values from the model.
@@ -62,60 +62,56 @@ public interface Evaluator extends AutoCloseable {
    * @return Either of: - Number (Rational/Double/BigInteger/Long/Integer) - Boolean
    * @throws IllegalArgumentException if a formula has unexpected type, e.g. Array.
    */
-  @Nullable Object evaluate(Formula formula) throws InterruptedException, SolverException;
+  @Nullable Object evaluate(Formula formula);
 
   /**
    * Type-safe evaluation for integer formulas.
    *
    * <p>The formula does not need to be a variable, we also allow complex expression.
    */
-  @Nullable BigInteger evaluate(IntegerFormula formula)
-      throws InterruptedException, SolverException;
+  @Nullable BigInteger evaluate(IntegerFormula formula);
 
   /**
    * Type-safe evaluation for rational formulas.
    *
    * <p>The formula does not need to be a variable, we also allow complex expression.
    */
-  @Nullable Rational evaluate(RationalFormula formula) throws InterruptedException, SolverException;
+  @Nullable Rational evaluate(RationalFormula formula);
 
   /**
    * Type-safe evaluation for boolean formulas.
    *
    * <p>The formula does not need to be a variable, we also allow complex expression.
    */
-  @Nullable Boolean evaluate(BooleanFormula formula) throws InterruptedException, SolverException;
+  @Nullable Boolean evaluate(BooleanFormula formula);
 
   /**
    * Type-safe evaluation for bitvector formulas.
    *
    * <p>The formula does not need to be a variable, we also allow complex expression.
    */
-  @Nullable BigInteger evaluate(BitvectorFormula formula)
-      throws InterruptedException, SolverException;
+  @Nullable BigInteger evaluate(BitvectorFormula formula);
 
   /**
    * Type-safe evaluation for string formulas.
    *
    * <p>The formula does not need to be a variable, we also allow complex expression.
    */
-  @Nullable String evaluate(StringFormula formula) throws InterruptedException, SolverException;
+  @Nullable String evaluate(StringFormula formula);
 
   /**
    * Type-safe evaluation for enumeration formulas.
    *
    * <p>The formula does not need to be a variable, we also allow complex expression.
    */
-  @Nullable String evaluate(EnumerationFormula formula)
-      throws InterruptedException, SolverException;
+  @Nullable String evaluate(EnumerationFormula formula);
 
   /**
    * Type-safe evaluation for floating-point formulas.
    *
    * <p>The formula does not need to be a variable, we also allow complex expression.
    */
-  @Nullable FloatingPointNumber evaluate(FloatingPointFormula formula)
-      throws InterruptedException, SolverException;
+  @Nullable FloatingPointNumber evaluate(FloatingPointFormula formula);
 
   /**
    * Free resources associated with this evaluator (existing {@link Formula} instances stay valid,

--- a/src/org/sosy_lab/java_smt/api/Model.java
+++ b/src/org/sosy_lab/java_smt/api/Model.java
@@ -52,15 +52,11 @@ public interface Model extends Evaluator, Iterable<ValueAssignment>, AutoCloseab
    */
   @Override
   default Iterator<ValueAssignment> iterator() {
-    try {
-      return asList().iterator();
-    } catch (InterruptedException | SolverException e) {
-      throw new RuntimeException(e);
-    }
+    return asList().iterator();
   }
 
   /** Build a list of assignments that stays valid after closing the model. */
-  ImmutableList<ValueAssignment> asList() throws InterruptedException, SolverException;
+  ImmutableList<ValueAssignment> asList();
 
   /**
    * Pretty-printing of the model values.

--- a/src/org/sosy_lab/java_smt/api/OptimizationProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/api/OptimizationProverEnvironment.java
@@ -68,7 +68,7 @@ public interface OptimizationProverEnvironment extends BasicProverEnvironment<Vo
    * (epsilon is irrelevant here and can be zero). The model returns the optimal assignment x=9.
    */
   @Override
-  Model getModel() throws SolverException, InterruptedException;
+  Model getModel() throws SolverException;
 
   /** Status of the optimization problem. */
   enum OptStatus {

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractEvaluator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractEvaluator.java
@@ -22,7 +22,6 @@ import org.sosy_lab.java_smt.api.FloatingPointNumber;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.StringFormula;
 
 @SuppressWarnings("ClassTypeParameterName")
@@ -41,7 +40,7 @@ public abstract class AbstractEvaluator<TFormulaInfo, TType, TEnv> implements Ev
   @SuppressWarnings("unchecked")
   @Nullable
   @Override
-  public final <T extends Formula> T eval(T f) throws InterruptedException, SolverException {
+  public final <T extends Formula> T eval(T f) {
     Preconditions.checkState(!isClosed());
     TFormulaInfo evaluation = evalImpl(creator.extractInfo(f));
     return evaluation == null ? null : (T) creator.encapsulateWithTypeOf(evaluation);
@@ -49,14 +48,14 @@ public abstract class AbstractEvaluator<TFormulaInfo, TType, TEnv> implements Ev
 
   @Nullable
   @Override
-  public final BigInteger evaluate(IntegerFormula f) throws InterruptedException, SolverException {
+  public final BigInteger evaluate(IntegerFormula f) {
     Preconditions.checkState(!isClosed());
     return (BigInteger) evaluateImpl(creator.extractInfo(f));
   }
 
   @Nullable
   @Override
-  public Rational evaluate(RationalFormula f) throws InterruptedException, SolverException {
+  public Rational evaluate(RationalFormula f) {
     Object value = evaluateImpl(creator.extractInfo(f));
     if (value instanceof BigInteger) {
       // We simplified the value internally. Here, we need to convert it back to Rational.
@@ -68,43 +67,41 @@ public abstract class AbstractEvaluator<TFormulaInfo, TType, TEnv> implements Ev
 
   @Nullable
   @Override
-  public final Boolean evaluate(BooleanFormula f) throws InterruptedException, SolverException {
+  public final Boolean evaluate(BooleanFormula f) {
     Preconditions.checkState(!isClosed());
     return (Boolean) evaluateImpl(creator.extractInfo(f));
   }
 
   @Nullable
   @Override
-  public final String evaluate(StringFormula f) throws InterruptedException, SolverException {
+  public final String evaluate(StringFormula f) {
     Preconditions.checkState(!isClosed());
     return (String) evaluateImpl(creator.extractInfo(f));
   }
 
   @Nullable
   @Override
-  public final String evaluate(EnumerationFormula f) throws InterruptedException, SolverException {
+  public final String evaluate(EnumerationFormula f) {
     Preconditions.checkState(!isClosed());
     return (String) evaluateImpl(creator.extractInfo(f));
   }
 
   @Override
-  public final @Nullable FloatingPointNumber evaluate(FloatingPointFormula f)
-      throws InterruptedException, SolverException {
+  public final @Nullable FloatingPointNumber evaluate(FloatingPointFormula f) {
     Preconditions.checkState(!isClosed());
     return (FloatingPointNumber) evaluateImpl(creator.extractInfo(f));
   }
 
   @Nullable
   @Override
-  public final BigInteger evaluate(BitvectorFormula f)
-      throws InterruptedException, SolverException {
+  public final BigInteger evaluate(BitvectorFormula f) {
     Preconditions.checkState(!isClosed());
     return (BigInteger) evaluateImpl(creator.extractInfo(f));
   }
 
   @Nullable
   @Override
-  public final Object evaluate(Formula f) throws InterruptedException, SolverException {
+  public final Object evaluate(Formula f) {
     Preconditions.checkState(!isClosed());
     Preconditions.checkArgument(
         !(f instanceof ArrayFormula),
@@ -117,8 +114,7 @@ public abstract class AbstractEvaluator<TFormulaInfo, TType, TEnv> implements Ev
    * set in the model and evaluation aborts, return <code>null</code>.
    */
   @Nullable
-  protected abstract TFormulaInfo evalImpl(TFormulaInfo formula)
-      throws InterruptedException, SolverException;
+  protected abstract TFormulaInfo evalImpl(TFormulaInfo formula);
 
   /**
    * Simplify the given formula and replace all symbols with their model values. If a symbol is not
@@ -126,7 +122,7 @@ public abstract class AbstractEvaluator<TFormulaInfo, TType, TEnv> implements Ev
    * formula into a Java object as far as possible, i.e., try to match a primitive or simple type.
    */
   @Nullable
-  protected final Object evaluateImpl(TFormulaInfo f) throws InterruptedException, SolverException {
+  protected final Object evaluateImpl(TFormulaInfo f) {
     Preconditions.checkState(!isClosed());
     TFormulaInfo evaluatedF = evalImpl(f);
     return evaluatedF == null ? null : creator.convertValue(f, evaluatedF);

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -26,7 +26,6 @@ import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Evaluator;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
-import org.sosy_lab.java_smt.api.SolverException;
 
 public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
 
@@ -89,13 +88,13 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public final void push() throws InterruptedException, SolverException {
+  public final void push() throws InterruptedException {
     checkState(!closed);
     pushImpl();
     assertedFormulas.add(LinkedHashMultimap.create());
   }
 
-  protected abstract void pushImpl() throws InterruptedException, SolverException;
+  protected abstract void pushImpl() throws InterruptedException;
 
   @Override
   public final void pop() {
@@ -109,8 +108,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
 
   @Override
   @CanIgnoreReturnValue
-  public final @Nullable T addConstraint(BooleanFormula constraint)
-      throws InterruptedException, SolverException {
+  public final @Nullable T addConstraint(BooleanFormula constraint) throws InterruptedException {
     checkState(!closed);
     T t = addConstraintImpl(constraint);
     Iterables.getLast(assertedFormulas).put(constraint, t);
@@ -118,7 +116,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   }
 
   protected abstract @Nullable T addConstraintImpl(BooleanFormula constraint)
-      throws InterruptedException, SolverException;
+      throws InterruptedException;
 
   protected ImmutableSet<BooleanFormula> getAssertedFormulas() {
     ImmutableSet.Builder<BooleanFormula> builder = ImmutableSet.builder();

--- a/src/org/sosy_lab/java_smt/basicimpl/CachingModel.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/CachingModel.java
@@ -22,7 +22,6 @@ import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.StringFormula;
 
 public class CachingModel implements Model {
@@ -36,7 +35,7 @@ public class CachingModel implements Model {
   }
 
   @Override
-  public ImmutableList<ValueAssignment> asList() throws InterruptedException, SolverException {
+  public ImmutableList<ValueAssignment> asList() {
     if (modelAssignments == null) {
       modelAssignments = delegate.asList();
     }
@@ -49,55 +48,47 @@ public class CachingModel implements Model {
   }
 
   @Override
-  public <T extends Formula> @Nullable T eval(T formula)
-      throws InterruptedException, SolverException {
+  public <T extends Formula> @Nullable T eval(T formula) {
     return delegate.eval(formula);
   }
 
   @Override
-  public @Nullable Object evaluate(Formula formula) throws InterruptedException, SolverException {
+  public @Nullable Object evaluate(Formula formula) {
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable BigInteger evaluate(IntegerFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable BigInteger evaluate(IntegerFormula formula) {
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable Rational evaluate(RationalFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable Rational evaluate(RationalFormula formula) {
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable Boolean evaluate(BooleanFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable Boolean evaluate(BooleanFormula formula) {
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable BigInteger evaluate(BitvectorFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable BigInteger evaluate(BitvectorFormula formula) {
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable String evaluate(StringFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable String evaluate(StringFormula formula) {
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable String evaluate(EnumerationFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable String evaluate(EnumerationFormula formula) {
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula formula) {
     return delegate.evaluate(formula);
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/withAssumptionsWrapper/BasicProverWithAssumptionsWrapper.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/withAssumptionsWrapper/BasicProverWithAssumptionsWrapper.java
@@ -43,13 +43,13 @@ public class BasicProverWithAssumptionsWrapper<T, P extends BasicProverEnvironme
   }
 
   @Override
-  public T addConstraint(BooleanFormula constraint) throws InterruptedException, SolverException {
+  public T addConstraint(BooleanFormula constraint) throws InterruptedException {
     clearAssumptions();
     return delegate.addConstraint(constraint);
   }
 
   @Override
-  public void push() throws InterruptedException, SolverException {
+  public void push() throws InterruptedException {
     clearAssumptions();
     delegate.push();
   }
@@ -80,13 +80,12 @@ public class BasicProverWithAssumptionsWrapper<T, P extends BasicProverEnvironme
   protected void registerPushedFormula(@SuppressWarnings("unused") T pPushResult) {}
 
   @Override
-  public Model getModel() throws SolverException, InterruptedException {
+  public Model getModel() throws SolverException {
     return delegate.getModel();
   }
 
   @Override
-  public ImmutableList<Model.ValueAssignment> getModelAssignments()
-      throws SolverException, InterruptedException {
+  public ImmutableList<Model.ValueAssignment> getModelAssignments() throws SolverException {
     return delegate.getModelAssignments();
   }
 

--- a/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingBasicProverEnvironment.java
@@ -36,15 +36,14 @@ class DebuggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public @Nullable T addConstraint(BooleanFormula constraint)
-      throws InterruptedException, SolverException {
+  public @Nullable T addConstraint(BooleanFormula constraint) throws InterruptedException {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(constraint);
     return delegate.addConstraint(constraint);
   }
 
   @Override
-  public void push() throws InterruptedException, SolverException {
+  public void push() throws InterruptedException {
     debugging.assertThreadLocal();
     delegate.push();
   }
@@ -73,7 +72,7 @@ class DebuggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException, InterruptedException {
+  public Model getModel() throws SolverException {
     debugging.assertThreadLocal();
     return new DebuggingModel(delegate.getModel(), debugging);
   }

--- a/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingModel.java
+++ b/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingModel.java
@@ -23,7 +23,6 @@ import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.StringFormula;
 
 public class DebuggingModel implements Model {
@@ -36,8 +35,7 @@ public class DebuggingModel implements Model {
   }
 
   @Override
-  public <T extends Formula> @Nullable T eval(T formula)
-      throws InterruptedException, SolverException {
+  public <T extends Formula> @Nullable T eval(T formula) {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(formula);
     T result = delegate.eval(formula);
@@ -46,70 +44,63 @@ public class DebuggingModel implements Model {
   }
 
   @Override
-  public @Nullable Object evaluate(Formula formula) throws InterruptedException, SolverException {
+  public @Nullable Object evaluate(Formula formula) {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(formula);
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable BigInteger evaluate(IntegerFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable BigInteger evaluate(IntegerFormula formula) {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(formula);
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable Rational evaluate(RationalFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable Rational evaluate(RationalFormula formula) {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(formula);
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable Boolean evaluate(BooleanFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable Boolean evaluate(BooleanFormula formula) {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(formula);
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable BigInteger evaluate(BitvectorFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable BigInteger evaluate(BitvectorFormula formula) {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(formula);
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable String evaluate(StringFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable String evaluate(StringFormula formula) {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(formula);
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable String evaluate(EnumerationFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable String evaluate(EnumerationFormula formula) {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(formula);
     return delegate.evaluate(formula);
   }
 
   @Override
-  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula formula)
-      throws InterruptedException, SolverException {
+  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula formula) {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(formula);
     return delegate.evaluate(formula);
   }
 
   @Override
-  public ImmutableList<ValueAssignment> asList() throws InterruptedException, SolverException {
+  public ImmutableList<ValueAssignment> asList() {
     debugging.assertThreadLocal();
     ImmutableList<ValueAssignment> result = delegate.asList();
     for (ValueAssignment v : result) {

--- a/src/org/sosy_lab/java_smt/delegate/logging/LoggingBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/logging/LoggingBasicProverEnvironment.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.common.log.LogManager;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -38,7 +39,7 @@ class LoggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public T push(BooleanFormula f) throws InterruptedException, SolverException {
+  public @Nullable T push(BooleanFormula f) throws InterruptedException {
     logger.log(Level.FINE, "up to level " + level++);
     logger.log(Level.FINE, "formula pushed:", f);
     return wrapped.push(f);
@@ -51,12 +52,12 @@ class LoggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public T addConstraint(BooleanFormula constraint) throws InterruptedException, SolverException {
+  public @Nullable T addConstraint(BooleanFormula constraint) throws InterruptedException {
     return wrapped.addConstraint(constraint);
   }
 
   @Override
-  public void push() throws InterruptedException, SolverException {
+  public void push() throws InterruptedException {
     logger.log(Level.FINE, "up to level " + level++);
     wrapped.push();
   }
@@ -86,15 +87,14 @@ class LoggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public Model getModel() throws SolverException, InterruptedException {
+  public Model getModel() throws SolverException {
     Model m = wrapped.getModel();
     logger.log(Level.FINE, "model", m);
     return m;
   }
 
   @Override
-  public ImmutableList<ValueAssignment> getModelAssignments()
-      throws SolverException, InterruptedException {
+  public ImmutableList<ValueAssignment> getModelAssignments() throws SolverException {
     ImmutableList<ValueAssignment> m = wrapped.getModelAssignments();
     logger.log(Level.FINE, "model", m);
     return m;

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsBasicProverEnvironment.java
@@ -42,14 +42,13 @@ class StatisticsBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public @Nullable T addConstraint(BooleanFormula pConstraint)
-      throws InterruptedException, SolverException {
+  public @Nullable T addConstraint(BooleanFormula pConstraint) throws InterruptedException {
     stats.constraint.getAndIncrement();
     return delegate.addConstraint(pConstraint);
   }
 
   @Override
-  public void push() throws InterruptedException, SolverException {
+  public void push() throws InterruptedException {
     stats.push.getAndIncrement();
     delegate.push();
   }
@@ -82,7 +81,7 @@ class StatisticsBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException, InterruptedException {
+  public Model getModel() throws SolverException {
     stats.model.getAndIncrement();
     return new StatisticsModel(delegate.getModel(), stats);
   }

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsModel.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsModel.java
@@ -23,7 +23,6 @@ import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.StringFormula;
 
 class StatisticsModel implements Model {
@@ -37,68 +36,61 @@ class StatisticsModel implements Model {
   }
 
   @Override
-  public <T extends Formula> @Nullable T eval(T pFormula)
-      throws InterruptedException, SolverException {
+  public <T extends Formula> @Nullable T eval(T pFormula) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.eval(pFormula);
   }
 
   @Override
-  public @Nullable Object evaluate(Formula pF) throws InterruptedException, SolverException {
+  public @Nullable Object evaluate(Formula pF) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.evaluate(pF);
   }
 
   @Override
-  public @Nullable BigInteger evaluate(IntegerFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable BigInteger evaluate(IntegerFormula pF) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.evaluate(pF);
   }
 
   @Override
-  public @Nullable Rational evaluate(RationalFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable Rational evaluate(RationalFormula pF) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.evaluate(pF);
   }
 
   @Override
-  public @Nullable Boolean evaluate(BooleanFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable Boolean evaluate(BooleanFormula pF) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.evaluate(pF);
   }
 
   @Override
-  public @Nullable BigInteger evaluate(BitvectorFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable BigInteger evaluate(BitvectorFormula pF) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.evaluate(pF);
   }
 
   @Override
-  public @Nullable String evaluate(StringFormula pF) throws InterruptedException, SolverException {
+  public @Nullable String evaluate(StringFormula pF) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.evaluate(pF);
   }
 
   @Override
-  public @Nullable String evaluate(EnumerationFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable String evaluate(EnumerationFormula pF) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.evaluate(pF);
   }
 
   @Override
-  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula pF) {
     stats.modelEvaluations.getAndIncrement();
     return delegate.evaluate(pF);
   }
 
   @Override
-  public ImmutableList<ValueAssignment> asList() throws InterruptedException, SolverException {
+  public ImmutableList<ValueAssignment> asList() {
     stats.modelListings.getAndIncrement();
     return delegate.asList();
   }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironment.java
@@ -39,15 +39,14 @@ class SynchronizedBasicProverEnvironment<T> implements BasicProverEnvironment<T>
   }
 
   @Override
-  public @Nullable T addConstraint(BooleanFormula pConstraint)
-      throws InterruptedException, SolverException {
+  public @Nullable T addConstraint(BooleanFormula pConstraint) throws InterruptedException {
     synchronized (sync) {
       return delegate.addConstraint(pConstraint);
     }
   }
 
   @Override
-  public void push() throws InterruptedException, SolverException {
+  public void push() throws InterruptedException {
     synchronized (sync) {
       delegate.push();
     }
@@ -77,7 +76,7 @@ class SynchronizedBasicProverEnvironment<T> implements BasicProverEnvironment<T>
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException, InterruptedException {
+  public Model getModel() throws SolverException {
     synchronized (sync) {
       return new SynchronizedModel(delegate.getModel(), sync);
     }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironmentWithContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironmentWithContext.java
@@ -58,8 +58,7 @@ class SynchronizedBasicProverEnvironmentWithContext<T> implements BasicProverEnv
   }
 
   @Override
-  public @Nullable T addConstraint(BooleanFormula pConstraint)
-      throws InterruptedException, SolverException {
+  public @Nullable T addConstraint(BooleanFormula pConstraint) throws InterruptedException {
     BooleanFormula constraint;
     synchronized (sync) {
       constraint = otherManager.translateFrom(pConstraint, manager);
@@ -68,7 +67,7 @@ class SynchronizedBasicProverEnvironmentWithContext<T> implements BasicProverEnv
   }
 
   @Override
-  public void push() throws InterruptedException, SolverException {
+  public void push() throws InterruptedException {
     delegate.push();
   }
 
@@ -92,7 +91,7 @@ class SynchronizedBasicProverEnvironmentWithContext<T> implements BasicProverEnv
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException, InterruptedException {
+  public Model getModel() throws SolverException {
     synchronized (sync) {
       return new SynchronizedModelWithContext(delegate.getModel(), sync, manager, otherManager);
     }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModel.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModel.java
@@ -24,7 +24,6 @@ import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.SolverContext;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.StringFormula;
 
 class SynchronizedModel implements Model {
@@ -38,77 +37,70 @@ class SynchronizedModel implements Model {
   }
 
   @Override
-  public <T extends Formula> @Nullable T eval(T pFormula)
-      throws InterruptedException, SolverException {
+  public <T extends Formula> @Nullable T eval(T pFormula) {
     synchronized (sync) {
       return delegate.eval(pFormula);
     }
   }
 
   @Override
-  public @Nullable Object evaluate(Formula pF) throws InterruptedException, SolverException {
+  public @Nullable Object evaluate(Formula pF) {
     synchronized (sync) {
       return delegate.evaluate(pF);
     }
   }
 
   @Override
-  public @Nullable BigInteger evaluate(IntegerFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable BigInteger evaluate(IntegerFormula pF) {
     synchronized (sync) {
       return delegate.evaluate(pF);
     }
   }
 
   @Override
-  public @Nullable Rational evaluate(RationalFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable Rational evaluate(RationalFormula pF) {
     synchronized (sync) {
       return delegate.evaluate(pF);
     }
   }
 
   @Override
-  public @Nullable Boolean evaluate(BooleanFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable Boolean evaluate(BooleanFormula pF) {
     synchronized (sync) {
       return delegate.evaluate(pF);
     }
   }
 
   @Override
-  public @Nullable BigInteger evaluate(BitvectorFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable BigInteger evaluate(BitvectorFormula pF) {
     synchronized (sync) {
       return delegate.evaluate(pF);
     }
   }
 
   @Override
-  public @Nullable String evaluate(StringFormula pF) throws InterruptedException, SolverException {
+  public @Nullable String evaluate(StringFormula pF) {
     synchronized (sync) {
       return delegate.evaluate(pF);
     }
   }
 
   @Override
-  public @Nullable String evaluate(EnumerationFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable String evaluate(EnumerationFormula pF) {
     synchronized (sync) {
       return delegate.evaluate(pF);
     }
   }
 
   @Override
-  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable FloatingPointNumber evaluate(FloatingPointFormula pF) {
     synchronized (sync) {
       return delegate.evaluate(pF);
     }
   }
 
   @Override
-  public ImmutableList<ValueAssignment> asList() throws InterruptedException, SolverException {
+  public ImmutableList<ValueAssignment> asList() {
     synchronized (sync) {
       return delegate.asList();
     }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModelWithContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedModelWithContext.java
@@ -25,7 +25,6 @@ import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.SolverContext;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.StringFormula;
 
 class SynchronizedModelWithContext implements Model {
@@ -67,8 +66,7 @@ class SynchronizedModelWithContext implements Model {
   }
 
   @Override
-  public @Nullable Boolean evaluate(BooleanFormula pF)
-      throws InterruptedException, SolverException {
+  public @Nullable Boolean evaluate(BooleanFormula pF) {
     BooleanFormula f;
     synchronized (sync) {
       f = otherManager.translateFrom(pF, manager);

--- a/src/org/sosy_lab/java_smt/example/NQueens.java
+++ b/src/org/sosy_lab/java_smt/example/NQueens.java
@@ -260,8 +260,7 @@ public final class NQueens {
    * @param col the column index of the cell to check.
    * @return true if a queen is placed on the cell, false otherwise.
    */
-  private boolean getValue(BooleanFormula[][] symbols, Model model, int row, int col)
-      throws InterruptedException, SolverException {
+  private boolean getValue(BooleanFormula[][] symbols, Model model, int row, int col) {
     return Boolean.TRUE.equals(model.evaluate(symbols[row][col]));
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaModel.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaModel.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractModel;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Bitwuzla;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Kind;
@@ -51,7 +50,7 @@ class BitwuzlaModel extends AbstractModel<Term, Sort, Void> {
 
   /** Build a list of assignments that stays valid after closing the model. */
   @Override
-  public ImmutableList<ValueAssignment> asList() throws InterruptedException, SolverException {
+  public ImmutableList<ValueAssignment> asList() {
     Preconditions.checkState(!isClosed());
     Preconditions.checkState(!prover.isClosed(), "Cannot use model after prover is closed");
     ImmutableSet.Builder<ValueAssignment> variablesBuilder = ImmutableSet.builder();
@@ -109,15 +108,13 @@ class BitwuzlaModel extends AbstractModel<Term, Sort, Void> {
         argumentInterpretation);
   }
 
-  private Collection<ValueAssignment> getArrayAssignment(Term pTerm)
-      throws InterruptedException, SolverException {
+  private Collection<ValueAssignment> getArrayAssignment(Term pTerm) {
     return getArrayAssignments(pTerm, ImmutableList.of());
   }
 
   // TODO: check this in detail. I think this might be incomplete.
   // We should add more Model tests in general. As most are parsing and int based!
-  private Collection<ValueAssignment> getArrayAssignments(Term pTerm, List<Object> upperIndices)
-      throws InterruptedException, SolverException {
+  private Collection<ValueAssignment> getArrayAssignments(Term pTerm, List<Object> upperIndices) {
     // Array children for store are structured in the following way:
     // {starting array, index, value} in "we add value at index to array"
     // Selections are structured: {starting array, index}

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorNativeApiTest.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorNativeApiTest.java
@@ -153,7 +153,7 @@ public class BoolectorNativeApiTest {
 
   @Test
   public void dumpVariableWithAssertionsOnStackTest()
-      throws InvalidConfigurationException, InterruptedException, SolverException {
+      throws InvalidConfigurationException, InterruptedException {
     ConfigurationBuilder config = Configuration.builder();
     try (BoolectorSolverContext context =
         BoolectorSolverContext.create(

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4Model.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4Model.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.List;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Formula;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractModel;
 
 public class CVC4Model extends AbstractModel<Expr, Type, ExprManager> {
@@ -35,8 +34,7 @@ public class CVC4Model extends AbstractModel<Expr, Type, ExprManager> {
       CVC4TheoremProver pProver,
       CVC4FormulaCreator pCreator,
       SmtEngine pSmtEngine,
-      Collection<Expr> pAssertedExpressions)
-      throws InterruptedException, SolverException {
+      Collection<Expr> pAssertedExpressions) {
     super(pProver, pCreator);
     smtEngine = pSmtEngine;
     prover = pProver;
@@ -62,8 +60,7 @@ public class CVC4Model extends AbstractModel<Expr, Type, ExprManager> {
     return prover.exportExpr(smtEngine.getValue(prover.importExpr(f)));
   }
 
-  private ImmutableList<ValueAssignment> generateModel()
-      throws InterruptedException, SolverException {
+  private ImmutableList<ValueAssignment> generateModel() {
     ImmutableSet.Builder<ValueAssignment> builder = ImmutableSet.builder();
     // Using creator.extractVariablesAndUFs we wouldn't get accurate information anymore as we
     // translate all bound vars back to their free counterparts in the visitor!
@@ -75,8 +72,7 @@ public class CVC4Model extends AbstractModel<Expr, Type, ExprManager> {
   }
 
   // TODO this method is highly recursive and should be rewritten with a proper visitor
-  private void recursiveAssignmentFinder(ImmutableSet.Builder<ValueAssignment> builder, Expr expr)
-      throws InterruptedException, SolverException {
+  private void recursiveAssignmentFinder(ImmutableSet.Builder<ValueAssignment> builder, Expr expr) {
     if (expr.isConst() || expr.isNull()) {
       // We don't care about consts.
       return;
@@ -99,8 +95,7 @@ public class CVC4Model extends AbstractModel<Expr, Type, ExprManager> {
     }
   }
 
-  private ValueAssignment getAssignment(Expr pKeyTerm)
-      throws InterruptedException, SolverException {
+  private ValueAssignment getAssignment(Expr pKeyTerm) {
     List<Object> argumentInterpretation = new ArrayList<>();
     for (Expr param : pKeyTerm) {
       argumentInterpretation.add(evaluateImpl(param));

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -135,7 +135,7 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
 
   @SuppressWarnings("resource")
   @Override
-  public CVC4Model getModel() throws InterruptedException, SolverException {
+  public CVC4Model getModel() throws SolverException {
     Preconditions.checkState(!closed);
     Preconditions.checkState(!changedSinceLastSatQuery);
     checkGenerateModels();
@@ -174,8 +174,7 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
   }
 
   @Override
-  public ImmutableList<ValueAssignment> getModelAssignments()
-      throws SolverException, InterruptedException {
+  public ImmutableList<ValueAssignment> getModelAssignments() throws SolverException {
     Preconditions.checkState(!closed);
     Preconditions.checkState(!changedSinceLastSatQuery);
     return super.getModelAssignments();

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -142,7 +142,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public CVC5Model getModel() throws InterruptedException, SolverException {
+  public CVC5Model getModel() throws SolverException {
     Preconditions.checkState(!closed);
     Preconditions.checkState(!changedSinceLastSatQuery);
     checkGenerateModels();
@@ -177,8 +177,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public ImmutableList<ValueAssignment> getModelAssignments()
-      throws SolverException, InterruptedException {
+  public ImmutableList<ValueAssignment> getModelAssignments() throws SolverException {
     Preconditions.checkState(!closed);
     Preconditions.checkState(!changedSinceLastSatQuery);
     return super.getModelAssignments();

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Model.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Model.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaManager;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractModel;
 
 public class CVC5Model extends AbstractModel<Term, Sort, Solver> {
@@ -36,8 +35,7 @@ public class CVC5Model extends AbstractModel<Term, Sort, Solver> {
       CVC5AbstractProver<?> pProver,
       FormulaManager pMgr,
       CVC5FormulaCreator pCreator,
-      Collection<Term> pAssertedExpressions)
-      throws InterruptedException, SolverException {
+      Collection<Term> pAssertedExpressions) {
     super(pProver, pCreator);
     solver = pProver.solver;
     mgr = pMgr;
@@ -55,8 +53,7 @@ public class CVC5Model extends AbstractModel<Term, Sort, Solver> {
     return solver.getValue(f);
   }
 
-  private ImmutableList<ValueAssignment> generateModel()
-      throws InterruptedException, SolverException {
+  private ImmutableList<ValueAssignment> generateModel() {
     ImmutableSet.Builder<ValueAssignment> builder = ImmutableSet.builder();
     // Using creator.extractVariablesAndUFs we wouldn't get accurate information anymore as we
     // translate all bound vars back to their free counterparts in the visitor!
@@ -68,8 +65,7 @@ public class CVC5Model extends AbstractModel<Term, Sort, Solver> {
   }
 
   // TODO this method is highly recursive and should be rewritten with a proper visitor
-  private void recursiveAssignmentFinder(ImmutableSet.Builder<ValueAssignment> builder, Term expr)
-      throws InterruptedException, SolverException {
+  private void recursiveAssignmentFinder(ImmutableSet.Builder<ValueAssignment> builder, Term expr) {
     try {
       Sort sort = expr.getSort();
       Kind kind = expr.getKind();
@@ -110,8 +106,7 @@ public class CVC5Model extends AbstractModel<Term, Sort, Solver> {
     }
   }
 
-  private ValueAssignment getAssignmentForUf(Term pKeyTerm)
-      throws InterruptedException, SolverException {
+  private ValueAssignment getAssignmentForUf(Term pKeyTerm) {
     // Ufs consist of arguments + 1 child, the first child is the function definition as a lambda
     // and the result, while the remaining children are the arguments. Note: we can't evaluate bound
     // variables!
@@ -171,8 +166,7 @@ public class CVC5Model extends AbstractModel<Term, Sort, Solver> {
         keyFormula, valueFormula, equation, nameStr, value, argumentInterpretationBuilder.build());
   }
 
-  private ValueAssignment getAssignment(Term pKeyTerm)
-      throws InterruptedException, SolverException {
+  private ValueAssignment getAssignment(Term pKeyTerm) {
     ImmutableList.Builder<Object> argumentInterpretationBuilder = ImmutableList.builder();
     for (int i = 0; i < pKeyTerm.getNumChildren(); i++) {
       try {

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5Model.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5Model.java
@@ -30,7 +30,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractModel;
 
 class Mathsat5Model extends AbstractModel<Long, Long, Long> {
@@ -49,7 +48,7 @@ class Mathsat5Model extends AbstractModel<Long, Long, Long> {
   }
 
   @Override
-  public ImmutableList<ValueAssignment> asList() throws InterruptedException, SolverException {
+  public ImmutableList<ValueAssignment> asList() {
     Preconditions.checkState(!isClosed());
     Preconditions.checkState(!prover.isClosed(), "cannot use model after prover is closed");
     ImmutableList.Builder<ValueAssignment> assignments = ImmutableList.builder();
@@ -72,8 +71,7 @@ class Mathsat5Model extends AbstractModel<Long, Long, Long> {
     return assignments.build();
   }
 
-  private ValueAssignment getAssignment(long key, long value)
-      throws InterruptedException, SolverException {
+  private ValueAssignment getAssignment(long key, long value) {
     List<Object> argumentInterpretation = new ArrayList<>();
     for (int i = 0; i < msat_term_arity(key); i++) {
       long arg = msat_term_get_arg(key, i);
@@ -91,8 +89,7 @@ class Mathsat5Model extends AbstractModel<Long, Long, Long> {
 
   /** split an array-assignment into several assignments for all positions. */
   private Collection<ValueAssignment> getArrayAssignments(
-      long symbol, long key, long array, List<Object> upperIndices)
-      throws InterruptedException, SolverException {
+      long symbol, long key, long array, List<Object> upperIndices) {
     Collection<ValueAssignment> assignments = new ArrayList<>();
     Set<Long> indices = new HashSet<>();
     while (msat_term_is_array_write(creator.getEnv(), array)) {

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -145,8 +145,7 @@ public abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<
   }
 
   @Override
-  public ImmutableList<ValueAssignment> getModelAssignments()
-      throws SolverException, InterruptedException {
+  public ImmutableList<ValueAssignment> getModelAssignments() throws SolverException {
     Preconditions.checkState(!closed);
     Preconditions.checkState(!changedSinceLastSatQuery);
     return super.getModelAssignments();

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolModel.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolModel.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractModel;
 import org.sosy_lab.java_smt.basicimpl.AbstractProver;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
@@ -45,7 +44,7 @@ class SmtInterpolModel extends AbstractModel<Term, Sort, Script> {
   }
 
   @Override
-  public ImmutableList<ValueAssignment> asList() throws InterruptedException, SolverException {
+  public ImmutableList<ValueAssignment> asList() {
 
     Set<FunctionSymbol> usedSymbols = new LinkedHashSet<>();
     for (Term assertedTerm : assertedTerms) {
@@ -96,8 +95,7 @@ class SmtInterpolModel extends AbstractModel<Term, Sort, Script> {
    * @param upperIndices indices for multi-dimensional arrays
    */
   private Collection<ValueAssignment> getArrayAssignment(
-      String symbol, Term key, Term array, List<Object> upperIndices)
-      throws InterruptedException, SolverException {
+      String symbol, Term key, Term array, List<Object> upperIndices) {
     assert array.getSort().isArraySort();
     Collection<ValueAssignment> assignments = new ArrayList<>();
     Term evaluation = model.evaluate(array);
@@ -139,8 +137,7 @@ class SmtInterpolModel extends AbstractModel<Term, Sort, Script> {
   }
 
   /** Get all modeled assignments for the UF. */
-  private Collection<ValueAssignment> getUFAssignments(FunctionSymbol symbol)
-      throws InterruptedException, SolverException {
+  private Collection<ValueAssignment> getUFAssignments(FunctionSymbol symbol) {
     final Collection<ValueAssignment> assignments = new ArrayList<>();
     final String name = unescape(symbol.getApplicationString());
 
@@ -159,8 +156,7 @@ class SmtInterpolModel extends AbstractModel<Term, Sort, Script> {
     return assignments;
   }
 
-  private ValueAssignment getAssignment(String key, ApplicationTerm term)
-      throws InterruptedException, SolverException {
+  private ValueAssignment getAssignment(String key, ApplicationTerm term) {
     Term value = model.evaluate(term);
     List<Object> argumentInterpretation = new ArrayList<>();
     for (Term param : term.getParameters()) {

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -104,25 +104,25 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws InterruptedException, SolverException {
+  public Model getModel() throws SolverException {
     Preconditions.checkState(!closed);
     checkGenerateModels();
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 
   @Override
-  protected Z3Model getEvaluatorWithoutChecks() throws InterruptedException, SolverException {
+  protected Z3Model getEvaluatorWithoutChecks() throws SolverException {
     return new Z3Model(this, z3context, getZ3Model(), creator);
   }
 
-  protected abstract long getZ3Model() throws InterruptedException, SolverException;
+  protected abstract long getZ3Model() throws SolverException;
 
   protected abstract void assertContraint(long constraint);
 
   protected abstract void assertContraintAndTrack(long constraint, long symbol);
 
   @Override
-  protected Void addConstraintImpl(BooleanFormula f) throws InterruptedException, SolverException {
+  protected Void addConstraintImpl(BooleanFormula f) throws InterruptedException {
     Preconditions.checkState(!closed);
     long e = creator.extractInfo(f);
     try {
@@ -135,7 +135,7 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
         assertContraint(e);
       }
     } catch (Z3Exception exception) {
-      throw creator.handleZ3Exception(exception);
+      throw creator.handleZ3ExceptionAsRuntimeException(exception);
     }
     return null;
   }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3OptimizationProver.java
@@ -101,12 +101,12 @@ class Z3OptimizationProver extends Z3AbstractProver implements OptimizationProve
   }
 
   @Override
-  protected void pushImpl() throws InterruptedException, SolverException {
+  protected void pushImpl() {
     push0();
     try {
       Native.optimizePush(z3context, z3optSolver);
     } catch (Z3Exception exception) {
-      throw creator.handleZ3Exception(exception);
+      throw creator.handleZ3ExceptionAsRuntimeException(exception);
     }
   }
 
@@ -197,11 +197,11 @@ class Z3OptimizationProver extends Z3AbstractProver implements OptimizationProve
   }
 
   @Override
-  protected long getZ3Model() throws InterruptedException, SolverException {
+  protected long getZ3Model() {
     try {
       return Native.optimizeGetModel(z3context, z3optSolver);
     } catch (Z3Exception e) {
-      throw creator.handleZ3Exception(e);
+      throw creator.handleZ3ExceptionAsRuntimeException(e);
     }
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
@@ -57,12 +57,12 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
   }
 
   @Override
-  protected void pushImpl() throws InterruptedException, SolverException {
+  protected void pushImpl() {
     push0();
     try {
       Native.solverPush(z3context, z3solver);
     } catch (Z3Exception exception) {
-      throw creator.handleZ3Exception(exception);
+      throw creator.handleZ3ExceptionAsRuntimeException(exception);
     }
   }
 
@@ -138,11 +138,11 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
   }
 
   @Override
-  protected long getZ3Model() throws InterruptedException, SolverException {
+  protected long getZ3Model() {
     try {
       return Native.solverGetModel(z3context, z3solver);
     } catch (Z3Exception e) {
-      throw creator.handleZ3Exception(e);
+      throw creator.handleZ3ExceptionAsRuntimeException(e);
     }
   }
 

--- a/src/org/sosy_lab/java_smt/test/ModelEvaluationTest.java
+++ b/src/org/sosy_lab/java_smt/test/ModelEvaluationTest.java
@@ -200,8 +200,7 @@ public class ModelEvaluationTest extends SolverBasedTest0.ParameterizedSolverBas
     return constraints;
   }
 
-  private BooleanFormula getNewConstraints(int i, Evaluator m)
-      throws InterruptedException, SolverException {
+  private BooleanFormula getNewConstraints(int i, Evaluator m) {
     BooleanFormula x = bmgr.makeVariable("x" + i);
     // prover.push(m.evaluate(x) ? bmgr.not(x) : x);
     return m.evaluate(x) ? x : bmgr.not(x);

--- a/src/org/sosy_lab/java_smt/test/ProverEnvironmentSubjectTest.java
+++ b/src/org/sosy_lab/java_smt/test/ProverEnvironmentSubjectTest.java
@@ -51,7 +51,7 @@ public class ProverEnvironmentSubjectTest extends SolverBasedTest0.Parameterized
   }
 
   @Test
-  public void testIsSatisfiableNo() throws InterruptedException, SolverException {
+  public void testIsSatisfiableNo() throws InterruptedException {
     requireUnsatCore();
     try (ProverEnvironment env =
         context.newProverEnvironment(
@@ -71,7 +71,7 @@ public class ProverEnvironmentSubjectTest extends SolverBasedTest0.Parameterized
   }
 
   @Test
-  public void testIsUnsatisfiableNo() throws InterruptedException, SolverException {
+  public void testIsUnsatisfiableNo() throws InterruptedException {
     requireModel();
     try (ProverEnvironment env = context.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
       env.push(simpleFormula);

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -412,7 +412,7 @@ public class SolverConcurrencyTest {
    */
   @Test
   public void testConcurrentIntegerStack()
-      throws InvalidConfigurationException, InterruptedException, SolverException {
+      throws InvalidConfigurationException, InterruptedException {
     requireIntegers();
     requireConcurrentMultipleStackSupport();
     SolverContext context = initSolver();
@@ -445,7 +445,7 @@ public class SolverConcurrencyTest {
    */
   @Test
   public void testConcurrentBitvectorStack()
-      throws InvalidConfigurationException, InterruptedException, SolverException {
+      throws InvalidConfigurationException, InterruptedException {
     requireBitvectors();
     requireConcurrentMultipleStackSupport();
     SolverContext context = initSolver();

--- a/src/org/sosy_lab/java_smt/test/SolverContextTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverContextTest.java
@@ -146,7 +146,7 @@ public class SolverContextTest extends SolverBasedTest0.ParameterizedSolverBased
   @Test(timeout = 1000)
   @SuppressWarnings({"try", "CheckReturnValue"})
   public void testCVC5WithValidOptionsTimeLimit()
-      throws InvalidConfigurationException, InterruptedException, SolverException {
+      throws InvalidConfigurationException, InterruptedException {
     assume().that(solverToUse()).isEqualTo(Solvers.CVC5);
 
     //  tlimit-per is time limit in ms of wall clock time per query

--- a/src/org/sosy_lab/java_smt/test/SolverStackTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverStackTest0.java
@@ -194,7 +194,7 @@ public abstract class SolverStackTest0 extends SolverBasedTest0.ParameterizedSol
   }
 
   @Test
-  public void stackTest2() throws InterruptedException, SolverException {
+  public void stackTest2() throws InterruptedException {
     BasicProverEnvironment<?> stack = newEnvironmentForTest(context);
     stack.push();
     assertThat(stack.size()).isEqualTo(1);
@@ -203,7 +203,7 @@ public abstract class SolverStackTest0 extends SolverBasedTest0.ParameterizedSol
   }
 
   @Test
-  public void stackTest3() throws InterruptedException, SolverException {
+  public void stackTest3() throws InterruptedException {
     BasicProverEnvironment<?> stack = newEnvironmentForTest(context);
     stack.push();
     assertThat(stack.size()).isEqualTo(1);
@@ -216,7 +216,7 @@ public abstract class SolverStackTest0 extends SolverBasedTest0.ParameterizedSol
   }
 
   @Test
-  public void stackTest4() throws InterruptedException, SolverException {
+  public void stackTest4() throws InterruptedException {
     BasicProverEnvironment<?> stack = newEnvironmentForTest(context);
     stack.push();
     stack.push();
@@ -262,7 +262,7 @@ public abstract class SolverStackTest0 extends SolverBasedTest0.ParameterizedSol
   }
 
   @Test
-  public void stackTest5() throws InterruptedException, SolverException {
+  public void stackTest5() throws InterruptedException {
     BasicProverEnvironment<?> stack = newEnvironmentForTest(context);
     stack.push();
     stack.pop();
@@ -509,7 +509,7 @@ public abstract class SolverStackTest0 extends SolverBasedTest0.ParameterizedSol
 
   @Test(expected = IllegalStateException.class)
   @SuppressWarnings("CheckReturnValue")
-  public void avoidDualStacksIfNotSupported() throws InterruptedException, SolverException {
+  public void avoidDualStacksIfNotSupported() throws InterruptedException {
     assume()
         .withMessage("Solver does not support multiple stacks yet")
         .that(solver)

--- a/src/org/sosy_lab/java_smt/test/SolverThreadLocalityTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverThreadLocalityTest.java
@@ -261,8 +261,7 @@ public class SolverThreadLocalityTest extends SolverBasedTest0.ParameterizedSolv
 
   @SuppressWarnings({"unchecked", "resource"})
   @Test
-  public <T> void nonLocalInterpolationTest()
-      throws InterruptedException, ExecutionException, SolverException {
+  public <T> void nonLocalInterpolationTest() throws InterruptedException, ExecutionException {
     requireIntegers();
     requireInterpolation();
     assume().that(solverToUse()).isNotEqualTo(Solvers.CVC5);

--- a/src/org/sosy_lab/java_smt/test/TimeoutTest.java
+++ b/src/org/sosy_lab/java_smt/test/TimeoutTest.java
@@ -23,7 +23,6 @@ import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.Tactic;
 import org.sosy_lab.java_smt.solvers.opensmt.Logics;
 
@@ -78,7 +77,7 @@ public class TimeoutTest extends SolverBasedTest0 {
   }
 
   @Test(timeout = TIMOUT_MILLISECONDS)
-  public void testProverTimeoutInt() throws InterruptedException, SolverException {
+  public void testProverTimeoutInt() throws InterruptedException {
     requireIntegers();
     TruthJUnit.assume()
         .withMessage(solverToUse() + " does not support interruption")
@@ -88,7 +87,7 @@ public class TimeoutTest extends SolverBasedTest0 {
   }
 
   @Test(timeout = TIMOUT_MILLISECONDS)
-  public void testProverTimeoutBv() throws InterruptedException, SolverException {
+  public void testProverTimeoutBv() throws InterruptedException {
     requireBitvectors();
     TruthJUnit.assume()
         .withMessage(solverToUse() + " does not support interruption")
@@ -98,7 +97,7 @@ public class TimeoutTest extends SolverBasedTest0 {
   }
 
   @Test(timeout = TIMOUT_MILLISECONDS)
-  public void testInterpolationProverTimeout() throws InterruptedException, SolverException {
+  public void testInterpolationProverTimeout() throws InterruptedException {
     requireInterpolation();
     requireIntegers();
     TruthJUnit.assume()
@@ -109,20 +108,20 @@ public class TimeoutTest extends SolverBasedTest0 {
   }
 
   @Test(timeout = TIMOUT_MILLISECONDS)
-  public void testOptimizationProverTimeout() throws InterruptedException, SolverException {
+  public void testOptimizationProverTimeout() throws InterruptedException {
     requireOptimization();
     requireIntegers();
     testBasicProverTimeoutInt(() -> context.newOptimizationProverEnvironment());
   }
 
   private void testBasicProverTimeoutInt(Supplier<BasicProverEnvironment<?>> proverConstructor)
-      throws InterruptedException, SolverException {
+      throws InterruptedException {
     HardIntegerFormulaGenerator gen = new HardIntegerFormulaGenerator(imgr, bmgr);
     testBasicProverTimeout(proverConstructor, gen.generate(100));
   }
 
   private void testBasicProverTimeoutBv(Supplier<BasicProverEnvironment<?>> proverConstructor)
-      throws InterruptedException, SolverException {
+      throws InterruptedException {
     HardBitvectorFormulaGenerator gen = new HardBitvectorFormulaGenerator(bvmgr, bmgr);
     testBasicProverTimeout(proverConstructor, gen.generate(100));
   }
@@ -130,7 +129,7 @@ public class TimeoutTest extends SolverBasedTest0 {
   @SuppressWarnings("CheckReturnValue")
   private void testBasicProverTimeout(
       Supplier<BasicProverEnvironment<?>> proverConstructor, BooleanFormula instance)
-      throws InterruptedException, SolverException {
+      throws InterruptedException {
     Thread t =
         new Thread(
             () -> {


### PR DESCRIPTION
In #407, we introduced a more detailed specification of exceptions for solvers, including InterruptedException and SolverException, to better handle model evaluation and prover operations.

However, based on user feedback and internal discussion, these changes caused significant disruption. To address this, we are reverting these API changes to restore the previous behavior and reduce the impact on users. We will still handle these exceptions internally, but will now throw them as RuntimeException to avoid changes in the API.