### PR TITLE
Fix handling of Unicode characters in String theory

### DIFF
--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
@@ -78,7 +78,11 @@ public abstract class AbstractStringFormulaManager<TFormulaInfo, TType, TEnv, TF
   protected static String escapeUnicodeForSmtlib(String input) {
     StringBuilder sb = new StringBuilder();
     for (int codePoint : input.codePoints().toArray()) {
-      if (0x20 <= codePoint && codePoint <= 0x7E) {
+      if (codePoint == 0x5c) {
+        // Backslashes must be escaped, otherwise they may get substituted when reading back
+        // the results from the model
+        sb.append("\\u{5c}");
+      } else if (0x20 <= codePoint && codePoint <= 0x7E) {
         sb.appendCodePoint(codePoint); // normal printable chars
       } else {
         sb.append("\\u{").append(String.format("%05X", codePoint)).append("}");

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
@@ -38,7 +38,7 @@ public abstract class AbstractStringFormulaManager<TFormulaInfo, TType, TEnv, TF
               + "((?<codePoint>[0-9a-fA-F]{4})"
               + "|"
               // or curly brackets like "\\u{61}"
-              + "(\\{(?<codePointInBrackets>[0-9a-fA-F]{1,5})}))");
+              + "(\\{(?<codePointInBrackets>[0-9a-fA-F]{1,5})\\}))");
 
   protected AbstractStringFormulaManager(
       FormulaCreator<TFormulaInfo, TType, TEnv, TFuncDecl> pCreator) {

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractStringFormulaManager.java
@@ -104,7 +104,13 @@ public abstract class AbstractStringFormulaManager<TFormulaInfo, TType, TEnv, TF
       checkArgument(
           isCodePointInRange(codePoint),
           "SMTLIB does only specify Unicode letters from Planes 0-2");
-      matcher.appendReplacement(sb, Character.toString(codePoint));
+      String replacement = Character.toString(codePoint);
+      if (replacement.equals("\\")) {
+        // Matcher.appendReplacement considers '\' as special character.
+        // Substitute with '\\' instead
+        replacement = "\\\\";
+      }
+      matcher.appendReplacement(sb, replacement);
     }
     matcher.appendTail(sb);
     return sb.toString();

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4StringFormulaManager.java
@@ -29,8 +29,8 @@ class CVC4StringFormulaManager extends AbstractStringFormulaManager<Expr, Type, 
 
   @Override
   protected Expr makeStringImpl(String pValue) {
-    // The boolean enables escape characters!
-    return exprManager.mkConst(new CVC4String(escapeUnicodeForSmtlib(pValue), true));
+    String str = escapeUnicodeForSmtlib(unescapeUnicodeForSmtlib(pValue));
+    return exprManager.mkConst(new CVC4String(str, true));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5StringFormulaManager.java
@@ -27,7 +27,8 @@ class CVC5StringFormulaManager extends AbstractStringFormulaManager<Term, Sort, 
 
   @Override
   protected Term makeStringImpl(String pValue) {
-    return solver.mkString(escapeUnicodeForSmtlib(pValue), true);
+    String str = escapeUnicodeForSmtlib(unescapeUnicodeForSmtlib(pValue));
+    return solver.mkString(str, true);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3StringFormulaManager.java
@@ -25,7 +25,8 @@ class Z3StringFormulaManager extends AbstractStringFormulaManager<Long, Long, Lo
 
   @Override
   protected Long makeStringImpl(String pValue) {
-    return Native.mkString(z3context, escapeUnicodeForSmtlib(pValue));
+    String str = escapeUnicodeForSmtlib(unescapeUnicodeForSmtlib(pValue));
+    return Native.mkString(z3context, str);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/test/ModelEvaluationTest.java
+++ b/src/org/sosy_lab/java_smt/test/ModelEvaluationTest.java
@@ -173,14 +173,12 @@ public class ModelEvaluationTest extends SolverBasedTest0.ParameterizedSolverBas
         Lists.newArrayList("hello \u00e6@\u20ac \u1234 \u4321"),
         Lists.newArrayList(smgr.makeString("hello \u00e6@\u20ac \u1234 \u4321")));
 
-    // TODO Z3 and CVC4 seem to break escaping on invalid Unicode Strings.
-    /*
-      evaluateInModel(
+    // invalid Unicode escape sequences (should be treated as normal characters)
+    evaluateInModel(
         smgr.equal(smgr.makeVariable("x"), smgr.makeString("\\u")),
         smgr.makeVariable("x"),
         Lists.newArrayList("\\u"),
         Lists.newArrayList(smgr.makeString("\\u")));
-    */
 
     // foreign variable: x vs y
     evaluateInModel(

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -24,8 +24,11 @@ import org.junit.Test;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Formula;
+import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.RegexFormula;
+import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.StringFormula;
 
@@ -120,6 +123,26 @@ public class StringFormulaManagerTest extends SolverBasedTest0.ParameterizedSolv
   }
 
   // Tests
+
+  @Test
+  public void testInputEscape() throws SolverException, InterruptedException {
+    // Test if SMTLIB Unicode literals are recognized and converted to their Unicode characters.
+    assertEqual(smgr.length(smgr.makeString("Ξ")), imgr.makeNumber(1));
+    assertEqual(smgr.length(smgr.makeString("\\u{39E}")), imgr.makeNumber(1));
+  }
+
+  @Test
+  public void testOutputUnescape() throws SolverException, InterruptedException {
+    // Test if Unicode escape sequences get properly converted back when reading from the model.
+    try (ProverEnvironment prover = context.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
+      assertThat(!prover.isUnsat()).isTrue();
+      try (Model model = prover.getModel()) {
+        assertThat(model.evaluate(smgr.makeString("\\u{39E}"))).isEqualTo("Ξ");
+        assertThat(model.evaluate(smgr.concat(smgr.makeString("\\u{39E"), smgr.makeString("}"))))
+            .isEqualTo("\\u{39E}");
+      }
+    }
+  }
 
   @Test
   public void testRegexAll() throws SolverException, InterruptedException {

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -1640,7 +1640,7 @@ public class StringFormulaManagerTest extends SolverBasedTest0.ParameterizedSolv
         .isNotEqualTo(Solvers.Z3);
 
     for (int i = 0; i < WORDS.size(); i++) {
-      for (int j = 1; j < WORDS.size(); j++) {
+      for (int j = 0; j < WORDS.size(); j++) {
         String word1 = WORDS.get(i);
         String word2 = WORDS.get(j);
         String word3 = "replacement";
@@ -1648,7 +1648,8 @@ public class StringFormulaManagerTest extends SolverBasedTest0.ParameterizedSolv
         StringFormula word2F = smgr.makeString(word2);
         StringFormula word3F = smgr.makeString(word3);
 
-        StringFormula result = smgr.makeString(word3.replaceAll(word2, word1));
+        StringFormula result =
+            smgr.makeString(word2.isEmpty() ? word3 : word3.replaceAll(word2, word1));
         assertEqual(smgr.replaceAll(word3F, word2F, word1F), result);
       }
     }


### PR DESCRIPTION
Hallo,
this MR patches several minor issues remaining after #422:
* When escaping a String we now also escape `\` to make sure the backslash is preserved and doesn't get captured later when unescaping again
* We now always apply `unescape` first when creating a new String constant. This is needed even when the solver does not support plain Unicode and we'll have to escape the String again later.  This change closes an issue with Z3 and CVC4 where broken escape sequences were not handled correctly.
* Added two more tests and fixed a bug in another

As mentioned in https://github.com/sosy-lab/java-smt/issues/412 I think that `makeString` should not be translating SMTLIB escape sequences at all. However, this is an API breaking change and can still be considered some other time