### PR TITLE
CVC5: Use official binaries

### DIFF
--- a/build/build-maven-publish.xml
+++ b/build/build-maven-publish.xml
@@ -238,6 +238,8 @@ SPDX-License-Identifier: Apache-2.0
         <stage-solver-file filename="libcvc5jni" classifier="libcvc5jni-x64" filedirectory="${libDir.x64}" fileending="so"/>
         <stage-solver-file filename="libcvc5jni" classifier="libcvc5jni-arm64" filedirectory="${libDir.arm64}" fileending="so"/>
         <stage-solver-file filename="libcvc5jni" classifier="libcvc5jni-x64" filedirectory="${libDir.x64}" fileending="dll"/>
+        <stage-solver-file filename="libcvc5jni" classifier="libcvc5jni-x64" filedirectory="${libDir.x64}" fileending="dylib"/>
+        <stage-solver-file filename="libcvc5jni" classifier="libcvc5jni-arm64" filedirectory="${libDir.arm64}" fileending="dylib"/>
     </target>
 
     <!--

--- a/build/build-publish-solvers/solver-cvc5.xml
+++ b/build/build-publish-solvers/solver-cvc5.xml
@@ -14,122 +14,49 @@ SPDX-License-Identifier: Apache-2.0
 <project name="publish-solvers-cvc5" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
     <import file="macros.xml"/>
 
+    <property name="cvc5.url" value="https://github.com/cvc5/cvc5/releases/download/latest"/>
+    <property name="cvc5.downloads" value="/dependencies/cvc5"/>
     <property name="cvc5.distDir" value="${ivy.solver.dist.dir}/cvc5"/>
 
-    <!-- Build options for CVC5, Reasoning:
-          - 'production' enable optimization, disables assertions and tracing,
-          - 'static' build libcvc5 and all dependencies statically,
-          - 'java-bindings' build the JNI bindings,
-          - 'auto-download' load all dependencies automatically,
-          - 'prefix' because I don't want it to use system installed or install system-wide,
-          Theoretically CVC5s performance should be improvable by using -best (uses the best
-          known general performance/dependencies) but this can not be combined with auto-download.
-    -->
-    <target name="set-properties-for-cvc5">
-        <checkPathOption pathOption="cvc5.path" defaultPath="/path/to/cvc5" targetName="CVC5 directory (Git checkout from https://github.com/cvc5/cvc5)"/>
-        <fail unless="cvc5.customRev">
-            Please specify a custom revision with the flag -Dcvc5.customRev=XXX.
-            The custom revision has to be unique amongst the already known version
-            numbers from the ivy repository. The script will append the git revision.
+    <target name="download-cvc5">
+        <fail unless="cvc5.version">
+            Please specify a version with the flag -Dcvc5.version=XXX.
+            The version must match one of the daily builds from https://github.com/cvc5/cvc5/releases
         </fail>
-        <checkPathOption pathOption="jdk-linux-arm64.path" defaultPath="/path/to/jdk" targetName="JDK source folder (Linux arm64 version)"/>
-        <checkPathOption pathOption="jdk-windows-x64.path" defaultPath="/path/to/jdk" targetName="JDK source folder (Windows x64 version)"/>
 
-        <!-- get the short commit hash of the cvc5 version used -->
-        <exec executable="git" dir="${cvc5.path}" outputproperty="cvc5.revision" failonerror="true">
-            <arg value="show"/>
-            <arg value="-s"/>
-            <arg value="--format=%h"/>
-        </exec>
-        <property name="cvc5.version" value="${cvc5.customRev}-g${cvc5.revision}"/>
-        <echo message="Building CVC5 in version '${cvc5.version}'"/>
+        <mkdir dir="${cvc5.downloads}"/>
+        <mkdir dir="${cvc5.distDir}"/>
 
-        <!-- set a path to the build folder, which is cleaned before building any binary files -->
-        <property name="cvc5.buildDir" location="${cvc5.path}/build"/>
+        <!-- Download binaries for linux on x64 -->
+        <get src="${cvc5.url}/cvc5-Linux-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}" verbose="true"/>
+        <unzip src="${cvc5.downloads}/cvc5-Linux-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}"/>
+        <copy file="${cvc5.downloads}/cvc5-Linux-x86_64-static/lib/libcvc5jni.so" tofile="${cvc5.distDir}/x64/libcvc5jni-${cvc5.version}.so"/>
 
-        <property name="cvc5.installDir.x64-linux" location="${cvc5.path}/install/x64-linux"/>
-        <property name="cvc5.installDir.arm64-linux" location="${cvc5.path}/install/arm64-linux"/>
-        <property name="cvc5.installDir.x64-windows" location="${cvc5.path}/install/x64-windows"/>
+        <!-- Download binaries for linux on arm64 -->
+        <get src="${cvc5.url}/cvc5-Linux-arm64-static-${cvc5.version}.zip" dest="${cvc5.downloads}" verbose="true"/>
+        <unzip src="${cvc5.downloads}/cvc5-Linux-arm64-static-${cvc5.version}.zip" dest="${cvc5.downloads}"/>
+        <copy file="${cvc5.downloads}/cvc5-Linux-arm64-static/lib/libcvc5jni.so" tofile="${cvc5.distDir}/arm64/libcvc5jni-${cvc5.version}.so"/>
+
+        <!-- Download binaries for macOS on x64 -->
+        <get src="${cvc5.url}/cvc5-macOS-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}" verbose="true"/>
+        <unzip src="${cvc5.downloads}/cvc5-macOS-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}"/>
+        <copy file="${cvc5.downloads}/cvc5-macOS-x86_64-static/lib/libcvc5jni.dylib" tofile="${cvc5.distDir}/x64/libcvc5jni-${cvc5.version}.dylib"/>
+
+        <!-- Download binaries for macOS on arm64 -->
+        <get src="${cvc5.url}/cvc5-macOS-arm64-static-${cvc5.version}.zip" dest="${cvc5.downloads}" verbose="true"/>
+        <unzip src="${cvc5.downloads}/cvc5-macOS-arm64-static-${cvc5.version}.zip" dest="${cvc5.downloads}"/>
+        <copy file="${cvc5.downloads}/cvc5-macOS-arm64-static/lib/libcvc5jni.dylib" tofile="${cvc5.distDir}/arm64/libcvc5jni-${cvc5.version}.dylib"/>
+
+        <!-- Download binaries for Windows on x64 -->
+        <get src="${cvc5.url}/cvc5-Win64-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}" verbose="true"/>
+        <unzip src="${cvc5.downloads}/cvc5-Win64-x86_64-static-${cvc5.version}.zip" dest="${cvc5.downloads}"/>
+        <copy file="${cvc5.downloads}/cvc5-Win64-x86_64-static/bin/cvc5jni.dll" tofile="${cvc5.distDir}/x64/libcvc5jni-${cvc5.version}.dll"/>
+
+        <!-- Download the Java bindings -->
+        <get src="${cvc5.url}/cvc5-Linux-arm64-java-api-${cvc5.version}.jar" dest="${cvc5.distDir}/cvc5-${cvc5.version}.jar" verbose="true"/>
     </target>
 
-    <target name="compile-cvc5-linux-x64" depends="set-properties-for-cvc5">
-        <echo message="Building CVC5 for x64 linux"/>
-        <delete dir="${cvc5.buildDir}" quiet="true"/>
-        <exec executable="./configure.sh" dir="${cvc5.path}" failonerror="true">
-            <arg value="production"/>
-            <arg value="--static"/>
-            <arg value="--java-bindings"/>
-            <arg value="--auto-download"/>
-            <arg value="--prefix=${cvc5.installDir.x64-linux}"/>
-        </exec>
-        <exec executable="make" dir="${cvc5.buildDir}" failonerror="true">
-            <arg value="-j4"/>
-            <arg value="install"/>
-        </exec>
-        <exec executable="strip" dir="${cvc5.installDir.x64-linux}/lib" failonerror="true">
-            <arg value="libcvc5jni.so"/>
-        </exec>
-    </target>
-
-    <target name="compile-cvc5-linux-arm64" depends="set-properties-for-cvc5">
-        <echo message="Building CVC5 for arm64 linux"/>
-        <delete dir="${cvc5.buildDir}" quiet="true"/>
-        <exec executable="./configure.sh" dir="${cvc5.path}" failonerror="true">
-            <env key="JNI_HOME" value="${jdk-linux-arm64.path}"/>
-            <arg value="production"/>
-            <arg value="--arm64"/>
-            <arg value="--static"/>
-            <arg value="--java-bindings"/>
-            <arg value="--auto-download"/>
-            <arg value="--prefix=${cvc5.installDir.arm64-linux}"/>
-        </exec>
-        <exec executable="make" dir="${cvc5.buildDir}" failonerror="true">
-            <arg value="-j4"/>
-            <arg value="install"/>
-        </exec>
-        <exec executable="aarch64-linux-gnu-strip" dir="${cvc5.installDir.arm64-linux}/lib" failonerror="true">
-            <arg value="libcvc5jni.so"/>
-        </exec>
-    </target>
-
-    <target name="compile-cvc5-windows-x64" depends="set-properties-for-cvc5">
-        <echo message="Building CVC5 for x64 windows"/>
-        <delete dir="${cvc5.buildDir}" quiet="true"/>
-        <exec executable="./configure.sh" dir="${cvc5.path}" failonerror="true">
-            <env key="JNI_HOME" value="${jdk-windows-x64.path}"/>
-            <arg value="production"/>
-            <arg value="--win64"/>
-            <arg value="--static"/>
-            <arg value="--java-bindings"/>
-            <arg value="--auto-download"/>
-            <arg value="--prefix=${cvc5.installDir.x64-windows}"/>
-        </exec>
-        <exec executable="make" dir="${cvc5.buildDir}" failonerror="true">
-            <arg value="-j4"/>
-            <arg value="install"/>
-        </exec>
-        <exec executable="x86_64-w64-mingw32-strip" dir="${cvc5.installDir.x64-windows}/bin" failonerror="true">
-            <arg value="cvc5jni.dll"/>
-        </exec>
-    </target>
-
-    <target name="package-cvc5" depends="compile-cvc5-linux-x64, compile-cvc5-linux-arm64, compile-cvc5-windows-x64">
-        <!-- get the actual jar location as cvc5.jar is just a link -->
-        <exec executable="readlink" dir="${cvc5.installDir.x64-linux}/share/java" outputproperty="cvc5.jar" failonerror="true">
-            <arg value="-f"/>
-            <arg value="cvc5.jar"/>
-        </exec>
-
-        <!-- copy library files into directory to be published for IVY -->
-        <echo message="Copying artifact for Ivy release"/>
-        <copy file="${cvc5.jar}" tofile="${cvc5.distDir}/cvc5-${cvc5.version}.jar"/>
-        <copy file="${cvc5.installDir.x64-linux}/lib/libcvc5jni.so" tofile="${cvc5.distDir}/x64/libcvc5jni-${cvc5.version}.so"/>
-        <copy file="${cvc5.installDir.arm64-linux}/lib/libcvc5jni.so" tofile="${cvc5.distDir}/arm64/libcvc5jni-${cvc5.version}.so"/>
-        <copy file="${cvc5.installDir.x64-windows}/bin/cvc5jni.dll" tofile="${cvc5.distDir}/x64/libcvc5jni-${cvc5.version}.dll"/>
-    </target>
-
-    <target name="publish-cvc5" depends="package-cvc5, load-ivy"
-            description="Publish CVC5 binaries to Ivy repository.">
+    <target name="publish-cvc5" depends="download-cvc5, load-ivy" description="Publish CVC5 binaries to Ivy repository.">
         <ivy:resolve conf="solver-cvc5" file="solvers_ivy_conf/ivy_cvc5.xml"/>
         <publishToRepository solverName="CVC5" solverVersion="${cvc5.version}" distDir="${cvc5.distDir}"/>
 

--- a/doc/Developers-How-to-Release-into-Ivy.md
+++ b/doc/Developers-How-to-Release-into-Ivy.md
@@ -116,36 +116,24 @@ Finally follow the instructions shown in the message at the end.
 
 ### Publishing CVC5
 
-We prefer to compile our own CVC5 binaries and Java bindings.
-For simple usage, we provide a Docker definition/environment under `/docker`,
-in which the following command can be run.
-
-To publish CVC5, checkout the [CVC5 repository](https://github.com/cvc5/cvc5) and download the
-JDK for windows and arm64 from Oracle. We will build bindings for several platforms and
-the JDKs are needed to cross-compile. To start building, execute the following command
-in the JavaSMT directory, where `$CVC5_DIR` is the path to the CVC5 directory and
-`$CVC5_VERSION` is the version number:
+We prefer to use the official CVC5 binaries, please build from source only if necessary (e.g., in
+case of an important bugfix). The binaries can be fetched and repackaged fully automatically:
 
 ```
-ant publish-cvc5 \
-    -Dcvc5.path=$CVC5_DIR\
-    -Dcvc5.customRev=$CVC5_VERSION \
-    -Djdk-windows.path=$JDK_DIR_WINDOWS \
-    -Djdk-linux-arm64.path=$JDK_DIR_LINUX_ARM64
+ant publish-cvc5 -Dcvc5.version=$CVC5_VERSION
 ```
+
+Where `CVC5_VERSION` must match one of the daily releases from
+their [github](https://github.com/cvc5/cvc5/releases/tag/latest) website
 
 Example:
 
 ```
-ant publish-cvc5 \
-    -Dcvc5.path=../CVC5 \
-    -Dcvc5.customRev=1.2.1 \
-    -Djdk-windows-x64.path=/workspace/solvers/jdk/openjdk-17.0.2_windows-x64_bin/jdk-17.0.2/ \
-    -Djdk-linux-arm64.path=/workspace/solvers/jdk/openjdk-17.0.2_linux-aarch64_bin/jdk-17.0.2/
+ant publish-cvc5 -Dcvc5.version=2025-03-31-34518c3
 ```
 
-During the build process, our script automatically appends the git-revision after the version.
-Finally, follow the instructions shown in the message at the end.
+During the build process, our script automatically fetches binaries for windows, linux and
+maxOS on x64 and arm64 and repackages them to be used in JavaSMT.
 
 
 ### Publishing OpenSMT

--- a/docker/ubuntu1804.Dockerfile
+++ b/docker/ubuntu1804.Dockerfile
@@ -33,18 +33,6 @@ RUN apt-get update \
         autoconf gperf \
  && apt-get clean
 
-# CVC5 requires some dependencies
-RUN apt-get update \
- && apt-get install -y \
-        python3 python3-venv python3-toml python3-pyparsing flex libssl-dev cmake \
- && apt-get clean \
- && wget https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3.tar.gz \
- && tar -zxvf cmake-3.26.3.tar.gz \
- && cd cmake-3.26.3 \
- && ./bootstrap \
- && make \
- && make install
-
 # Bitwuzla requires Ninja and Meson (updated version from pip), and uses SWIG >4.0 from dependencies.
 # GMP >6.3.0 is automatically downloaded and build within Bitwuzla.
 RUN apt-get update \
@@ -60,7 +48,7 @@ RUN pip3 install --upgrade meson
 # - lzip is required to unpack the gmp tar ball
 RUN apt-get update \
  && apt-get install -y \
-        flex bison libpcre2-dev lzip \
+        cmake flex bison libpcre2-dev lzip \
  && apt-get clean
 
 WORKDIR /dependencies

--- a/docker/ubuntu2204.Dockerfile
+++ b/docker/ubuntu2204.Dockerfile
@@ -34,12 +34,6 @@ RUN  apt-get update \
         autoconf gperf \
  && apt-get clean
 
-# CVC5 requires some dependencies
-RUN apt-get update \
- && apt-get install -y \
-        python3 python3-venv python3-toml python3-pyparsing flex libssl-dev cmake \
- && apt-get clean
-
 # Bitwuzla requires Ninja and Meson (updated version from pip), and uses SWIG >4.0 from dependencies.
 # GMP >6.3.0 is automatically downloaded and build within Bitwuzla.
 RUN apt-get update \
@@ -55,7 +49,7 @@ RUN pip3 install --upgrade meson
 # - lzip is required to unpack the gmp tar ball
 RUN apt-get update \
  && apt-get install -y \
-        flex bison libpcre2-dev lzip \
+        cmake flex bison libpcre2-dev lzip \
  && apt-get clean
 
 WORKDIR /dependencies

--- a/lib/ivy.xml
+++ b/lib/ivy.xml
@@ -193,7 +193,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency org="org.sosy_lab" name="javasmt-solver-opensmt" rev="2.8.0-sosy0-ge831bf23" conf="runtime-opensmt-x64->solver-opensmt-x64; runtime-opensmt-arm64->solver-opensmt-arm64; contrib->sources,javadoc"/>
         <dependency org="org.sosy_lab" name="javasmt-solver-optimathsat" rev="1.7.3-sosy1" conf="runtime-optimathsat->solver-optimathsat" />
         <dependency org="org.sosy_lab" name="javasmt-solver-cvc4" rev="1.8-prerelease-2020-06-24-g7825d8f28" conf="runtime-cvc4->solver-cvc4" />
-        <dependency org="org.sosy_lab" name="javasmt-solver-cvc5" rev="1.2.1-g8594a8e4dc" conf="runtime-cvc5-x64->solver-cvc5-x64; runtime-cvc5-arm64->solver-cvc5-arm64"/>
+        <dependency org="org.sosy_lab" name="javasmt-solver-cvc5" rev="2025-03-31-34518c3" conf="runtime-cvc5-x64->solver-cvc5-x64; runtime-cvc5-arm64->solver-cvc5-arm64"/>
         <dependency org="org.sosy_lab" name="javasmt-solver-boolector" rev="3.2.2-g1a89c229" conf="runtime-boolector->solver-boolector" />
         <dependency org="org.sosy_lab" name="javasmt-solver-bitwuzla" rev="0.7.0-13.1-g595512ae" conf="runtime-bitwuzla-x64->solver-bitwuzla-x64; runtime-bitwuzla-arm64->solver-bitwuzla-arm64; contrib->sources,javadoc"/>
 

--- a/solvers_ivy_conf/ivy_cvc5.xml
+++ b/solvers_ivy_conf/ivy_cvc5.xml
@@ -27,12 +27,14 @@ SPDX-License-Identifier: Apache-2.0
         <conf name="solver-cvc5" extends="solver-cvc5-x64"/>
 
         <!-- main configurations -->
-        <conf name="solver-cvc5-x64" extends="solver-cvc5-linux-x64, solver-cvc5-windows-x64"/>
-        <conf name="solver-cvc5-arm64" extends="solver-cvc5-linux-arm64"/>
+        <conf name="solver-cvc5-x64" extends="solver-cvc5-linux-x64, solver-cvc5-macos-x64, solver-cvc5-windows-x64"/>
+        <conf name="solver-cvc5-arm64" extends="solver-cvc5-linux-arm64, solver-cvc5-macos-arm64"/>
 
         <!-- basic configurations -->
         <conf name="solver-cvc5-linux-x64" extends="solver-cvc5-common"/>
         <conf name="solver-cvc5-linux-arm64" extends="solver-cvc5-common"/>
+        <conf name="solver-cvc5-macos-x64" extends="solver-cvc5-common"/>
+        <conf name="solver-cvc5-macos-arm64" extends="solver-cvc5-common"/>
         <conf name="solver-cvc5-windows-x64" extends="solver-cvc5-common"/>
 
         <conf name="solver-cvc5-common" visibility="private"/>
@@ -41,6 +43,8 @@ SPDX-License-Identifier: Apache-2.0
     <publications defaultconf="solver-cvc5">
         <artifact name="libcvc5jni" conf="solver-cvc5-linux-x64" e:arch="x64" type="shared-object" ext="so"/>
         <artifact name="libcvc5jni" conf="solver-cvc5-linux-arm64" e:arch="arm64" type="shared-object" ext="so"/>
+        <artifact name="libcvc5jni" conf="solver-cvc5-macos-x64" e:arch="x64" type="shared-object" ext="dylib"/>
+        <artifact name="libcvc5jni" conf="solver-cvc5-macos-arm64" e:arch="arm64" type="shared-object" ext="dylib"/>
         <artifact name="libcvc5jni" conf="solver-cvc5-windows-x64" e:arch="x64" type="shared-object" ext="dll"/>
         <!-- Java code -->
         <artifact name="cvc5" conf="solver-cvc5-common" ext="jar"/>


### PR DESCRIPTION
Hello,
this PR switches the build to using the official CVC5 binaries release on [github](https://github.com/cvc5/cvc5/releases/tag/latest). This will allow us to support macOS on both x64 and arm64 platforms. Before merging we should wait for the next CVC5 release as the daily builds that this PR currently uses will not be permanently available. The last stable release, however, does not have some bug fixes that are need.