### PR TITLE
Blacklist more SMTLIB keywords as variable/uf names

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2FormulaManager.java
@@ -133,7 +133,7 @@ public class Yices2FormulaManager extends AbstractFormulaManager<Integer, Intege
   private static String quote(String str) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(str));
     Preconditions.checkArgument(CharMatcher.anyOf("|\\").matchesNoneOf(str));
-    Preconditions.checkArgument(!SMTLIB2_KEYWORDS.contains(str));
+    Preconditions.checkArgument(!isReserved(str));
 
     if (VALID_CHARS.matchesAllOf(str) && !DIGITS.matches(str.charAt(0))) {
       // simple symbol

--- a/src/org/sosy_lab/java_smt/test/VariableNamesTest.java
+++ b/src/org/sosy_lab/java_smt/test/VariableNamesTest.java
@@ -49,7 +49,6 @@ public class VariableNamesTest extends SolverBasedTest0.ParameterizedSolverBased
           "bar",
           "baz",
           "declare",
-          "exit",
           "(exit)",
           "!=",
           "~",

--- a/src/org/sosy_lab/java_smt/test/VariableNamesTest.java
+++ b/src/org/sosy_lab/java_smt/test/VariableNamesTest.java
@@ -162,8 +162,7 @@ public class VariableNamesTest extends SolverBasedTest0.ParameterizedSolverBased
   protected List<String> getAllNames() {
     return ImmutableList.<String>builder()
         .addAll(NAMES)
-        .addAll(AbstractFormulaManager.BASIC_OPERATORS)
-        .addAll(AbstractFormulaManager.SMTLIB2_KEYWORDS)
+        .addAll(AbstractFormulaManager.RESERVED)
         .addAll(AbstractFormulaManager.DISALLOWED_CHARACTER_REPLACEMENT.values())
         .addAll(FURTHER_SMTLIB2_KEYWORDS)
         .addAll(UNSUPPORTED_NAMES)


### PR DESCRIPTION
Hello,
this will update the list of forbidden variable/uf names to include all SMTLIB commands, such as `check-sat` or `assert`, and all predefined function names, like `mod` or `fp.add`. While such symbol names are fine when using the API, they cause issues when printing the formulas as most solvers will fail to add the necessary quotes to the symbols. This will then causing issues in `FormulaManager.translateFrom()` as the generated output is invalid and can't to be read back by the target solver to translate the formula.

By forbidding such symbol names entirely we circumvent the issues. User should always use `FormulaManager.isValidName()` to check if their name is on the list, and substitute it with `FormulaManager.escape()` if necessary.