### PR TITLE
CVC5: Add parser support

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
@@ -93,10 +93,9 @@ class CVC5FormulaManager extends AbstractFormulaManager<Term, Sort, TermManager,
     for (String token : tokens) {
       if (Tokenizer.isDeclarationToken(token)) {
         // Parse the variable/UF declaration to get a name
-        TermManager tm = new TermManager();
-        Solver solver = new Solver(tm);
+        Solver solver = new Solver(getEnvironment());
         InputParser parser = new InputParser(solver);
-        SymbolManager symbolManager = new SymbolManager(tm);
+        SymbolManager symbolManager = new SymbolManager(getEnvironment());
         parser.setStringInput(InputLanguage.SMT_LIB_2_6, "(set-logic ALL)" + token, "");
         parser.nextCommand().invoke(solver, symbolManager);
         parser.nextCommand().invoke(solver, symbolManager);
@@ -157,8 +156,7 @@ class CVC5FormulaManager extends AbstractFormulaManager<Term, Sort, TermManager,
     String input = String.join("\n", processed.build());
 
     // Add the declarations to the input and parse everything
-    TermManager termManager = new TermManager();
-    Solver solver = new Solver(termManager);
+    Solver solver = new Solver(getEnvironment());
     InputParser parser = new InputParser(solver);
     SymbolManager symbolManager = parser.getSymbolManager();
     parser.setStringInput(InputLanguage.SMT_LIB_2_6, "(set-logic ALL)" + decls + input, "");
@@ -180,7 +178,7 @@ class CVC5FormulaManager extends AbstractFormulaManager<Term, Sort, TermManager,
 
     // Get the assertions from the input
     Term[] asserted = solver.getAssertions();
-    Term result = asserted.length == 1 ? asserted[0] : termManager.mkTerm(Kind.AND, asserted);
+    Term result = asserted.length == 1 ? asserted[0] : getEnvironment().mkTerm(Kind.AND, asserted);
 
     // Now get all declared symbols
     Term[] declared = symbolManager.getDeclaredTerms();

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
@@ -25,14 +25,10 @@ import io.github.cvc5.SymbolManager;
 import io.github.cvc5.Term;
 import io.github.cvc5.TermManager;
 import io.github.cvc5.modes.InputLanguage;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.basicimpl.AbstractFormulaManager;
@@ -193,21 +189,6 @@ class CVC5FormulaManager extends AbstractFormulaManager<Term, Sort, TermManager,
 
     // Now get all declared symbols
     Term[] declared = symbolManager.getDeclaredTerms();
-
-    // Check that all variables/UF have a single type signature
-    // The CVC5 parser allows polymorphic types, but we don't support them in JavaSMT
-    Set<String> duplicates =
-        Arrays.stream(declared)
-            .collect(Collectors.groupingBy(Term::getSymbol, Collectors.counting()))
-            .entrySet()
-            .stream()
-            .filter(m -> m.getValue() > 1)
-            .map(Entry::getKey)
-            .collect(Collectors.toSet());
-    Preconditions.checkArgument(
-        duplicates.isEmpty(),
-        "Parsing failed as there were multiple conflicting definitions for the symbol(s) '%s'",
-        duplicates);
 
     // Process the symbols from the parser
     Map<Term, Term> subst = new HashMap<>();

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
@@ -111,18 +111,25 @@ class CVC5FormulaManager extends AbstractFormulaManager<Term, Sort, TermManager,
 
         // Check if the symbol is already defined in the variable cache
         if (cache.containsRow(symbol)) {
+          Sort typeDefinition = cache.row(symbol).keySet().toArray(new Sort[0])[0];
           Preconditions.checkArgument(
               cache.contains(symbol, sort),
-              "Symbol %s is already used by the solver with a different typ",
-              symbol);
+              "Symbol '%s' is already used by the solver with a different type. The new type is "
+                  + "%s, but we already have a definition with type %s.",
+              symbol,
+              sort,
+              typeDefinition);
           continue; // Skip if it's a redefinition
         }
 
         // Check if it collides with a definition that was parsed earlier
         Preconditions.checkArgument(
             !localSymbols.containsKey(symbol) || localSymbols.get(symbol).equals(sort),
-            "Symbol %s has already been defined by this script with a different type",
-            sort);
+            "Symbol '%s' has already been defined by this script with a different type. The new "
+                + "type is %s, but we have already a definition with type %s.",
+            symbol,
+            sort,
+            localSymbols.get(symbol));
 
         // Add the symbol to the local definitions for this parse
         localSymbols.put(symbol, sort);

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaManager.java
@@ -103,6 +103,10 @@ class CVC5FormulaManager extends AbstractFormulaManager<Term, Sort, TermManager,
         Term parsed = symbolManager.getDeclaredTerms()[0];
 
         String symbol = parsed.getSymbol();
+        if (symbol.startsWith("|") && symbol.endsWith("|")) {
+          // Strip quotes from the name
+          symbol = symbol.substring(1, symbol.length() - 1);
+        }
         Sort sort = parsed.getSort();
 
         // Check if the symbol is already defined in the variable cache
@@ -201,12 +205,17 @@ class CVC5FormulaManager extends AbstractFormulaManager<Term, Sort, TermManager,
     // Process the symbols from the parser
     Map<Term, Term> subst = new HashMap<>();
     for (Term term : declared) {
-      if (cache.containsRow(term.getSymbol())) {
+      String symbol = term.getSymbol();
+      if (symbol.startsWith("|") && symbol.endsWith("|")) {
+        // Strip quotes from the name
+        symbol = symbol.substring(1, symbol.length() - 1);
+      }
+      if (cache.containsRow(symbol)) {
         // Symbol is from the context: add the original term to the substitution map
-        subst.put(term, cache.get(term.getSymbol(), term.getSort()));
+        subst.put(term, cache.get(symbol, term.getSort()));
       } else {
         // Symbol is new, add it to the context
-        cache.put(term.getSymbol(), term.getSort(), term);
+        cache.put(symbol, term.getSort(), term);
       }
     }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Model.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Model.java
@@ -9,6 +9,7 @@
 package org.sosy_lab.java_smt.solvers.cvc5;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.github.cvc5.CVC5ApiException;
@@ -81,7 +82,7 @@ public class CVC5Model extends AbstractModel<Term, Sort, TermManager> {
         // Vars and UFs, as well as bound vars in UFs!
         // In CVC5 consts are variables! Free variables (in CVC5s notation, we call them bound
         // variables, created with mkVar() can never have a value!)
-        builder.add(getAssignment(expr));
+        builder.addAll(getAssignment(expr));
       } else if (kind == Kind.FORALL || kind == Kind.EXISTS) {
         // Body of the quantifier, with bound vars!
         Term body = expr.getChild(1);
@@ -169,7 +170,96 @@ public class CVC5Model extends AbstractModel<Term, Sort, TermManager> {
         keyFormula, valueFormula, equation, nameStr, value, argumentInterpretationBuilder.build());
   }
 
-  private ValueAssignment getAssignment(Term pKeyTerm) {
+  /** Takes a (nested) select statement and returns its indices. */
+  private Iterable<Term> getArgs(Term array) throws CVC5ApiException {
+    if (array.getKind().equals(Kind.SELECT)) {
+      return FluentIterable.concat(getArgs(array.getChild(0)), ImmutableList.of(array.getChild(1)));
+    } else {
+      return ImmutableList.of();
+    }
+  }
+
+  /** Takes a select statement with multiple indices and returns the variable name at the bottom. */
+  private String getVar(Term array) throws CVC5ApiException {
+    if (array.getKind().equals(Kind.SELECT)) {
+      return getVar(array.getChild(0));
+    } else {
+      return array.getSymbol();
+    }
+  }
+
+  /** Build assignment for an array value. */
+  private Iterable<ValueAssignment> buildArrayAssignment(Term expr, Term value) {
+    // CVC5 returns values such as "(Store (Store ... i1,1 e1,1) i1,0 e1,0)" where the i1,x match
+    // the first index of the array and the elements e1,Y can again be arrays (if there is more
+    // than one index). We need "pattern match" this values to extract assignments from it.
+    // Initially we have:
+    //  arr = (Store (Store ... i1,1 e1,1) i1,0 e1,0)
+    // where 'arr' is the name of the variable. By applying (Select i1,0 ...) to both side we get:
+    // (Select i1,0 arr) = (Select i1,0 (Store (Store ... i1,1 e1,1) i1,0 e1,0))
+    // The right side simplifies to e1,0 as the index matches. We need to continue with this for
+    // all other matches to the first index, that is
+    //  (Select i1,1 arr) = (Select i1,0 (Store (Store ... i1,1 e1,1) i1,0 e1,0))
+    //                    = (Select i1,0 (Store ... i1,1 e1,1))
+    //                    = e1,1
+    // until all matches are explored and the bottom of the Store chain is reached. If the array
+    // has more than one dimension we also have to descend into the elements to apply the next
+    // index there. For instance, let's consider a 2-dimensional array with type (Array Int ->
+    // (Array Int -> Int)). After matching the first index just as in the above example we might
+    // have:
+    //  (Select i1,0 arr) = (Select i1,0 (Store (Store ... i1,1 e1,1) i1,0 e1,0)) = e1,0
+    // In this case e1,0 is again a Store chain, let's say e1,0 := (Store (Store ... i2,1 e2,1)
+    // i2,0 e2,0), and we now continue with the second index:
+    //  (Select i2,1 (Select i1,0 arr)) = (Select i2,1 (Store (Store ... i2,1 e2,1) i2,0 e2,0)) =
+    //                                  = e2,1
+    // This again has to be done for all possible matches.
+    // Once we've reached the last index, the successor element will be a non-array value. We
+    // then create the final assignments and return:
+    //  (Select iK,mK ... (Select i2,1 (Select i1,0 arr)) = eik,mK
+    try {
+      if (value.getKind().equals(Kind.STORE)) {
+        // This is a Store node for the current index. We need to follow the chain downwards to
+        // match this index, while also exploring the successor for the other indices
+        Term index = value.getChild(1);
+        Term element = value.getChild(2);
+
+        Term select = creator.getEnv().mkTerm(Kind.SELECT, expr, index);
+
+        Iterable<ValueAssignment> current;
+        if (expr.getSort().getArrayElementSort().isArray()) {
+          current = buildArrayAssignment(select, element);
+        } else {
+          Term equation = creator.getEnv().mkTerm(Kind.EQUAL, select, element);
+          current =
+              FluentIterable.of(
+                  new ValueAssignment(
+                      creator.encapsulate(creator.getFormulaType(element), select),
+                      creator.encapsulate(creator.getFormulaType(element), element),
+                      creator.encapsulateBoolean(equation),
+                      getVar(expr),
+                      creator.convertValue(element, element),
+                      FluentIterable.from(getArgs(select))
+                          .transform(creator::convertValue)
+                          .toList()));
+        }
+        return FluentIterable.concat(current, buildArrayAssignment(expr, value.getChild(0)));
+
+      } else if (value.getKind().equals(Kind.CONST_ARRAY)) {
+        // We've reached the end of the Store chain
+        return ImmutableList.of();
+
+      } else {
+        // Should be unreachable
+        // We assume that array values are made up of "const" and "store" nodes with non-array
+        // constants as leaves
+        throw new IllegalArgumentException();
+      }
+    } catch (CVC5ApiException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Iterable<ValueAssignment> getAssignment(Term pKeyTerm) {
     ImmutableList.Builder<Object> argumentInterpretationBuilder = ImmutableList.builder();
     for (int i = 0; i < pKeyTerm.getNumChildren(); i++) {
       try {
@@ -193,13 +283,23 @@ public class CVC5Model extends AbstractModel<Term, Sort, TermManager> {
     }
 
     Term valueTerm = solver.getValue(pKeyTerm);
-    Formula keyFormula = creator.encapsulateWithTypeOf(pKeyTerm);
-    Formula valueFormula = creator.encapsulateWithTypeOf(valueTerm);
-    BooleanFormula equation =
-        creator.encapsulateBoolean(termManager.mkTerm(Kind.EQUAL, pKeyTerm, valueTerm));
-    Object value = creator.convertValue(pKeyTerm, valueTerm);
-    return new ValueAssignment(
-        keyFormula, valueFormula, equation, nameStr, value, argumentInterpretationBuilder.build());
+    if (valueTerm.getSort().isArray()) {
+      return buildArrayAssignment(pKeyTerm, valueTerm);
+    } else {
+      Formula keyFormula = creator.encapsulateWithTypeOf(pKeyTerm);
+      Formula valueFormula = creator.encapsulateWithTypeOf(valueTerm);
+      BooleanFormula equation =
+          creator.encapsulateBoolean(termManager.mkTerm(Kind.EQUAL, pKeyTerm, valueTerm));
+      Object value = creator.convertValue(pKeyTerm, valueTerm);
+      return ImmutableList.of(
+          new ValueAssignment(
+              keyFormula,
+              valueFormula,
+              equation,
+              nameStr,
+              value,
+              argumentInterpretationBuilder.build()));
+    }
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/test/ModelTest.java
+++ b/src/org/sosy_lab/java_smt/test/ModelTest.java
@@ -2240,7 +2240,7 @@ public class ModelTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
     assume()
         .withMessage("Solver is quite slow for this example")
         .that(solverToUse())
-        .isNotEqualTo(Solvers.PRINCESS);
+        .isNoneOf(Solvers.PRINCESS, Solvers.CVC5);
 
     BooleanFormula formula =
         context

--- a/src/org/sosy_lab/java_smt/test/ModelTest.java
+++ b/src/org/sosy_lab/java_smt/test/ModelTest.java
@@ -1724,7 +1724,6 @@ public class ModelTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
     // supported yet
     // TODO: only filter out UF formulas here, not all
     if (solver != Solvers.BOOLECTOR) {
-      // CVC5 crashes here
       assertThatFormula(bmgr.and(pModelAssignments)).implies(constraint);
     }
   }

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -324,7 +324,7 @@ public abstract class SolverBasedTest0 {
     assume()
         .withMessage("Solver %s does not support parsing formulae", solverToUse())
         .that(solverToUse())
-        .isNoneOf(Solvers.CVC4, Solvers.BOOLECTOR, Solvers.YICES2, Solvers.CVC5);
+        .isNoneOf(Solvers.CVC4, Solvers.BOOLECTOR, Solvers.YICES2);
   }
 
   protected void requireArrayModel() {

--- a/src/org/sosy_lab/java_smt/test/SolverFormulaIODeclarationsTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverFormulaIODeclarationsTest.java
@@ -194,13 +194,6 @@ public class SolverFormulaIODeclarationsTest
   @Test
   public void parseDeclareConflictInQueryTest3() {
     requireIntegers();
-    // CVC5 allows multiple definitions of the same symbol with different types. This is causing
-    // some issues with JavaSMT where UF functions must have a single type.
-    // In the test above we were able to work around the issue by checking if the list of
-    // declared symbols that is returned by the parser contains any duplicates. However, this
-    // does not seem to work here as the two definitions only differ in their return type and
-    // CVC5 reports only one if the declaration.
-    // TODO Report this to the developers
     String query = "(declare-fun x (Int) Bool)(declare-fun x (Int) Int)(assert (x 0))";
     if (Solvers.Z3 != solverToUse()) {
       assertThrows(IllegalArgumentException.class, () -> mgr.parse(query));

--- a/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
@@ -277,12 +277,16 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
 
   @Test
   public void parseMathSatTestParseFirst1() throws SolverException, InterruptedException {
+    // MathSat prints reserved symbols starting with . or @ that CVC5 can't parse
+    assume().that(solver).isNotEqualTo(Solvers.CVC5);
     requireParser();
     compareParseWithOrgParseFirst(MATHSAT_DUMP1, this::genBoolExpr);
   }
 
   @Test
   public void parseMathSatTestExprFirst1() throws SolverException, InterruptedException {
+    // MathSat prints reserved symbols starting with . or @ that CVC5 can't parse
+    assume().that(solver).isNotEqualTo(Solvers.CVC5);
     requireParser();
     compareParseWithOrgExprFirst(MATHSAT_DUMP1, this::genBoolExpr);
   }
@@ -313,6 +317,8 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
 
   @Test
   public void parseMathSatTestParseFirst2() throws SolverException, InterruptedException {
+    // MathSat prints reserved symbols starting with . or @ that CVC5 can't parse
+    assume().that(solver).isNotEqualTo(Solvers.CVC5);
     requireParser();
     requireIntegers();
     compareParseWithOrgParseFirst(MATHSAT_DUMP2, this::redundancyExprGen);
@@ -320,6 +326,8 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
 
   @Test
   public void parseMathSatTestExprFirst2() throws SolverException, InterruptedException {
+    // MathSat prints reserved symbols starting with . or @ that CVC5 can't parse
+    assume().that(solver).isNotEqualTo(Solvers.CVC5);
     requireParser();
     compareParseWithOrgExprFirst(MATHSAT_DUMP2, this::redundancyExprGen);
   }
@@ -352,6 +360,8 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
 
   @Test
   public void parseMathSatTestExprFirst3() throws SolverException, InterruptedException {
+    // MathSat prints reserved symbols starting with . or @ that CVC5 can't parse
+    assume().that(solver).isNotEqualTo(Solvers.CVC5);
     requireParser();
     requireIntegers();
     compareParseWithOrgExprFirst(MATHSAT_DUMP3, this::functionExprGen);


### PR DESCRIPTION
Hello,
this PR will add  support for parsing to CVC5. The approach taken is very similar to what we're doing in the Bitwuzla code as we again have to carefully synchronize symbol definitions from the parser with those from our variable/uf cache. Note that we also included some changes to the way that CVC5 array values from the model are translate into `ValueAssignments` for JavaSMT. This was needed to fix tests that became possible with the new parser support.