### PR TITLE
Fix empty sums in Z3

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3NumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3NumeralFormulaManager.java
@@ -72,7 +72,11 @@ abstract class Z3NumeralFormulaManager<
 
   @Override
   protected Long sumImpl(List<Long> operands) {
-    return Native.mkAdd(z3context, operands.size(), Longs.toArray(operands));
+    if (operands.isEmpty()) {
+      return makeNumberImpl(0);
+    } else {
+      return Native.mkAdd(z3context, operands.size(), Longs.toArray(operands));
+    }
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/test/NumeralFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/NumeralFormulaManagerTest.java
@@ -69,6 +69,16 @@ public class NumeralFormulaManagerTest extends SolverBasedTest0.ParameterizedSol
     assertThatFormula(bmgr.and(imgr.distinct(symbols), bmgr.and(constraints))).isUnsatisfiable();
   }
 
+  @Test
+  public void trivialSumTest() throws SolverException, InterruptedException {
+    requireIntegers();
+    assertThatFormula(imgr.equal(imgr.sum(ImmutableList.of()), imgr.makeNumber(0)))
+        .isTautological();
+    assertThatFormula(
+            imgr.equal(imgr.sum(ImmutableList.of(imgr.makeVariable("a"))), imgr.makeVariable("a")))
+        .isTautological();
+  }
+
   @SuppressWarnings("CheckReturnValue")
   @Test
   public void failOnInvalidStringInteger() {


### PR DESCRIPTION
Hello,
Z3 crashes when `NumeralFormulaManager.sum()` is called with no arguments. This PR adds some checks to handle this special-case.