### PR TITLE
Add special-case handling for distinct() with fewer than 2 arguments

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4NumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4NumeralFormulaManager.java
@@ -178,8 +178,12 @@ abstract class CVC4NumeralFormulaManager<
 
   @Override
   protected Expr distinctImpl(List<Expr> pParam) {
-    vectorExpr param = new vectorExpr();
-    pParam.forEach(param::add);
-    return exprManager.mkExpr(Kind.DISTINCT, param);
+    if (pParam.size() < 2) {
+      return exprManager.mkConst(true);
+    } else {
+      vectorExpr param = new vectorExpr();
+      pParam.forEach(param::add);
+      return exprManager.mkExpr(Kind.DISTINCT, param);
+    }
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5NumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5NumeralFormulaManager.java
@@ -188,6 +188,10 @@ abstract class CVC5NumeralFormulaManager<
 
   @Override
   protected Term distinctImpl(List<Term> pParam) {
-    return solver.mkTerm(Kind.DISTINCT, pParam.toArray(new Term[0]));
+    if (pParam.size() < 2) {
+      return solver.mkTrue();
+    } else {
+      return solver.mkTerm(Kind.DISTINCT, pParam.toArray(new Term[0]));
+    }
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolNumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolNumeralFormulaManager.java
@@ -148,7 +148,11 @@ abstract class SmtInterpolNumeralFormulaManager<
 
   @Override
   public Term distinctImpl(List<Term> pNumbers) {
-    return env.term("distinct", pNumbers.toArray(new Term[0]));
+    if (pNumbers.size() < 2) {
+      return env.getTheory().mTrue;
+    } else {
+      return env.term("distinct", pNumbers.toArray(new Term[0]));
+    }
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2NumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2NumeralFormulaManager.java
@@ -24,6 +24,7 @@ import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_parse_f
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_parse_rational;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_sub;
 import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_term_constructor;
+import static org.sosy_lab.java_smt.solvers.yices2.Yices2NativeApi.yices_true;
 
 import com.google.common.primitives.Ints;
 import java.math.BigInteger;
@@ -104,8 +105,11 @@ abstract class Yices2NumeralFormulaManager<
 
   @Override
   public Integer distinctImpl(List<Integer> pNumbers) {
-    int[] numberTerms = Ints.toArray(pNumbers);
-    return yices_distinct(numberTerms.length, numberTerms);
+    if (pNumbers.size() < 2) {
+      return yices_true();
+    } else {
+      return yices_distinct(pNumbers.size(), Ints.toArray(pNumbers));
+    }
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/test/NumeralFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/NumeralFormulaManagerTest.java
@@ -69,6 +69,13 @@ public class NumeralFormulaManagerTest extends SolverBasedTest0.ParameterizedSol
     assertThatFormula(bmgr.and(imgr.distinct(symbols), bmgr.and(constraints))).isUnsatisfiable();
   }
 
+  @Test
+  public void trivialDistinctTest() throws SolverException, InterruptedException {
+    requireIntegers();
+    assertThatFormula(imgr.distinct(ImmutableList.of())).isTautological();
+    assertThatFormula(imgr.distinct(ImmutableList.of(imgr.makeVariable("a")))).isTautological();
+  }
+
   @SuppressWarnings("CheckReturnValue")
   @Test
   public void failOnInvalidStringInteger() {


### PR DESCRIPTION
Hello,
several solvers crash when `NumeralFormulaManager.distinct()` is used with fewer than 2 arguments. This PR adds support for such special-cases to all solvers.