### PR TITLE
Use official binaries for CVC5/Add parsing support

### DIFF
--- a/build/build-maven-publish.xml
+++ b/build/build-maven-publish.xml
@@ -238,6 +238,8 @@ SPDX-License-Identifier: Apache-2.0
         <stage-solver-file filename="libcvc5jni" classifier="libcvc5jni-x64" filedirectory="${libDir.x64}" fileending="so"/>
         <stage-solver-file filename="libcvc5jni" classifier="libcvc5jni-arm64" filedirectory="${libDir.arm64}" fileending="so"/>
         <stage-solver-file filename="libcvc5jni" classifier="libcvc5jni-x64" filedirectory="${libDir.x64}" fileending="dll"/>
+        <stage-solver-file filename="libcvc5jni" classifier="libcvc5jni-x64" filedirectory="${libDir.x64}" fileending="dylib"/>
+        <stage-solver-file filename="libcvc5jni" classifier="libcvc5jni-arm64" filedirectory="${libDir.arm64}" fileending="dylib"/>
     </target>
 
     <!--

--- a/build/build-publish-solvers/solver-cvc5.xml
+++ b/build/build-publish-solvers/solver-cvc5.xml
@@ -14,122 +14,49 @@ SPDX-License-Identifier: Apache-2.0
 <project name="publish-solvers-cvc5" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
     <import file="macros.xml"/>
 
+    <property name="cvc5.url" value="https://github.com/cvc5/cvc5/releases/download/latest"/>
+    <property name="cvc5.downloads" value="/dependencies/cvc5"/>
     <property name="cvc5.distDir" value="${ivy.solver.dist.dir}/cvc5"/>
 
-    <!-- Build options for CVC5, Reasoning:
-          - 'production' enable optimization, disables assertions and tracing,
-          - 'static' build libcvc5 and all dependencies statically,
-          - 'java-bindings' build the JNI bindings,
-          - 'auto-download' load all dependencies automatically,
-          - 'prefix' because I don't want it to use system installed or install system-wide,
-          Theoretically CVC5s performance should be improvable by using -best (uses the best
-          known general performance/dependencies) but this can not be combined with auto-download.
-    -->
-    <target name="set-properties-for-cvc5">
-        <checkPathOption pathOption="cvc5.path" defaultPath="/path/to/cvc5" targetName="CVC5 directory (Git checkout from https://github.com/cvc5/cvc5)"/>
-        <fail unless="cvc5.customRev">
-            Please specify a custom revision with the flag -Dcvc5.customRev=XXX.
-            The custom revision has to be unique amongst the already known version
-            numbers from the ivy repository. The script will append the git revision.
+    <target name="download-cvc5">
+        <fail unless="cvc5.version">
+            Please specify a version with the flag -Dcvc5.version=XXX.
+            The version must match one of the daily builds from https://github.com/cvc5/cvc5/releases
         </fail>
-        <checkPathOption pathOption="jdk-linux-arm64.path" defaultPath="/path/to/jdk" targetName="JDK source folder (Linux arm64 version)"/>
-        <checkPathOption pathOption="jdk-windows-x64.path" defaultPath="/path/to/jdk" targetName="JDK source folder (Windows x64 version)"/>
 
-        <!-- get the short commit hash of the cvc5 version used -->
-        <exec executable="git" dir="${cvc5.path}" outputproperty="cvc5.revision" failonerror="true">
-            <arg value="show"/>
-            <arg value="-s"/>
-            <arg value="--format=%h"/>
-        </exec>
-        <property name="cvc5.version" value="${cvc5.customRev}-g${cvc5.revision}"/>
-        <echo message="Building CVC5 in version '${cvc5.version}'"/>
+        <mkdir dir="${cvc5.downloads}"/>
+        <mkdir dir="${cvc5.distDir}"/>
 
-        <!-- set a path to the build folder, which is cleaned before building any binary files -->
-        <property name="cvc5.buildDir" location="${cvc5.path}/build"/>
+        <!-- Download binaries for linux on x64 -->
+        <get src="${cvc5.url}/cvc5-Linux-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}" verbose="true"/>
+        <unzip src="${cvc5.downloads}/cvc5-Linux-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}"/>
+        <copy file="${cvc5.downloads}/cvc5-Linux-x86_64-static/lib/libcvc5jni.so" tofile="${cvc5.distDir}/x64/libcvc5jni-${cvc5.version}.so"/>
 
-        <property name="cvc5.installDir.x64-linux" location="${cvc5.path}/install/x64-linux"/>
-        <property name="cvc5.installDir.arm64-linux" location="${cvc5.path}/install/arm64-linux"/>
-        <property name="cvc5.installDir.x64-windows" location="${cvc5.path}/install/x64-windows"/>
+        <!-- Download binaries for linux on arm64 -->
+        <get src="${cvc5.url}/cvc5-Linux-arm64-static-${cvc5.version}.zip" dest="${cvc5.downloads}" verbose="true"/>
+        <unzip src="${cvc5.downloads}/cvc5-Linux-arm64-static-${cvc5.version}.zip" dest="${cvc5.downloads}"/>
+        <copy file="${cvc5.downloads}/cvc5-Linux-arm64-static/lib/libcvc5jni.so" tofile="${cvc5.distDir}/arm64/libcvc5jni-${cvc5.version}.so"/>
+
+        <!-- Download binaries for macOS on x64 -->
+        <get src="${cvc5.url}/cvc5-macOS-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}" verbose="true"/>
+        <unzip src="${cvc5.downloads}/cvc5-macOS-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}"/>
+        <copy file="${cvc5.downloads}/cvc5-macOS-x86_64-static/lib/libcvc5jni.dylib" tofile="${cvc5.distDir}/x64/libcvc5jni-${cvc5.version}.dylib"/>
+
+        <!-- Download binaries for macOS on arm64 -->
+        <get src="${cvc5.url}/cvc5-macOS-arm64-static-${cvc5.version}.zip" dest="${cvc5.downloads}" verbose="true"/>
+        <unzip src="${cvc5.downloads}/cvc5-macOS-arm64-static-${cvc5.version}.zip" dest="${cvc5.downloads}"/>
+        <copy file="${cvc5.downloads}/cvc5-macOS-arm64-static/lib/libcvc5jni.dylib" tofile="${cvc5.distDir}/arm64/libcvc5jni-${cvc5.version}.dylib"/>
+
+        <!-- Download binaries for Windows on x64 -->
+        <get src="${cvc5.url}/cvc5-Win64-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}" verbose="true"/>
+        <unzip src="${cvc5.downloads}/cvc5-Win64-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}"/>
+        <copy file="${cvc5.downloads}/cvc5-Win64-x86_64-static/bin/cvc5jni.dll" tofile="${cvc5.distDir}/x64/libcvc5jni-${cvc5.version}.dll"/>
+
+        <!-- Download the Java bindings -->
+        <get src="${cvc5.url}/cvc5-Linux-arm64-java-api-${cvc5.version}.jar" dest="${cvc5.distDir}/cvc5-${cvc5.version}.jar" verbose="true"/>
     </target>
 
-    <target name="compile-cvc5-linux-x64" depends="set-properties-for-cvc5">
-        <echo message="Building CVC5 for x64 linux"/>
-        <delete dir="${cvc5.buildDir}" quiet="true"/>
-        <exec executable="./configure.sh" dir="${cvc5.path}" failonerror="true">
-            <arg value="production"/>
-            <arg value="--static"/>
-            <arg value="--java-bindings"/>
-            <arg value="--auto-download"/>
-            <arg value="--prefix=${cvc5.installDir.x64-linux}"/>
-        </exec>
-        <exec executable="make" dir="${cvc5.buildDir}" failonerror="true">
-            <arg value="-j4"/>
-            <arg value="install"/>
-        </exec>
-        <exec executable="strip" dir="${cvc5.installDir.x64-linux}/lib" failonerror="true">
-            <arg value="libcvc5jni.so"/>
-        </exec>
-    </target>
-
-    <target name="compile-cvc5-linux-arm64" depends="set-properties-for-cvc5">
-        <echo message="Building CVC5 for arm64 linux"/>
-        <delete dir="${cvc5.buildDir}" quiet="true"/>
-        <exec executable="./configure.sh" dir="${cvc5.path}" failonerror="true">
-            <env key="JNI_HOME" value="${jdk-linux-arm64.path}"/>
-            <arg value="production"/>
-            <arg value="--arm64"/>
-            <arg value="--static"/>
-            <arg value="--java-bindings"/>
-            <arg value="--auto-download"/>
-            <arg value="--prefix=${cvc5.installDir.arm64-linux}"/>
-        </exec>
-        <exec executable="make" dir="${cvc5.buildDir}" failonerror="true">
-            <arg value="-j4"/>
-            <arg value="install"/>
-        </exec>
-        <exec executable="aarch64-linux-gnu-strip" dir="${cvc5.installDir.arm64-linux}/lib" failonerror="true">
-            <arg value="libcvc5jni.so"/>
-        </exec>
-    </target>
-
-    <target name="compile-cvc5-windows-x64" depends="set-properties-for-cvc5">
-        <echo message="Building CVC5 for x64 windows"/>
-        <delete dir="${cvc5.buildDir}" quiet="true"/>
-        <exec executable="./configure.sh" dir="${cvc5.path}" failonerror="true">
-            <env key="JNI_HOME" value="${jdk-windows-x64.path}"/>
-            <arg value="production"/>
-            <arg value="--win64"/>
-            <arg value="--static"/>
-            <arg value="--java-bindings"/>
-            <arg value="--auto-download"/>
-            <arg value="--prefix=${cvc5.installDir.x64-windows}"/>
-        </exec>
-        <exec executable="make" dir="${cvc5.buildDir}" failonerror="true">
-            <arg value="-j4"/>
-            <arg value="install"/>
-        </exec>
-        <exec executable="x86_64-w64-mingw32-strip" dir="${cvc5.installDir.x64-windows}/bin" failonerror="true">
-            <arg value="cvc5jni.dll"/>
-        </exec>
-    </target>
-
-    <target name="package-cvc5" depends="compile-cvc5-linux-x64, compile-cvc5-linux-arm64, compile-cvc5-windows-x64">
-        <!-- get the actual jar location as cvc5.jar is just a link -->
-        <exec executable="readlink" dir="${cvc5.installDir.x64-linux}/share/java" outputproperty="cvc5.jar" failonerror="true">
-            <arg value="-f"/>
-            <arg value="cvc5.jar"/>
-        </exec>
-
-        <!-- copy library files into directory to be published for IVY -->
-        <echo message="Copying artifact for Ivy release"/>
-        <copy file="${cvc5.jar}" tofile="${cvc5.distDir}/cvc5-${cvc5.version}.jar"/>
-        <copy file="${cvc5.installDir.x64-linux}/lib/libcvc5jni.so" tofile="${cvc5.distDir}/x64/libcvc5jni-${cvc5.version}.so"/>
-        <copy file="${cvc5.installDir.arm64-linux}/lib/libcvc5jni.so" tofile="${cvc5.distDir}/arm64/libcvc5jni-${cvc5.version}.so"/>
-        <copy file="${cvc5.installDir.x64-windows}/bin/cvc5jni.dll" tofile="${cvc5.distDir}/x64/libcvc5jni-${cvc5.version}.dll"/>
-    </target>
-
-    <target name="publish-cvc5" depends="package-cvc5, load-ivy"
-            description="Publish CVC5 binaries to Ivy repository.">
+    <target name="publish-cvc5" depends="download-cvc5, load-ivy" description="Publish CVC5 binaries to Ivy repository.">
         <ivy:resolve conf="solver-cvc5" file="solvers_ivy_conf/ivy_cvc5.xml"/>
         <publishToRepository solverName="CVC5" solverVersion="${cvc5.version}" distDir="${cvc5.distDir}"/>
 

--- a/doc/Developers-How-to-Release-into-Ivy.md
+++ b/doc/Developers-How-to-Release-into-Ivy.md
@@ -116,36 +116,24 @@ Finally follow the instructions shown in the message at the end.
 
 ### Publishing CVC5
 
-We prefer to compile our own CVC5 binaries and Java bindings.
-For simple usage, we provide a Docker definition/environment under `/docker`,
-in which the following command can be run.
-
-To publish CVC5, checkout the [CVC5 repository](https://github.com/cvc5/cvc5) and download the
-JDK for windows and arm64 from Oracle. We will build bindings for several platforms and
-the JDKs are needed to cross-compile. To start building, execute the following command
-in the JavaSMT directory, where `$CVC5_DIR` is the path to the CVC5 directory and
-`$CVC5_VERSION` is the version number:
+We prefer to use the official CVC5 binaries, please build from source only if necessary (e.g., in
+case of an important bugfix). The binaries can be fetched and repackaged fully automatically:
 
 ```
-ant publish-cvc5 \
-    -Dcvc5.path=$CVC5_DIR\
-    -Dcvc5.customRev=$CVC5_VERSION \
-    -Djdk-windows.path=$JDK_DIR_WINDOWS \
-    -Djdk-linux-arm64.path=$JDK_DIR_LINUX_ARM64
+ant publish-cvc5 -Dcvc5.version=$CVC5_VERSION
 ```
+
+Where `CVC5_VERSION` must match one of the daily releases from
+their [github](https://github.com/cvc5/cvc5/releases/tag/latest) website
 
 Example:
 
 ```
-ant publish-cvc5 \
-    -Dcvc5.path=../CVC5 \
-    -Dcvc5.customRev=1.2.1 \
-    -Djdk-windows-x64.path=/workspace/solvers/jdk/openjdk-17.0.2_windows-x64_bin/jdk-17.0.2/ \
-    -Djdk-linux-arm64.path=/workspace/solvers/jdk/openjdk-17.0.2_linux-aarch64_bin/jdk-17.0.2/
+ant publish-cvc5 -Dcvc5.version=2025-03-31-34518c3
 ```
 
-During the build process, our script automatically appends the git-revision after the version.
-Finally, follow the instructions shown in the message at the end.
+During the build process, our script automatically fetches binaries for windows, linux and
+maxOS on x64 and arm64 and repackages them to be used in JavaSMT.
 
 
 ### Publishing OpenSMT

--- a/docker/ubuntu1804.Dockerfile
+++ b/docker/ubuntu1804.Dockerfile
@@ -33,18 +33,6 @@ RUN apt-get update \
         autoconf gperf \
  && apt-get clean
 
-# CVC5 requires some dependencies
-RUN apt-get update \
- && apt-get install -y \
-        python3 python3-venv python3-toml python3-pyparsing flex libssl-dev cmake \
- && apt-get clean \
- && wget https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3.tar.gz \
- && tar -zxvf cmake-3.26.3.tar.gz \
- && cd cmake-3.26.3 \
- && ./bootstrap \
- && make \
- && make install
-
 # Bitwuzla requires Ninja and Meson (updated version from pip), and uses SWIG >4.0 from dependencies.
 # GMP >6.3.0 is automatically downloaded and build within Bitwuzla.
 RUN apt-get update \
@@ -60,7 +48,7 @@ RUN pip3 install --upgrade meson
 # - lzip is required to unpack the gmp tar ball
 RUN apt-get update \
  && apt-get install -y \
-        flex bison libpcre2-dev lzip \
+        cmake flex bison libpcre2-dev lzip \
  && apt-get clean
 
 WORKDIR /dependencies

--- a/docker/ubuntu2204.Dockerfile
+++ b/docker/ubuntu2204.Dockerfile
@@ -34,12 +34,6 @@ RUN  apt-get update \
         autoconf gperf \
  && apt-get clean
 
-# CVC5 requires some dependencies
-RUN apt-get update \
- && apt-get install -y \
-        python3 python3-venv python3-toml python3-pyparsing flex libssl-dev cmake \
- && apt-get clean
-
 # Bitwuzla requires Ninja and Meson (updated version from pip), and uses SWIG >4.0 from dependencies.
 # GMP >6.3.0 is automatically downloaded and build within Bitwuzla.
 RUN apt-get update \
@@ -55,7 +49,7 @@ RUN pip3 install --upgrade meson
 # - lzip is required to unpack the gmp tar ball
 RUN apt-get update \
  && apt-get install -y \
-        flex bison libpcre2-dev lzip \
+        cmake flex bison libpcre2-dev lzip \
  && apt-get clean
 
 WORKDIR /dependencies

--- a/lib/ivy.xml
+++ b/lib/ivy.xml
@@ -193,7 +193,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency org="org.sosy_lab" name="javasmt-solver-opensmt" rev="2.8.0-sosy0-ge831bf23" conf="runtime-opensmt-x64->solver-opensmt-x64; runtime-opensmt-arm64->solver-opensmt-arm64; contrib->sources,javadoc"/>
         <dependency org="org.sosy_lab" name="javasmt-solver-optimathsat" rev="1.7.3-sosy1" conf="runtime-optimathsat->solver-optimathsat" />
         <dependency org="org.sosy_lab" name="javasmt-solver-cvc4" rev="1.8-prerelease-2020-06-24-g7825d8f28" conf="runtime-cvc4->solver-cvc4" />
-        <dependency org="org.sosy_lab" name="javasmt-solver-cvc5" rev="1.2.1-g8594a8e4dc" conf="runtime-cvc5-x64->solver-cvc5-x64; runtime-cvc5-arm64->solver-cvc5-arm64"/>
+        <dependency org="org.sosy_lab" name="javasmt-solver-cvc5" rev="2025-03-31-34518c3" conf="runtime-cvc5-x64->solver-cvc5-x64; runtime-cvc5-arm64->solver-cvc5-arm64"/>
         <dependency org="org.sosy_lab" name="javasmt-solver-boolector" rev="3.2.2-g1a89c229" conf="runtime-boolector->solver-boolector" />
         <dependency org="org.sosy_lab" name="javasmt-solver-bitwuzla" rev="0.7.0-13.1-g595512ae" conf="runtime-bitwuzla-x64->solver-bitwuzla-x64; runtime-bitwuzla-arm64->solver-bitwuzla-arm64; contrib->sources,javadoc"/>
 

--- a/solvers_ivy_conf/ivy_cvc5.xml
+++ b/solvers_ivy_conf/ivy_cvc5.xml
@@ -27,12 +27,14 @@ SPDX-License-Identifier: Apache-2.0
         <conf name="solver-cvc5" extends="solver-cvc5-x64"/>
 
         <!-- main configurations -->
-        <conf name="solver-cvc5-x64" extends="solver-cvc5-linux-x64, solver-cvc5-windows-x64"/>
-        <conf name="solver-cvc5-arm64" extends="solver-cvc5-linux-arm64"/>
+        <conf name="solver-cvc5-x64" extends="solver-cvc5-linux-x64, solver-cvc5-macos-x64, solver-cvc5-windows-x64"/>
+        <conf name="solver-cvc5-arm64" extends="solver-cvc5-linux-arm64, solver-cvc5-macos-arm64"/>
 
         <!-- basic configurations -->
         <conf name="solver-cvc5-linux-x64" extends="solver-cvc5-common"/>
         <conf name="solver-cvc5-linux-arm64" extends="solver-cvc5-common"/>
+        <conf name="solver-cvc5-macos-x64" extends="solver-cvc5-common"/>
+        <conf name="solver-cvc5-macos-arm64" extends="solver-cvc5-common"/>
         <conf name="solver-cvc5-windows-x64" extends="solver-cvc5-common"/>
 
         <conf name="solver-cvc5-common" visibility="private"/>
@@ -41,6 +43,8 @@ SPDX-License-Identifier: Apache-2.0
     <publications defaultconf="solver-cvc5">
         <artifact name="libcvc5jni" conf="solver-cvc5-linux-x64" e:arch="x64" type="shared-object" ext="so"/>
         <artifact name="libcvc5jni" conf="solver-cvc5-linux-arm64" e:arch="arm64" type="shared-object" ext="so"/>
+        <artifact name="libcvc5jni" conf="solver-cvc5-macos-x64" e:arch="x64" type="shared-object" ext="dylib"/>
+        <artifact name="libcvc5jni" conf="solver-cvc5-macos-arm64" e:arch="arm64" type="shared-object" ext="dylib"/>
         <artifact name="libcvc5jni" conf="solver-cvc5-windows-x64" e:arch="x64" type="shared-object" ext="dll"/>
         <!-- Java code -->
         <artifact name="cvc5" conf="solver-cvc5-common" ext="jar"/>

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
@@ -34,9 +34,7 @@ import io.github.cvc5.TermManager;
 import java.lang.reflect.Array;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.ArrayFormula;
@@ -72,13 +70,9 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
   /** CVC5 does not allow using some key-functions from SMTLIB2 as identifiers. */
   private static final ImmutableSet<String> UNSUPPORTED_IDENTIFIERS = ImmutableSet.of("let");
 
-  // private static final Pattern FLOATING_POINT_PATTERN = Pattern.compile("^\\(fp #b(?<sign>\\d)
-  // #b(?<exp>\\d+) #b(?<mant>\\d+)$");
+  /** We use a variable cache to keep track of variables/Ufs that have already been defined */
+  private final Table<String, Sort, Term> variablesCache = HashBasedTable.create();
 
-  // <Name, Sort.toString, Term> because CVC5 returns distinct pointers for types, while the
-  // String representation is equal (and they are equal)
-  private final Table<String, String, Term> variablesCache = HashBasedTable.create();
-  private final Map<String, Term> functionsCache = new HashMap<>();
   private final TermManager termManager;
   private final Solver solver;
 
@@ -98,9 +92,13 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
     return solver;
   }
 
+  Table<String, Sort, Term> getDeclaredVariables() {
+    return variablesCache;
+  }
+
   @Override
   public Term makeVariable(Sort sort, String name) {
-    Term existingVar = variablesCache.get(name, sort.toString());
+    Term existingVar = variablesCache.get(name, sort);
     if (existingVar != null) {
       return existingVar;
     }
@@ -124,7 +122,7 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
                   .getKey());
     }
     Term newVar = termManager.mkConst(sort, name);
-    variablesCache.put(name, sort.toString(), newVar);
+    variablesCache.put(name, sort, newVar);
     return newVar;
   }
 
@@ -426,13 +424,6 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
                 getFormulaType(f),
                 f.getKind()));
 
-      } else if (f.getKind() == Kind.VARIABLE) {
-        // BOUND vars are used for all vars that are bound to a quantifier in CVC5.
-        // We resubstitute them back to the original free.
-        // CVC5 doesn't give you the de-brujin index
-        Term originalVar = accessVariablesCache(formula.toString(), sort);
-        return visitor.visitBoundVariable(encapsulate(originalVar), 0);
-
       } else if (f.getKind() == Kind.FORALL || f.getKind() == Kind.EXISTS) {
         // QUANTIFIER: replace bound variable with free variable for visitation
         assert f.getNumChildren() == 2;
@@ -440,7 +431,7 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
         List<Formula> freeVars = new ArrayList<>();
         for (Term boundVar : f.getChild(0)) { // unpack grand-children of f.
           String name = getName(boundVar);
-          Term freeVar = Preconditions.checkNotNull(accessVariablesCache(name, boundVar.getSort()));
+          Term freeVar = makeVariable(boundVar.getSort(), name);
           body = body.substitute(boundVar, freeVar);
           freeVars.add(encapsulate(freeVar));
         }
@@ -520,7 +511,7 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
    * back to a common one.
    */
   private Term normalize(Term operator) {
-    Term function = functionsCache.get(getName(operator));
+    Term function = variablesCache.get(getName(operator), operator.getSort());
     if (function != null) {
       checkState(
           function.getId() == operator.getId(),
@@ -766,20 +757,19 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
   public Term declareUFImpl(String pName, Sort pReturnType, List<Sort> pArgTypes) {
     checkSymbol(pName);
 
-    Term exp = functionsCache.get(pName);
+    // Ufs in CVC5 can't have 0 arity. We just use a variable as a workaround.
+    Sort termSort =
+        pArgTypes.isEmpty()
+            ? pReturnType
+            : environment.mkFunctionSort(pArgTypes.toArray(new Sort[0]), pReturnType);
+    Term exp = variablesCache.get(pName, termSort);
 
     if (exp == null) {
-      // Ufs in CVC5 can't have 0 arity. We just use a variable as a workaround.
-      Sort sort =
-          pArgTypes.isEmpty()
-              ? pReturnType
-              : termManager.mkFunctionSort(pArgTypes.toArray(new Sort[0]), pReturnType);
-      exp = termManager.mkConst(sort, pName);
-      functionsCache.put(pName, exp);
-
+      exp = termManager.mkConst(termSort, pName);
+      variablesCache.put(pName, exp.getSort(), exp);
     } else {
       Preconditions.checkArgument(
-          exp.getSort().equals(exp.getSort()),
+          pReturnType.equals(exp.getSort().getFunctionCodomainSort()),
           "Symbol %s already in use for different return type %s",
           exp,
           exp.getSort());
@@ -799,6 +789,11 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
       }
     }
     return exp;
+  }
+
+  @Override
+  public Object convertValue(Term pValue) {
+    return convertValue(pValue, pValue);
   }
 
   @Override
@@ -856,29 +851,5 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
     Preconditions.checkState(bvValue.isBitVectorValue());
     final var bits = bvValue.getBitVectorValue();
     return FloatingPointNumber.of(bits, expWidth, mantWidth);
-  }
-
-  private Term accessVariablesCache(String name, Sort sort) {
-    Term existingVar = variablesCache.get(name, sort.toString());
-    if (existingVar == null) {
-      throw new IllegalArgumentException(
-          "Symbol "
-              + name
-              + " requested with type "
-              + sort
-              + ", but "
-              + "already "
-              + "used "
-              + "with "
-              + "type"
-              + variablesCache
-                  .rowMap()
-                  .get(name)
-                  .entrySet()
-                  .toArray((java.util.Map.Entry[]) Array.newInstance(java.util.Map.Entry.class, 0))[
-                  0]
-                  .getKey());
-    }
-    return existingVar;
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Model.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Model.java
@@ -9,6 +9,7 @@
 package org.sosy_lab.java_smt.solvers.cvc5;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.github.cvc5.CVC5ApiException;
@@ -81,7 +82,7 @@ public class CVC5Model extends AbstractModel<Term, Sort, TermManager> {
         // Vars and UFs, as well as bound vars in UFs!
         // In CVC5 consts are variables! Free variables (in CVC5s notation, we call them bound
         // variables, created with mkVar() can never have a value!)
-        builder.add(getAssignment(expr));
+        builder.addAll(getAssignment(expr));
       } else if (kind == Kind.FORALL || kind == Kind.EXISTS) {
         // Body of the quantifier, with bound vars!
         Term body = expr.getChild(1);
@@ -169,7 +170,96 @@ public class CVC5Model extends AbstractModel<Term, Sort, TermManager> {
         keyFormula, valueFormula, equation, nameStr, value, argumentInterpretationBuilder.build());
   }
 
-  private ValueAssignment getAssignment(Term pKeyTerm) {
+  /** Takes a (nested) select statement and returns its indices. */
+  private Iterable<Term> getArgs(Term array) throws CVC5ApiException {
+    if (array.getKind().equals(Kind.SELECT)) {
+      return FluentIterable.concat(getArgs(array.getChild(0)), ImmutableList.of(array.getChild(1)));
+    } else {
+      return ImmutableList.of();
+    }
+  }
+
+  /** Takes a select statement with multiple indices and returns the variable name at the bottom. */
+  private String getVar(Term array) throws CVC5ApiException {
+    if (array.getKind().equals(Kind.SELECT)) {
+      return getVar(array.getChild(0));
+    } else {
+      return array.getSymbol();
+    }
+  }
+
+  /** Build assignment for an array value. */
+  private Iterable<ValueAssignment> buildArrayAssignment(Term expr, Term value) {
+    // CVC5 returns values such as "(Store (Store ... i1,1 e1,1) i1,0 e1,0)" where the i1,x match
+    // the first index of the array and the elements e1,Y can again be arrays (if there is more
+    // than one index). We need "pattern match" this values to extract assignments from it.
+    // Initially we have:
+    //  arr = (Store (Store ... i1,1 e1,1) i1,0 e1,0)
+    // where 'arr' is the name of the variable. By applying (Select i1,0 ...) to both side we get:
+    // (Select i1,0 arr) = (Select i1,0 (Store (Store ... i1,1 e1,1) i1,0 e1,0))
+    // The right side simplifies to e1,0 as the index matches. We need to continue with this for
+    // all other matches to the first index, that is
+    // (Select i1,1 arr) = (Select i1,0 (Store (Store ... i1,1 e1,1) i1,0 e1,0))
+    //                   = (Select i1,0 (Store ... i1,1 e1,1))
+    //                   = e1,1
+    // until all matches are explored and the bottom of the Store chain is reached. If the array
+    // has more than one dimension we also have to descend into the elements to apply the next
+    // index there. For instance, let's consider a 2-dimensional array with type (Array Int ->
+    // (Array Int -> Int)). After matching the first index just as in the above example we might
+    // have:
+    // (Select i1,0 arr) = (Select i1,0 (Store (Store ... i1,1 e1,1) i1,0 e1,0)) = e1,0
+    // In this case e1,0 is again a Store chain, let's say e1,0 := (Store (Store ... i2,1 e2,1)
+    // i2,0 e2,0), and we now continue with the second index:
+    // (Select i2,1 (Select i1,0 arr)) = (Select i2,1 (Store (Store ... i2,1 e2,1) i2,0 e2,0)) =
+    //                                 = e2,1
+    // This again has to be done for all possible matches.
+    // Once we've reached the last index, the successor element will be a non-array value. We
+    // then create the final assignments and return:
+    // (Select iK,mK ... (Select i2,1 (Select i1,0 arr)) = eik,mK
+    try {
+      if (value.getKind().equals(Kind.STORE)) {
+        // This is a Store node for the current index. We need to follow the chain downwards to
+        // match this index, while also exploring the successor for the other indices
+        Term index = value.getChild(1);
+        Term element = value.getChild(2);
+
+        Term select = creator.getEnv().mkTerm(Kind.SELECT, expr, index);
+
+        Iterable<ValueAssignment> current;
+        if (expr.getSort().getArrayElementSort().isArray()) {
+          current = buildArrayAssignment(select, element);
+        } else {
+          Term equation = creator.getEnv().mkTerm(Kind.EQUAL, select, element);
+          current =
+              FluentIterable.of(
+                  new ValueAssignment(
+                      creator.encapsulate(creator.getFormulaType(element), select),
+                      creator.encapsulate(creator.getFormulaType(element), element),
+                      creator.encapsulateBoolean(equation),
+                      getVar(expr),
+                      creator.convertValue(element, element),
+                      FluentIterable.from(getArgs(select))
+                          .transform(creator::convertValue)
+                          .toList()));
+        }
+        return FluentIterable.concat(current, buildArrayAssignment(expr, value.getChild(0)));
+
+      } else if (value.getKind().equals(Kind.CONST_ARRAY)) {
+        // We've reached the end of the Store chain
+        return ImmutableList.of();
+
+      } else {
+        // Should be unreachable
+        // We assume that array values are made up of "cons" and "store" nodes with non-array
+        // constants as leaves
+        throw new IllegalArgumentException();
+      }
+    } catch (CVC5ApiException pE) {
+      throw new RuntimeException(pE);
+    }
+  }
+
+  private Iterable<ValueAssignment> getAssignment(Term pKeyTerm) {
     ImmutableList.Builder<Object> argumentInterpretationBuilder = ImmutableList.builder();
     for (int i = 0; i < pKeyTerm.getNumChildren(); i++) {
       try {
@@ -193,13 +283,23 @@ public class CVC5Model extends AbstractModel<Term, Sort, TermManager> {
     }
 
     Term valueTerm = solver.getValue(pKeyTerm);
-    Formula keyFormula = creator.encapsulateWithTypeOf(pKeyTerm);
-    Formula valueFormula = creator.encapsulateWithTypeOf(valueTerm);
-    BooleanFormula equation =
-        creator.encapsulateBoolean(termManager.mkTerm(Kind.EQUAL, pKeyTerm, valueTerm));
-    Object value = creator.convertValue(pKeyTerm, valueTerm);
-    return new ValueAssignment(
-        keyFormula, valueFormula, equation, nameStr, value, argumentInterpretationBuilder.build());
+    if (valueTerm.getSort().isArray()) {
+      return buildArrayAssignment(pKeyTerm, valueTerm);
+    } else {
+      Formula keyFormula = creator.encapsulateWithTypeOf(pKeyTerm);
+      Formula valueFormula = creator.encapsulateWithTypeOf(valueTerm);
+      BooleanFormula equation =
+          creator.encapsulateBoolean(termManager.mkTerm(Kind.EQUAL, pKeyTerm, valueTerm));
+      Object value = creator.convertValue(pKeyTerm, valueTerm);
+      return ImmutableList.of(
+          new ValueAssignment(
+              keyFormula,
+              valueFormula,
+              equation,
+              nameStr,
+              value,
+              argumentInterpretationBuilder.build()));
+    }
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/test/ModelTest.java
+++ b/src/org/sosy_lab/java_smt/test/ModelTest.java
@@ -2240,7 +2240,7 @@ public class ModelTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
     assume()
         .withMessage("Solver is quite slow for this example")
         .that(solverToUse())
-        .isNotEqualTo(Solvers.PRINCESS);
+        .isNoneOf(Solvers.PRINCESS, Solvers.CVC5);
 
     BooleanFormula formula =
         context

--- a/src/org/sosy_lab/java_smt/test/ModelTest.java
+++ b/src/org/sosy_lab/java_smt/test/ModelTest.java
@@ -1724,7 +1724,6 @@ public class ModelTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
     // supported yet
     // TODO: only filter out UF formulas here, not all
     if (solver != Solvers.BOOLECTOR) {
-      // CVC5 crashes here
       assertThatFormula(bmgr.and(pModelAssignments)).implies(constraint);
     }
   }

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -324,7 +324,7 @@ public abstract class SolverBasedTest0 {
     assume()
         .withMessage("Solver %s does not support parsing formulae", solverToUse())
         .that(solverToUse())
-        .isNoneOf(Solvers.CVC4, Solvers.BOOLECTOR, Solvers.YICES2, Solvers.CVC5);
+        .isNoneOf(Solvers.CVC4, Solvers.BOOLECTOR, Solvers.YICES2);
   }
 
   protected void requireArrayModel() {

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -124,6 +124,11 @@ public class SolverConcurrencyTest {
           .that(solver)
           .isNotEqualTo(Solvers.MATHSAT5);
     }
+
+    assume()
+        .withMessage("Solver does not support concurrency without concurrent context.")
+        .that(solver)
+        .isNotEqualTo(Solvers.CVC5);
   }
 
   private void requireConcurrentMultipleStackSupport() {
@@ -298,7 +303,7 @@ public class SolverConcurrencyTest {
     assume()
         .withMessage("Solver does not support translation of formulas")
         .that(solver)
-        .isNoneOf(Solvers.CVC4, Solvers.PRINCESS, Solvers.CVC5);
+        .isNoneOf(Solvers.CVC4, Solvers.PRINCESS);
 
     ConcurrentLinkedQueue<ContextAndFormula> contextAndFormulaList = new ConcurrentLinkedQueue<>();
 
@@ -348,11 +353,6 @@ public class SolverConcurrencyTest {
   public void testIntConcurrencyWithoutConcurrentContext() throws InvalidConfigurationException {
     requireIntegers();
 
-    assume()
-        .withMessage("Solver does not support concurrency without concurrent context.")
-        .that(solver)
-        .isNotEqualTo(Solvers.CVC5);
-
     ConcurrentLinkedQueue<SolverContext> contextList = new ConcurrentLinkedQueue<>();
     // Initialize contexts before using them in the threads
     for (int i = 0; i < NUMBER_OF_THREADS; i++) {
@@ -372,11 +372,6 @@ public class SolverConcurrencyTest {
   @Test
   public void testBvConcurrencyWithoutConcurrentContext() throws InvalidConfigurationException {
     requireBitvectors();
-
-    assume()
-        .withMessage("Solver does not support concurrency without concurrent context.")
-        .that(solver)
-        .isNotEqualTo(Solvers.CVC5);
 
     ConcurrentLinkedQueue<SolverContext> contextList = new ConcurrentLinkedQueue<>();
     // Initialize contexts before using them in the threads
@@ -545,7 +540,7 @@ public class SolverConcurrencyTest {
     assume()
         .withMessage("Solver does not support translation of formulas")
         .that(solver)
-        .isNoneOf(Solvers.CVC4, Solvers.CVC5, Solvers.PRINCESS);
+        .isNoneOf(Solvers.CVC4, Solvers.PRINCESS);
 
     // This is fine! We might access this more than once at a time,
     // but that gives only access to the bucket, which is threadsafe.

--- a/src/org/sosy_lab/java_smt/test/SolverFormulaIODeclarationsTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverFormulaIODeclarationsTest.java
@@ -194,13 +194,6 @@ public class SolverFormulaIODeclarationsTest
   @Test
   public void parseDeclareConflictInQueryTest3() {
     requireIntegers();
-    // CVC5 allows multiple definitions of the same symbol with different types. This is causing
-    // some issues with JavaSMT where UF functions must have a single type.
-    // In the test above we were able to work around the issue by checking if the list of
-    // declared symbols that is returned by the parser contains any duplicates. However, this
-    // does not seem to work here as the two definitions only differ in their return type and
-    // CVC5 reports only one if the declaration.
-    // TODO Report this to the developers
     String query = "(declare-fun x (Int) Bool)(declare-fun x (Int) Int)(assert (x 0))";
     if (Solvers.Z3 != solverToUse()) {
       assertThrows(IllegalArgumentException.class, () -> mgr.parse(query));

--- a/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
@@ -277,12 +277,16 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
 
   @Test
   public void parseMathSatTestParseFirst1() throws SolverException, InterruptedException {
+    // MathSat prints reserved symbols starting with . or @ that CVC5 can't parse
+    assume().that(solver).isNotEqualTo(Solvers.CVC5);
     requireParser();
     compareParseWithOrgParseFirst(MATHSAT_DUMP1, this::genBoolExpr);
   }
 
   @Test
   public void parseMathSatTestExprFirst1() throws SolverException, InterruptedException {
+    // MathSat prints reserved symbols starting with . or @ that CVC5 can't parse
+    assume().that(solver).isNotEqualTo(Solvers.CVC5);
     requireParser();
     compareParseWithOrgExprFirst(MATHSAT_DUMP1, this::genBoolExpr);
   }
@@ -313,6 +317,8 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
 
   @Test
   public void parseMathSatTestParseFirst2() throws SolverException, InterruptedException {
+    // MathSat prints reserved symbols starting with . or @ that CVC5 can't parse
+    assume().that(solver).isNotEqualTo(Solvers.CVC5);
     requireParser();
     requireIntegers();
     compareParseWithOrgParseFirst(MATHSAT_DUMP2, this::redundancyExprGen);
@@ -320,6 +326,8 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
 
   @Test
   public void parseMathSatTestExprFirst2() throws SolverException, InterruptedException {
+    // MathSat prints reserved symbols starting with . or @ that CVC5 can't parse
+    assume().that(solver).isNotEqualTo(Solvers.CVC5);
     requireParser();
     compareParseWithOrgExprFirst(MATHSAT_DUMP2, this::redundancyExprGen);
   }
@@ -352,6 +360,8 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
 
   @Test
   public void parseMathSatTestExprFirst3() throws SolverException, InterruptedException {
+    // MathSat prints reserved symbols starting with . or @ that CVC5 can't parse
+    assume().that(solver).isNotEqualTo(Solvers.CVC5);
     requireParser();
     requireIntegers();
     compareParseWithOrgExprFirst(MATHSAT_DUMP3, this::functionExprGen);

--- a/src/org/sosy_lab/java_smt/test/TimeoutTest.java
+++ b/src/org/sosy_lab/java_smt/test/TimeoutTest.java
@@ -8,13 +8,14 @@
 
 package org.sosy_lab.java_smt.test;
 
+import static com.google.common.truth.TruthJUnit.assume;
 import static org.junit.Assert.assertThrows;
 
-import com.google.common.truth.TruthJUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -62,13 +63,20 @@ public class TimeoutTest extends SolverBasedTest0 {
     return Logics.QF_LIA;
   }
 
+  @Before
+  public void setUp() {
+    // FIXME CVC5 has interruptions, but crashes on Windows, probably due to concurrency issues
+    // TODO Add interruption for Princess
+    assume()
+        .withMessage(solverToUse() + " does not support interruption")
+        .that(solverToUse())
+        .isNoneOf(Solvers.PRINCESS, Solvers.CVC5);
+  }
+
   @Test
   @SuppressWarnings("CheckReturnValue")
   public void testTacticTimeout() {
-    TruthJUnit.assume()
-        .withMessage("Only Z3 has native tactics")
-        .that(solverToUse())
-        .isEqualTo(Solvers.Z3);
+    assume().withMessage("Only Z3 has native tactics").that(solverToUse()).isEqualTo(Solvers.Z3);
     Fuzzer fuzzer = new Fuzzer(mgr, new Random(0));
     String msg = "ShutdownRequest";
     BooleanFormula test = fuzzer.fuzz(20, 3);
@@ -79,21 +87,12 @@ public class TimeoutTest extends SolverBasedTest0 {
   @Test(timeout = TIMEOUT_MILLISECONDS)
   public void testProverTimeoutInt() throws InterruptedException {
     requireIntegers();
-    TruthJUnit.assume()
-        .withMessage(solverToUse() + " does not support interruption")
-        .that(solverToUse())
-        .isNoneOf(Solvers.PRINCESS, Solvers.BOOLECTOR, Solvers.CVC5);
     testBasicProverTimeoutInt(() -> context.newProverEnvironment());
   }
 
   @Test(timeout = TIMEOUT_MILLISECONDS)
   public void testProverTimeoutBv() throws InterruptedException {
     requireBitvectors();
-    TruthJUnit.assume()
-        .withMessage(solverToUse() + " does not support interruption")
-        .that(solverToUse())
-        .isNoneOf(Solvers.PRINCESS, Solvers.CVC5);
-
     testBasicProverTimeoutBv(() -> context.newProverEnvironment());
   }
 
@@ -101,10 +100,6 @@ public class TimeoutTest extends SolverBasedTest0 {
   public void testInterpolationProverTimeout() throws InterruptedException {
     requireInterpolation();
     requireIntegers();
-    TruthJUnit.assume()
-        .withMessage(solverToUse() + " does not support interruption")
-        .that(solverToUse())
-        .isNoneOf(Solvers.PRINCESS, Solvers.BOOLECTOR, Solvers.CVC5);
     testBasicProverTimeoutInt(() -> context.newProverEnvironmentWithInterpolation());
   }
 


### PR DESCRIPTION
Hello,
this PR switches the build to using the official CVC5 binaries release on [github](https://github.com/cvc5/cvc5/releases/tag/latest). This will allow us to support macOS on both x64 and arm64 platforms. I've also added support for SMTLIB parsing in CVC5, but this could still be split off into a separate PR if needed. Before merging we should wait for the next CVC5 release as the daily builds that this PR currently uses will not be permanently available. The last stable release, however, does not have some bug fixes that are need.