### PR TITLE
Allow empty String ranges

### DIFF
--- a/src/org/sosy_lab/java_smt/api/StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/StringFormulaManager.java
@@ -8,7 +8,6 @@
 
 package org.sosy_lab.java_smt.api;
 
-import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.List;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
@@ -155,13 +154,6 @@ public interface StringFormulaManager {
    * @see #range(StringFormula, StringFormula)
    */
   default RegexFormula range(char start, char end) {
-    Preconditions.checkArgument(
-        start <= end,
-        "Range from start '%s' (%s) to end '%s' (%s) is empty.",
-        start,
-        (int) start,
-        end,
-        (int) end);
     return range(makeString(String.valueOf(start)), makeString(String.valueOf(end)));
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4StringFormulaManager.java
@@ -145,6 +145,7 @@ class CVC4StringFormulaManager extends AbstractStringFormulaManager<Expr, Type, 
 
   @Override
   protected Expr range(Expr start, Expr end) {
+    // FIXME CVC4 will crash when start > end, even if we add an ITE with preconditions
     return exprManager.mkExpr(Kind.REGEXP_RANGE, start, end);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4StringFormulaManager.java
@@ -143,10 +143,33 @@ class CVC4StringFormulaManager extends AbstractStringFormulaManager<Expr, Type, 
     return exprManager.mkExpr(Kind.REGEXP_SIGMA, new vectorExpr());
   }
 
+  /**
+   * Check if the String only contains printable US ASCII characters.
+   *
+   * <p>We use this function to check if the String contains any characters that would have to be
+   * escaped in SMTLIB.
+   */
+  private boolean isAsciiString(String str) {
+    return str.codePoints().allMatch(c -> c >= 0x20 && c <= 0x7E);
+  }
+
   @Override
   protected Expr range(Expr start, Expr end) {
-    // FIXME CVC4 will crash when start > end, even if we add an ITE with preconditions
-    return exprManager.mkExpr(Kind.REGEXP_RANGE, start, end);
+    Preconditions.checkArgument(
+        start.isConst() && end.isConst(), "CVC4 does not support variables as bounds");
+
+    String lower = (String) formulaCreator.convertValue(start, start);
+    String upper = (String) formulaCreator.convertValue(end, end);
+
+    Preconditions.checkArgument(
+        isAsciiString(lower) && isAsciiString(upper),
+        "CVC4 only allows printable US ASCII characters as bounds");
+
+    // Return the empty language if the bounds are not single character Strings, or if the upper
+    // bound is smaller than the lower bound
+    return lower.length() != 1 || upper.length() != 1 || upper.compareTo(lower) < 0
+        ? noneImpl()
+        : exprManager.mkExpr(Kind.REGEXP_RANGE, start, end);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5StringFormulaManager.java
@@ -140,17 +140,15 @@ class CVC5StringFormulaManager extends AbstractStringFormulaManager<Term, Sort, 
 
   @Override
   protected Term range(Term start, Term end) {
-    // Precondition: Both bounds must be single character Strings and the lower bound must be
-    // smaller or equal to the upper bound. Otherwise, return the empty language.
+    // Precondition: Both bounds must be single character Strings
+    // CVC5 already checks that the lower bound is smaller than the upper bound and returns the
+    // empty language otherwise.
     Term one = solver.mkInteger(1);
     Term cond =
         solver.mkTerm(
             Kind.AND,
-            lessOrEquals(start, end),
-            solver.mkTerm(
-                Kind.AND,
-                solver.mkTerm(Kind.EQUAL, length(start), one),
-                solver.mkTerm(Kind.EQUAL, length(end), one)));
+            solver.mkTerm(Kind.EQUAL, length(start), one),
+            solver.mkTerm(Kind.EQUAL, length(end), one));
     return solver.mkTerm(Kind.ITE, cond, solver.mkTerm(Kind.REGEXP_RANGE, start, end), noneImpl());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5StringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5StringFormulaManager.java
@@ -140,7 +140,18 @@ class CVC5StringFormulaManager extends AbstractStringFormulaManager<Term, Sort, 
 
   @Override
   protected Term range(Term start, Term end) {
-    return solver.mkTerm(Kind.REGEXP_RANGE, start, end);
+    // Precondition: Both bounds must be single character Strings and the lower bound must be
+    // smaller or equal to the upper bound. Otherwise, return the empty language.
+    Term one = solver.mkInteger(1);
+    Term cond =
+        solver.mkTerm(
+            Kind.AND,
+            lessOrEquals(start, end),
+            solver.mkTerm(
+                Kind.AND,
+                solver.mkTerm(Kind.EQUAL, length(start), one),
+                solver.mkTerm(Kind.EQUAL, length(end), one)));
+    return solver.mkTerm(Kind.ITE, cond, solver.mkTerm(Kind.REGEXP_RANGE, start, end), noneImpl());
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
@@ -605,6 +605,9 @@ class PrincessEnvironment {
    * @throws IllegalArgumentException for any other type.
    */
   private static FormulaType<?> mergeFormulaTypes(FormulaType<?> type1, FormulaType<?> type2) {
+    if (type1.equals(type2)) {
+      return type1;
+    }
     if ((type1.isIntegerType() || type1.isRationalType())
         && (type2.isIntegerType() || type2.isRationalType())) {
       return type1.isRationalType() ? type1 : type2;

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessStringFormulaManager.java
@@ -11,11 +11,16 @@ package org.sosy_lab.java_smt.solvers.princess;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.sosy_lab.java_smt.solvers.princess.PrincessEnvironment.toITermSeq;
 
+import ap.basetypes.IdealInt;
 import ap.parser.IAtom;
+import ap.parser.IBinFormula;
+import ap.parser.IBinJunctor;
 import ap.parser.IExpression;
 import ap.parser.IFormula;
 import ap.parser.IFunApp;
+import ap.parser.IIntLit;
 import ap.parser.ITerm;
+import ap.parser.ITermITE;
 import ap.types.Sort;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -166,7 +171,19 @@ public class PrincessStringFormulaManager
 
   @Override
   protected ITerm range(IExpression start, IExpression end) {
-    return new IFunApp(PrincessEnvironment.stringTheory.re_range(), toITermSeq(start, end));
+    // Precondition: Both bounds must be single character Strings and the lower bound must be
+    // smaller or equal to the upper bound. Otherwise, return the empty language.
+    ITerm one = new IIntLit(IdealInt.apply(1));
+    IFormula cond =
+        new IBinFormula(
+            IBinJunctor.And(),
+            lessOrEquals(start, end),
+            new IBinFormula(
+                IBinJunctor.And(), length(start).$eq$eq$eq(one), length(end).$eq$eq$eq(one)));
+    return new ITermITE(
+        cond,
+        new IFunApp(PrincessEnvironment.stringTheory.re_range(), toITermSeq(start, end)),
+        noneImpl());
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessStringFormulaManager.java
@@ -171,15 +171,13 @@ public class PrincessStringFormulaManager
 
   @Override
   protected ITerm range(IExpression start, IExpression end) {
-    // Precondition: Both bounds must be single character Strings and the lower bound must be
-    // smaller or equal to the upper bound. Otherwise, return the empty language.
+    // Precondition: Both bounds must be single character Strings
+    // Princess already checks that the lower bound is smaller than the upper bound and returns the
+    // empty language otherwise.
     ITerm one = new IIntLit(IdealInt.apply(1));
     IFormula cond =
         new IBinFormula(
-            IBinJunctor.And(),
-            lessOrEquals(start, end),
-            new IBinFormula(
-                IBinJunctor.And(), length(start).$eq$eq$eq(one), length(end).$eq$eq$eq(one)));
+            IBinJunctor.And(), length(start).$eq$eq$eq(one), length(end).$eq$eq$eq(one));
     return new ITermITE(
         cond,
         new IFunApp(PrincessEnvironment.stringTheory.re_range(), toITermSeq(start, end)),

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessStringFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessStringFormulaManager.java
@@ -166,7 +166,7 @@ public class PrincessStringFormulaManager
 
   @Override
   protected ITerm range(IExpression start, IExpression end) {
-    return new IFunApp(PrincessEnvironment.stringTheory.re_range(), toITermSeq());
+    return new IFunApp(PrincessEnvironment.stringTheory.re_range(), toITermSeq(start, end));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -296,28 +296,19 @@ public class StringFormulaManagerTest extends SolverBasedTest0.ParameterizedSolv
 
     // Check some corner cases:
     // StringFormulaManager.range("b", "a") should be empty
-    if (solver != Solvers.CVC4) {
-      // FIXME CVC4 expects that the lower bound is smaller or equal to the upper bound
-      assertThatFormula(smgr.in(var, smgr.range(smgr.makeString("b"), smgr.makeString("a"))))
-          .isUnsatisfiable();
-      assertThatFormula(smgr.in(var, smgr.range('b', 'a'))).isUnsatisfiable();
-    }
+    assertThatFormula(smgr.in(var, smgr.range(smgr.makeString("b"), smgr.makeString("a"))))
+        .isUnsatisfiable();
+    assertThatFormula(smgr.in(var, smgr.range('b', 'a'))).isUnsatisfiable();
 
     // Only 'singleton' Strings (= Strings with one character) are allowed:
     // StringFormulaManager.range("", "a") should be empty
-    if (solver != Solvers.CVC4) {
-      // FIXME CVC4 expects both bounds to be single character Strings
-      assertThatFormula(smgr.in(var, smgr.range(smgr.makeString(""), smgr.makeString("a"))))
-          .isUnsatisfiable();
-    }
+    assertThatFormula(smgr.in(var, smgr.range(smgr.makeString(""), smgr.makeString("a"))))
+        .isUnsatisfiable();
 
     // Try again with two characters:
     // StringFormulaManager.range("aa", "ab") should be empty
-    if (solver != Solvers.CVC4) {
-      // FIXME CVC4 expects both bounds to be single character Strings
-      assertThatFormula(smgr.in(var, smgr.range(smgr.makeString("aa"), smgr.makeString("ab"))))
-          .isUnsatisfiable();
-    }
+    assertThatFormula(smgr.in(var, smgr.range(smgr.makeString("aa"), smgr.makeString("ab"))))
+        .isUnsatisfiable();
 
     // Now use variables for the bounds:
     // StringFormulaManager.range(lower, "b") should be empty iff "b" < lower


### PR DESCRIPTION
Hello,
I've noticed that there is a precondition the `char` override for `StringFormulaManager.range`:
```
* @return formula denoting the range regular expression over two chars.
* @see #range(StringFormula, StringFormula)
*/
default RegexFormula range(char start, char end) {
  Preconditions.checkArgument(
      start <= end,
      "Range from start '%s' (%s) to end '%s' (%s) is empty.",
      start,
      (int) start,
      end,
      (int) end);
  return range(makeString(String.valueOf(start)), makeString(String.valueOf(end)));
}
```
However, the JavaDoc for the (general) `range` method does not mention this restriction:
```
/**
 * @return formula denoting the range regular expression over two sequences of length 1.
 */
RegexFormula range(StringFormula start, StringFormula end);
```
And, according to SMTLIB, empty ranges should be fine:
```
; RE range
; (re.range s₁ s₂) is the set of all *singleton* strings s such that
; (str.<= s₁ s s₂) provided s₁ and s₂ are singleton. Otherwise, it 
; is the empty language.
(re.range String String RegLan)
```
I've tried it out with different solvers, and only CVC4 seems to cause issues when the precondition in the `default` method is simply removed. CVC5 and Princess still assume that the bounds are single character Strings and will throw an exception otherwise. However, they can handle the case when the lower bound is larger than the upper bound and simply return the empty language. Z3 supports both cases, and will also return the empty language when one of the bounds is not a single character String.

In this PR I removed the precondition from the `default` override to make sure it matches the behavior of the general method. I also added some checks to prevent crashes on CVC5 and Princess if either of the bounds is not a single character Strings, and fixed two bugs for Princess. Note that there are still some issues on CVC4, but this will be hard to fix as the solver is no longer maintained.