### PR TITLE
add deprecated methods for maybe binary compatibility

### DIFF
--- a/src/org/sosy_lab/java_smt/api/BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/BitvectorFormulaManager.java
@@ -137,7 +137,9 @@ public interface BitvectorFormulaManager {
    * signed remainder() it follows the dividend). Unsigned remainder() is equivalent to unsigned
    * modulo().
    */
-  @Deprecated(forRemoval = true)
+  @Deprecated(
+      forRemoval = true,
+      since = "2024.08, because of inconsistent behavior at modulo and remainder operations")
   default BitvectorFormula modulo(
       BitvectorFormula dividend, BitvectorFormula divisor, boolean signed) {
     return remainder(dividend, divisor, signed);
@@ -361,6 +363,23 @@ public interface BitvectorFormulaManager {
 
   /** Concatenate two bitvectors. */
   BitvectorFormula concat(BitvectorFormula prefix, BitvectorFormula suffix);
+
+  /**
+   * Extract a range of bits from a bitvector. We require {@code 0 <= lsb <= msb < bitsize}.
+   *
+   * <p>If msb equals lsb, then a single bit will be returned, i.e., the bit from the given
+   * position. If lsb equals 0 and msb equals bitsize-1, then the complete bitvector will be
+   * returned.
+   *
+   * @param number from where the bits are extracted.
+   * @param msb Upper index for the most significant bit. Must be in interval from lsb to bitsize-1.
+   * @param lsb Lower index for the least significant bit. Must be in interval from 0 to msb.
+   * @param signed unused and will be removed in the future.
+   */
+  @Deprecated(forRemoval = true, since = "2022.04, because of unused flag for sign")
+  default BitvectorFormula extract(BitvectorFormula number, int msb, int lsb, boolean signed) {
+    return extract(number, msb, lsb);
+  }
 
   /**
    * Extract a range of bits from a bitvector. We require {@code 0 <= lsb <= msb < bitsize}.

--- a/src/org/sosy_lab/java_smt/api/FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/FloatingPointFormulaManager.java
@@ -150,6 +150,51 @@ public interface FloatingPointFormulaManager {
    * Build a formula of compatible type from a {@link FloatingPointFormula}. This method uses the
    * default rounding mode.
    *
+   * <p>Compatible formula types are all numeral types and bitvector types. It is also possible to
+   * cast a floating-point number into another floating-point type. We do not support casting from
+   * boolean or array types. We try to keep an exact representation, however fall back to rounding
+   * if needed.
+   *
+   * @param source the source formula of floating-point type
+   * @param targetType the type of the resulting formula
+   * @throws IllegalArgumentException if an incompatible type is used, e.g. a {@link
+   *     FloatingPointFormula} cannot be cast to {@link BooleanFormula}.
+   */
+  @Deprecated(
+      forRemoval = true,
+      since = "2022.06, because of missing sign-bit for bitvector conversion")
+  default <T extends Formula> T castTo(FloatingPointFormula source, FormulaType<T> targetType) {
+    return castTo(source, true, targetType);
+  }
+
+  /**
+   * Build a formula of compatible type from a {@link FloatingPointFormula}.
+   *
+   * <p>Compatible formula types are all numeral types and bitvector types. It is also possible to
+   * cast a floating-point number into another floating-point type. We do not support casting from
+   * boolean or array types. We try to keep an exact representation, however fall back to rounding
+   * if needed.
+   *
+   * @param source the source formula of floating-point type
+   * @param targetType the type of the resulting formula
+   * @param pFloatingPointRoundingMode if rounding is needed, we apply the rounding mode.
+   * @throws IllegalArgumentException if an incompatible type is used, e.g. a {@link
+   *     FloatingPointFormula} cannot be cast to {@link BooleanFormula}.
+   */
+  @Deprecated(
+      forRemoval = true,
+      since = "2022.06, because of missing sign-bit for bitvector conversion")
+  default <T extends Formula> T castTo(
+      FloatingPointFormula source,
+      FormulaType<T> targetType,
+      FloatingPointRoundingMode pFloatingPointRoundingMode) {
+    return castTo(source, true, targetType, pFloatingPointRoundingMode);
+  }
+
+  /**
+   * Build a formula of compatible type from a {@link FloatingPointFormula}. This method uses the
+   * default rounding mode.
+   *
    * <p>Compatible formula types are all numeral types and (signed/unsigned) bitvector types. It is
    * also possible to cast a floating-point number into another floating-point type. We do not
    * support casting from boolean or array types. We try to keep an exact representation, however


### PR DESCRIPTION
I do not see any benefit for JavaSMT and do not like  the idea of re-adding old stuff.
The group of users, mostly developers of related projects, are maybe never using this code and might never compare older JavaSMT versions with a newer one.

Nevertheless, the PR is here.