### PR TITLE
Disable the flaky tests for CVC5

### DIFF
--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -124,6 +124,11 @@ public class SolverConcurrencyTest {
           .that(solver)
           .isNotEqualTo(Solvers.MATHSAT5);
     }
+
+    assume()
+        .withMessage("Solver does not support concurrency without concurrent context.")
+        .that(solver)
+        .isNotEqualTo(Solvers.CVC5);
   }
 
   private void requireConcurrentMultipleStackSupport() {
@@ -298,7 +303,7 @@ public class SolverConcurrencyTest {
     assume()
         .withMessage("Solver does not support translation of formulas")
         .that(solver)
-        .isNoneOf(Solvers.CVC4, Solvers.PRINCESS, Solvers.CVC5);
+        .isNoneOf(Solvers.CVC4, Solvers.PRINCESS);
 
     ConcurrentLinkedQueue<ContextAndFormula> contextAndFormulaList = new ConcurrentLinkedQueue<>();
 
@@ -348,11 +353,6 @@ public class SolverConcurrencyTest {
   public void testIntConcurrencyWithoutConcurrentContext() throws InvalidConfigurationException {
     requireIntegers();
 
-    assume()
-        .withMessage("Solver does not support concurrency without concurrent context.")
-        .that(solver)
-        .isNotEqualTo(Solvers.CVC5);
-
     ConcurrentLinkedQueue<SolverContext> contextList = new ConcurrentLinkedQueue<>();
     // Initialize contexts before using them in the threads
     for (int i = 0; i < NUMBER_OF_THREADS; i++) {
@@ -372,11 +372,6 @@ public class SolverConcurrencyTest {
   @Test
   public void testBvConcurrencyWithoutConcurrentContext() throws InvalidConfigurationException {
     requireBitvectors();
-
-    assume()
-        .withMessage("Solver does not support concurrency without concurrent context.")
-        .that(solver)
-        .isNotEqualTo(Solvers.CVC5);
 
     ConcurrentLinkedQueue<SolverContext> contextList = new ConcurrentLinkedQueue<>();
     // Initialize contexts before using them in the threads
@@ -545,7 +540,7 @@ public class SolverConcurrencyTest {
     assume()
         .withMessage("Solver does not support translation of formulas")
         .that(solver)
-        .isNoneOf(Solvers.CVC4, Solvers.CVC5, Solvers.PRINCESS);
+        .isNoneOf(Solvers.CVC4, Solvers.PRINCESS);
 
     // This is fine! We might access this more than once at a time,
     // but that gives only access to the bucket, which is threadsafe.

--- a/src/org/sosy_lab/java_smt/test/TimeoutTest.java
+++ b/src/org/sosy_lab/java_smt/test/TimeoutTest.java
@@ -8,13 +8,14 @@
 
 package org.sosy_lab.java_smt.test;
 
+import static com.google.common.truth.TruthJUnit.assume;
 import static org.junit.Assert.assertThrows;
 
-import com.google.common.truth.TruthJUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -62,13 +63,20 @@ public class TimeoutTest extends SolverBasedTest0 {
     return Logics.QF_LIA;
   }
 
+  @Before
+  public void setUp() {
+    // FIXME CVC5 has interruptions, but crashes on Windows, probably due to concurrency issues
+    // TODO Add interruption for Princess
+    assume()
+        .withMessage(solverToUse() + " does not support interruption")
+        .that(solverToUse())
+        .isNoneOf(Solvers.PRINCESS, Solvers.CVC5);
+  }
+
   @Test
   @SuppressWarnings("CheckReturnValue")
   public void testTacticTimeout() {
-    TruthJUnit.assume()
-        .withMessage("Only Z3 has native tactics")
-        .that(solverToUse())
-        .isEqualTo(Solvers.Z3);
+    assume().withMessage("Only Z3 has native tactics").that(solverToUse()).isEqualTo(Solvers.Z3);
     Fuzzer fuzzer = new Fuzzer(mgr, new Random(0));
     String msg = "ShutdownRequest";
     BooleanFormula test = fuzzer.fuzz(20, 3);
@@ -79,21 +87,12 @@ public class TimeoutTest extends SolverBasedTest0 {
   @Test(timeout = TIMEOUT_MILLISECONDS)
   public void testProverTimeoutInt() throws InterruptedException {
     requireIntegers();
-    TruthJUnit.assume()
-        .withMessage(solverToUse() + " does not support interruption")
-        .that(solverToUse())
-        .isNoneOf(Solvers.PRINCESS, Solvers.BOOLECTOR, Solvers.CVC5);
     testBasicProverTimeoutInt(() -> context.newProverEnvironment());
   }
 
   @Test(timeout = TIMEOUT_MILLISECONDS)
   public void testProverTimeoutBv() throws InterruptedException {
     requireBitvectors();
-    TruthJUnit.assume()
-        .withMessage(solverToUse() + " does not support interruption")
-        .that(solverToUse())
-        .isNoneOf(Solvers.PRINCESS, Solvers.CVC5);
-
     testBasicProverTimeoutBv(() -> context.newProverEnvironment());
   }
 
@@ -101,10 +100,6 @@ public class TimeoutTest extends SolverBasedTest0 {
   public void testInterpolationProverTimeout() throws InterruptedException {
     requireInterpolation();
     requireIntegers();
-    TruthJUnit.assume()
-        .withMessage(solverToUse() + " does not support interruption")
-        .that(solverToUse())
-        .isNoneOf(Solvers.PRINCESS, Solvers.BOOLECTOR, Solvers.CVC5);
     testBasicProverTimeoutInt(() -> context.newProverEnvironmentWithInterpolation());
   }
 


### PR DESCRIPTION
Hello,
the flaky tests seem to have gotten worse after the recent update to CVC5. I would suggest disabling `TimoutTest` and `SolverConcurrencyTest` entirely for CVC5 to temporarily fix the issue. The concurrency issues with CVC5 are well known and have already been reported [here](https://github.com/cvc5/cvc5/issues/10256) and [here](https://github.com/cvc5/cvc5/discussions/10265). They seem to be working on a solution, but it will take more time. In the meantime we should have a test-suite that is always green, and once the concurrency problems in CVC5 are resolved the test can easily be turned on again.