### PR TITLE
Add support for integer modulo in MathSAT

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5IntegerFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5IntegerFormulaManager.java
@@ -70,6 +70,11 @@ class Mathsat5IntegerFormulaManager
   }
 
   @Override
+  protected Long modulo(Long pNumber1, Long pNumber2) {
+    return subtract(pNumber1, multiply(divide(pNumber1, pNumber2), pNumber2));
+  }
+
+  @Override
   protected Long modularCongruence(Long pNumber1, Long pNumber2, BigInteger pModulo) {
     return modularCongruence0(pNumber1, pNumber2, pModulo.toString());
   }

--- a/src/org/sosy_lab/java_smt/test/NonLinearArithmeticWithModuloTest.java
+++ b/src/org/sosy_lab/java_smt/test/NonLinearArithmeticWithModuloTest.java
@@ -110,7 +110,12 @@ public class NonLinearArithmeticWithModuloTest extends SolverBasedTest0 {
                 handleExpectedException(() -> imgr.modulo(a, imgr.makeNumber(3)))));
 
     // INFO: OpenSMT does support modulo with constants
-    if (ImmutableSet.of(Solvers.SMTINTERPOL, Solvers.CVC4, Solvers.YICES2, Solvers.OPENSMT)
+    if (ImmutableSet.of(
+                Solvers.SMTINTERPOL,
+                Solvers.CVC4,
+                Solvers.YICES2,
+                Solvers.OPENSMT,
+                Solvers.MATHSAT5)
             .contains(solver)
         && nonLinearArithmetic == NonLinearArithmetic.APPROXIMATE_FALLBACK) {
       // some solvers support modulo with constants
@@ -148,7 +153,8 @@ public class NonLinearArithmeticWithModuloTest extends SolverBasedTest0 {
                 imgr.makeNumber(1),
                 handleExpectedException(() -> imgr.modulo(imgr.makeNumber(5), a))));
 
-    if (Solvers.CVC4 == solver && nonLinearArithmetic != NonLinearArithmetic.APPROXIMATE_ALWAYS) {
+    if (ImmutableSet.of(Solvers.CVC4, Solvers.MATHSAT5).contains(solver)
+        && nonLinearArithmetic != NonLinearArithmetic.APPROXIMATE_ALWAYS) {
       // some solvers support non-linear multiplication (partially)
       assertThatFormula(f).isUnsatisfiable();
 

--- a/src/org/sosy_lab/java_smt/test/NumeralFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/NumeralFormulaManagerTest.java
@@ -9,12 +9,14 @@
 package org.sosy_lab.java_smt.test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
+import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
@@ -25,6 +27,78 @@ import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.visitors.DefaultFormulaVisitor;
 
 public class NumeralFormulaManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
+
+  @Test
+  public void divZeroTest() throws SolverException, InterruptedException {
+    requireIntegers();
+    assume().that(solver).isNoneOf(Solvers.OPENSMT, Solvers.YICES2); // No division by zero
+
+    IntegerFormula zero = imgr.makeNumber(0);
+    IntegerFormula three = imgr.makeNumber(3);
+    IntegerFormula seven = imgr.makeNumber(7);
+
+    // Show that 3/0=0 and 3/0=7 can hold separately
+    IntegerFormula f1 = imgr.divide(three, zero);
+    assertThatFormula(imgr.equal(f1, zero)).isSatisfiable();
+    assertThatFormula(imgr.equal(f1, seven)).isSatisfiable();
+
+    // But if 3/0=0 in the model, it can't also be another value
+    IntegerFormula var = imgr.makeVariable("var");
+    IntegerFormula f2 = imgr.divide(var, zero);
+    IntegerFormula res = imgr.makeVariable("res");
+    assertThatFormula(
+            bmgr.and(
+                imgr.equal(f1, zero),
+                imgr.equal(var, three),
+                imgr.equal(f2, res),
+                bmgr.not(imgr.equal(res, zero))))
+        .isUnsatisfiable();
+
+    // Show that a=b => a/0=b/0
+    IntegerFormula var1 = imgr.makeVariable("arg1");
+    IntegerFormula var2 = imgr.makeVariable("arg2");
+    assertThatFormula(
+            bmgr.implication(
+                imgr.equal(var1, var2),
+                imgr.equal(imgr.divide(var1, zero), imgr.divide(var2, zero))))
+        .isTautological();
+  }
+
+  @Test
+  public void modZeroTest() throws SolverException, InterruptedException {
+    requireIntegers();
+    assume().that(solver).isNoneOf(Solvers.OPENSMT, Solvers.YICES2); // No division by zero
+
+    IntegerFormula zero = imgr.makeNumber(0);
+    IntegerFormula three = imgr.makeNumber(3);
+    IntegerFormula seven = imgr.makeNumber(7);
+
+    // Show that 3%0=0 and 3%0=7 can hold separately
+    IntegerFormula f1 = imgr.modulo(three, zero);
+    assertThatFormula(imgr.equal(f1, zero)).isSatisfiable();
+    assertThatFormula(imgr.equal(f1, seven)).isSatisfiable();
+
+    // But if 3%0=0 in the model, it can't also be another value
+    IntegerFormula var = imgr.makeVariable("var");
+    IntegerFormula f2 = imgr.modulo(var, zero);
+    IntegerFormula res = imgr.makeVariable("res");
+    assertThatFormula(
+            bmgr.and(
+                imgr.equal(f1, zero),
+                imgr.equal(var, three),
+                imgr.equal(f2, res),
+                bmgr.not(imgr.equal(res, zero))))
+        .isUnsatisfiable();
+
+    // Show that a=b => a%0=b%0
+    IntegerFormula var1 = imgr.makeVariable("arg1");
+    IntegerFormula var2 = imgr.makeVariable("arg2");
+    assertThatFormula(
+            bmgr.implication(
+                imgr.equal(var1, var2),
+                imgr.equal(imgr.modulo(var1, zero), imgr.modulo(var2, zero))))
+        .isTautological();
+  }
 
   @Test
   public void distinctTest() throws SolverException, InterruptedException {

--- a/src/org/sosy_lab/java_smt/test/SolverTheoriesTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverTheoriesTest.java
@@ -257,23 +257,17 @@ public class SolverTheoriesTest extends SolverBasedTest0.ParameterizedSolverBase
     assertDivision(a, num3, numNeg4, aEqNeg10);
     assertDivision(a, numNeg3, num4, aEqNeg10);
 
-    switch (solverToUse()) {
-      case MATHSAT5: // modulo not supported
-        assertThrows(UnsupportedOperationException.class, () -> buildModulo(num10, num5, num0));
-        break;
-      default:
-        assertModulo(num10, num5, num0);
-        assertModulo(num10, num3, num1, aEq10);
-        assertModulo(numNeg10, num5, num0);
-        assertModulo(numNeg10, num3, num2);
-        assertModulo(numNeg10, numNeg3, num2);
+    assertModulo(num10, num5, num0);
+    assertModulo(num10, num3, num1, aEq10);
+    assertModulo(numNeg10, num5, num0);
+    assertModulo(numNeg10, num3, num2);
+    assertModulo(numNeg10, numNeg3, num2);
 
-        assertModulo(a, num5, num0, aEq10);
-        assertModulo(a, num3, num1, aEq10);
-        assertModulo(a, num5, num0, aEqNeg10);
-        assertModulo(a, num3, num2, aEqNeg10);
-        assertModulo(a, numNeg3, num2, aEqNeg10);
-    }
+    assertModulo(a, num5, num0, aEq10);
+    assertModulo(a, num3, num1, aEq10);
+    assertModulo(a, num5, num0, aEqNeg10);
+    assertModulo(a, num3, num2, aEqNeg10);
+    assertModulo(a, numNeg3, num2, aEqNeg10);
   }
 
   @Test
@@ -319,8 +313,7 @@ public class SolverTheoriesTest extends SolverBasedTest0.ParameterizedSolverBase
             IllegalArgumentException.class,
             () -> assertThatFormula(buildModulo(num10, num0, num10)).isSatisfiable());
         break;
-      case OPENSMT: // INFO
-      case MATHSAT5: // modulo not supported
+      case OPENSMT: // INFO: OpenSMT does not allow division by zero
         assertThrows(UnsupportedOperationException.class, () -> buildModulo(num10, num0, num10));
         break;
       default:
@@ -364,11 +357,6 @@ public class SolverTheoriesTest extends SolverBasedTest0.ParameterizedSolverBase
       case YICES2:
         assertThrows(UnsupportedOperationException.class, () -> buildDivision(a, b, num5));
         assertThrows(UnsupportedOperationException.class, () -> buildModulo(a, b, num0));
-        break;
-      case MATHSAT5: // modulo not supported
-        assertDivision(a, b, num5, aEq10, bEq2);
-        assertDivision(a, b, num5, aEqNeg10, bEqNeg2);
-        assertThrows(UnsupportedOperationException.class, () -> buildModulo(num10, num5, num0));
         break;
       default:
         assertDivision(a, b, num5, aEq10, bEq2);

--- a/src/org/sosy_lab/java_smt/test/SolverTheoriesTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverTheoriesTest.java
@@ -741,7 +741,7 @@ public class SolverTheoriesTest extends SolverBasedTest0.ParameterizedSolverBase
     switch (solver) {
       case MATHSAT5:
         // Mathsat5 has a different internal representation of the formula
-        assertThat(_b_at_i.toString()).isEqualTo("(`read_T(18)_T(20)` b i)");
+        assertThat(_b_at_i.toString()).isEqualTo("(`read_T(19)_T(21)` b i)");
         break;
       case BOOLECTOR:
         assume()
@@ -772,7 +772,7 @@ public class SolverTheoriesTest extends SolverBasedTest0.ParameterizedSolverBase
     switch (solver) {
       case MATHSAT5:
         assertThat(valueInMulti.toString())
-            .isEqualTo("(`read_int_int` (`read_int_T(17)` multi i) i)");
+            .isEqualTo("(`read_int_int` (`read_int_T(18)` multi i) i)");
         break;
       case PRINCESS:
         assertThat(valueInMulti.toString()).isEqualTo("select(select(multi, i), i)");
@@ -800,7 +800,7 @@ public class SolverTheoriesTest extends SolverBasedTest0.ParameterizedSolverBase
     switch (solver) {
       case MATHSAT5:
         assertThat(valueInMulti.toString())
-            .isEqualTo("(`read_int_rat` (`read_int_T(17)` multi i) i)");
+            .isEqualTo("(`read_int_rat` (`read_int_T(18)` multi i) i)");
         break;
       case PRINCESS:
         assertThat(valueInMulti.toString()).isEqualTo("select(select(multi, i), i)");
@@ -833,8 +833,8 @@ public class SolverTheoriesTest extends SolverBasedTest0.ParameterizedSolverBase
 
     switch (solver) {
       case MATHSAT5:
-        String readWrite = "(`read_int_T(18)` (`read_int_T(19)` multi i) i)";
-        assertThat(valueInMulti.toString()).isEqualTo(readWrite);
+        assertThat(valueInMulti.toString())
+            .isEqualTo("(`read_int_T(19)` (`read_int_T(20)` multi " + "i) i)");
         break;
       default:
         assertThat(valueInMulti.toString()).isEqualTo("(select (select multi i) i)");


### PR DESCRIPTION
Hello,
MathSAT is missing native support for integer modulo. In this PR we add a work-around based on the definition `remainder = dividend - floor(dividend/divisor)*divisor` to support the operation.