### PR TITLE
Use Podman for the build container

### DIFF
--- a/docker/buildUbuntu1804.sh
+++ b/docker/buildUbuntu1804.sh
@@ -4,7 +4,7 @@
 # an API wrapper for a collection of SMT solvers:
 # https://github.com/sosy-lab/java-smt
 #
-# SPDX-FileCopyrightText: 2021 Dirk Beyer <https://www.sosy-lab.org>
+# SPDX-FileCopyrightText: 2025 Dirk Beyer <https://www.sosy-lab.org>
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,6 +15,5 @@ podman build -t registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu180
 # with read and write rights to the Gitlab registry (full API access is not required)
 #
 # Please use the following commands to push the build image to Gitlab:
-#   docker login registry.gitlab.com
-#   docker push registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu1804
-
+#   podman login registry.gitlab.com
+#   podman push registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu1804

--- a/docker/buildUbuntu1804.sh
+++ b/docker/buildUbuntu1804.sh
@@ -8,7 +8,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-docker build -t registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu1804 - < ubuntu1804.Dockerfile
+podman build -t registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu1804 - < ubuntu1804.Dockerfile
 
 # For pushing to Gitlab registry, please create your personal access token:
 #   https://gitlab.com/-/user_settings/personal_access_tokens

--- a/docker/buildUbuntu2204.sh
+++ b/docker/buildUbuntu2204.sh
@@ -8,7 +8,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-docker build -t registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu2204 - < ubuntu2204.Dockerfile
+podman build -t registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu2204 - < ubuntu2204.Dockerfile
 
 # For pushing to Gitlab registry, please create your personal access token:
 #   https://gitlab.com/-/user_settings/personal_access_tokens

--- a/docker/buildUbuntu2204.sh
+++ b/docker/buildUbuntu2204.sh
@@ -4,7 +4,7 @@
 # an API wrapper for a collection of SMT solvers:
 # https://github.com/sosy-lab/java-smt
 #
-# SPDX-FileCopyrightText: 2024 Dirk Beyer <https://www.sosy-lab.org>
+# SPDX-FileCopyrightText: 2025 Dirk Beyer <https://www.sosy-lab.org>
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,6 +15,5 @@ podman build -t registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu220
 # with read and write rights to the Gitlab registry (full API access is not required)
 #
 # Please use the following commands to push the build image to Gitlab:
-#   docker login registry.gitlab.com
-#   docker push registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu2204
-
+#   podman login registry.gitlab.com
+#   podman push registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu2204

--- a/docker/runUbuntu1804.sh
+++ b/docker/runUbuntu1804.sh
@@ -12,8 +12,7 @@
 # JavaSMT and all solver files are located in the directory "workspace".
 WORKSPACE=$HOME/workspace
 
-docker run -it \
+podman run -it \
     --mount type=bind,source=${WORKSPACE},target=/workspace \
     --workdir /workspace/java-smt \
-    --user $(id -u ${USER}):$(id -g ${USER}) \
     registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu1804

--- a/docker/runUbuntu2204.sh
+++ b/docker/runUbuntu2204.sh
@@ -12,8 +12,7 @@
 # JavaSMT and all solver files are located in the directory "workspace".
 WORKSPACE=$HOME/workspace
 
-docker run -it \
+podman run -it \
     --mount type=bind,source=${WORKSPACE},target=/workspace \
     --workdir /workspace/java-smt \
-    --user $(id -u ${USER}):$(id -g ${USER}) \
     registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu2204

--- a/docker/ubuntu1804.Dockerfile
+++ b/docker/ubuntu1804.Dockerfile
@@ -67,14 +67,5 @@ RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz \
  && make install \
  && cd --
 
-# Add the user "developer" with UID:1000, GID:1000, home at /developer.
-# This allows to map the docker-internal user to the local user 1000:1000 outside of the container.
-# This avoids to have new files created with root-rights.
-RUN groupadd -r developer -g 1000 \
- && useradd -u 1000 -r -g developer -m -d /developer -s /sbin/nologin -c "JavaSMT Development User" developer \
- && chmod 755 /developer
-
-USER developer
-
 # JNI is not found when compiling Boolector in the image, so we need to set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/

--- a/docker/ubuntu2204.Dockerfile
+++ b/docker/ubuntu2204.Dockerfile
@@ -79,14 +79,5 @@ RUN wget https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_windows-x64_bi
  && unzip openjdk-11+28_windows-x64_bin.zip \
  && rm openjdk-11+28_windows-x64_bin.zip
 
-# Add the user "developer" with UID:1000, GID:1000, home at /developer.
-# This allows to map the docker-internal user to the local user 1000:1000 outside of the container.
-# This avoids to have new files created with root-rights.
-RUN groupadd -r developer -g 1000 \
- && useradd -u 1000 -r -g developer -m -d /developer -s /sbin/nologin -c "JavaSMT Development User" developer \
- && chmod 755 /developer
-
-USER developer
-
 # JNI is not found when compiling Boolector in the image, so we need to set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/


### PR DESCRIPTION
Hello,
as reported in #414 the docker build images are no longer working with the latest Ubuntu release. There seems to be an issue with the work-around we use to build the solver binaries as a user inside the Docker image. I've tried finding a solution, but had no luck so far. This pull request now aims to replace Docker with Podman entirely.

Podman is a drop in replacement for Docker and supports the same command line options, making larger changes to our build scripts unnecessary. It also runs in user mode by default, meaning that we no longer need the work around that is broken now.