### PR TITLE
Update OpenSMT to 2.9.0 and include support for proofs in the JNI bindings

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -87,7 +87,7 @@ SPDX-License-Identifier: Apache-2.0
             <fileset dir="." includes="${libraryFiles} ${jarFiles} Javadoc-z3/"/>
             <fileset dir="lib/native/source/libmathsat5j" includes="*.so *.dll *.o"/>
             <fileset dir="lib/native/source/libbitwuzla" includes="install-linux/ install-linux-x64/ install-linux-arm64/ install-windows/ install-windows-x64/ build/ doc/ *.so *.dll bitwuzla_wrap.o"/>
-            <fileset dir="lib/native/source/opensmt" includes="install-linux-x64/ install-linux-arm64/ *.so"/>
+            <fileset dir="lib/native/source/opensmt" includes="build/ doc/ install-linux-x64/ install-linux-arm64/ *.o *.so version.h"/>
         </delete>
     </target>
 

--- a/build/build-publish-solvers/solver-opensmt.xml
+++ b/build/build-publish-solvers/solver-opensmt.xml
@@ -20,19 +20,12 @@ SPDX-License-Identifier: Apache-2.0
     <target name="set-properties-for-opensmt">
         <checkPathOption pathOption="opensmt.path" defaultPath="/path/to/opensmt" targetName="OpenSMT source folder (git checkout from 'https://github.com/usi-verification-and-security/opensmt.git)"/>
 
-        <!--
-            Please provide GMP from http://gmplib.org/ in version 6.3.0 (version 6.2.1 also works) and build GMP:
-            For linux-x64:
-                ./configure -?-enable-cxx -?-with-pic -?-disable-shared -?-enable-static -?-enable-fat
-                make -j4
-            For linux-arm64:
-                ./configure -?-enable-cxx -?-with-pic -?-disable-shared -?-enable-static -?-enable-fat \
-                     -?-host=aarch64-linux-gnu \
-                     CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ LD=aarch64-linux-gnu-ld
-                make -j4
-        -->
-        <checkPathOption pathOption="gmp-linux-x64.path" defaultPath="/path/to/gmp" targetName="GMP directory (Linux x64)"/>
-        <checkPathOption pathOption="gmp-linux-arm64.path" defaultPath="/path/to/gmp" targetName="GMP directory (Linux arm64)"/>
+        <!-- Define paths to the GMP installation for x86 and arm64
+             When using the docker image the files are already included and can be found under
+             /dependencies/gmp-6.2.1/install -->
+        <checkPathOption pathOption="gmp-linux-x64.path" defaultPath="/path/to/gmp" targetName="GMP installation directory (Linux x64)"/>
+        <checkPathOption pathOption="gmp-linux-arm64.path" defaultPath="/path/to/gmp" targetName="GMP installation directory (Linux arm64)"/>
+
         <checkPathOption pathOption="jdk-linux-arm64.path" defaultPath="/path/to/jdk" targetName="JDK source folder (Linux arm64 version)"/>
 
         <fail unless="opensmt.customRev">
@@ -76,12 +69,17 @@ SPDX-License-Identifier: Apache-2.0
         </exec>
 
         <!-- Build OpenSMT,
-                     Make sure to remove the old 'build/' directory from OpenSMT!
-                     It keeps old build commands and previous cmake-flags. -->
+             Make sure to remove the old 'build/' directory from OpenSMT!
+             It keeps old build commands and previous cmake-flags. -->
         <delete dir="${opensmt.path}/build" quiet="true"/>
         <exec executable="make" dir="${opensmt.path}" failonerror="true">
             <arg value="INSTALL_DIR=${opensmt.installPath}"/>
-            <arg value="CMAKE_FLAGS=-DFORCE_STATIC_GMP=ON"/>
+            <!-- The next arg is ONE large parameter. If executed manually outside of ant, please wrap it in quotes. -->
+            <arg value="CMAKE_FLAGS=
+              -DFORCE_STATIC_GMP=ON
+              -DGMP_LIBRARY=${gmp-linux-x64.path}/lib/libgmp.a
+              -DGMPXX_LIBRARY=${gmp-linux-x64.path}/lib/libgmpxx.a
+              -DGMP_INCLUDE_DIR=${gmp-linux-x64.path}/include"/>
             <arg value="install"/>
         </exec>
 
@@ -115,7 +113,13 @@ SPDX-License-Identifier: Apache-2.0
         <exec executable="make" dir="${opensmt.path}" failonerror="true">
             <arg value="INSTALL_DIR=${opensmt.installPath}"/>
             <!-- The next arg is ONE large parameter. If executed manually outside of ant, please wrap it in quotes. -->
-            <arg value="CMAKE_FLAGS=-DFORCE_STATIC_GMP=ON -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DGMP_LIBRARY=${gmp-linux-arm64.path}/.libs/libgmp.a -DGMPXX_LIBRARY=${gmp-linux-arm64.path}/.libs/libgmpxx.a -DGMP_INCLUDE_DIR=${gmp-linux-arm64.path}"/>
+            <arg value="CMAKE_FLAGS=
+              -DFORCE_STATIC_GMP=ON
+              -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc
+              -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++
+              -DGMP_LIBRARY=${gmp-linux-arm64.path}/lib/libgmp.a
+              -DGMPXX_LIBRARY=${gmp-linux-arm64.path}/lib/libgmpxx.a
+              -DGMP_INCLUDE_DIR=${gmp-linux-arm64.path}/include"/>
             <arg value="install"/>
         </exec>
 
@@ -198,7 +202,7 @@ SPDX-License-Identifier: Apache-2.0
             <arg value="-I${source.installPathLinuxX64}/include/opensmt"/>
             <arg value="-I${java.home}/include"/>
             <arg value="-I${java.home}/include/linux"/>
-            <arg value="-I${gmp-linux-x64.path}"/>
+            <arg value="-I${gmp-linux-x64.path}/include"/>
         </exec>
 
         <!-- link the wrapper to create libopensmtj-x64.so -->
@@ -216,7 +220,7 @@ SPDX-License-Identifier: Apache-2.0
             <arg value="libopensmtj-x64.so"/>
             <arg value="opensmt-wrap.o"/>
             <arg value="-L${source.installPathLinuxX64}/lib"/>
-            <arg value="-L${gmp-linux-x64.path}/.libs"/>
+            <arg value="-L${gmp-linux-x64.path}/lib"/>
             <arg value="-Wl,-Bstatic"/>
             <arg value="-lopensmt"/>
             <arg value="-lgmpxx"/>
@@ -246,7 +250,7 @@ SPDX-License-Identifier: Apache-2.0
             <arg value="-I${source.installPathLinuxArm64}/include/opensmt"/>
             <arg value="-I${jdk-linux-arm64.path}/include"/>
             <arg value="-I${jdk-linux-arm64.path}/include/linux"/>
-            <arg value="-I${gmp-linux-arm64.path}"/>
+            <arg value="-I${gmp-linux-arm64.path}/include"/>
         </exec>
 
         <!-- link the wrapper to create libopensmtj-arm64.so -->
@@ -264,7 +268,7 @@ SPDX-License-Identifier: Apache-2.0
             <arg value="libopensmtj-arm64.so"/>
             <arg value="opensmt-wrap.o"/>
             <arg value="-L${source.installPathLinuxArm64}/lib"/>
-            <arg value="-L${gmp-linux-arm64.path}/.libs"/>
+            <arg value="-L${gmp-linux-arm64.path}/lib"/>
             <arg value="-Wl,-Bstatic"/>
             <arg value="-lopensmt"/>
             <arg value="-lgmpxx"/>

--- a/build/build-publish-solvers/solver-opensmt.xml
+++ b/build/build-publish-solvers/solver-opensmt.xml
@@ -72,7 +72,7 @@ SPDX-License-Identifier: Apache-2.0
              Make sure to remove the old 'build/' directory from OpenSMT!
              It keeps old build commands and previous cmake-flags. -->
         <delete dir="${opensmt.path}/build" quiet="true"/>
-        <exec executable="make" dir="${opensmt.path}" failonerror="true">
+        <exec executable="make" dir="${opensmt.path}" failonerror="false" resultproperty="build.returnCode">
             <arg value="INSTALL_DIR=${opensmt.installPath}"/>
             <!-- The next arg is ONE large parameter. If executed manually outside of ant, please wrap it in quotes. -->
             <arg value="CMAKE_FLAGS=
@@ -89,6 +89,15 @@ SPDX-License-Identifier: Apache-2.0
             <arg value="-R"/>
             <arg value="${source.path}/api.patch"/>
         </exec>
+
+        <!-- Abort if the build failed -->
+        <fail message="Failed to build OpenSMT">
+            <condition>
+                <not>
+                    <equals arg1="0" arg2="${build.returnCode}"/>
+                </not>
+            </condition>
+        </fail>
 
         <!-- copy OpenSMT include files to JavaSMT -->
         <copy todir="${source.installPathLinuxX64}">
@@ -110,7 +119,7 @@ SPDX-License-Identifier: Apache-2.0
              Make sure to remove the old 'build/' directory from OpenSMT!
              It keeps old build commands and previous cmake-flags. -->
         <delete dir="${opensmt.path}/build" quiet="true"/>
-        <exec executable="make" dir="${opensmt.path}" failonerror="true">
+        <exec executable="make" dir="${opensmt.path}" failonerror="false" resultproperty="build.returnCode">
             <arg value="INSTALL_DIR=${opensmt.installPath}"/>
             <!-- The next arg is ONE large parameter. If executed manually outside of ant, please wrap it in quotes. -->
             <arg value="CMAKE_FLAGS=
@@ -129,6 +138,15 @@ SPDX-License-Identifier: Apache-2.0
             <arg value="-R"/>
             <arg value="${source.path}/api.patch"/>
         </exec>
+
+        <!-- Abort if the build failed -->
+        <fail message="Failed to build OpenSMT">
+            <condition>
+                <not>
+                    <equals arg1="0" arg2="${build.returnCode}"/>
+                </not>
+            </condition>
+        </fail>
 
         <!-- copy OpenSMT include files to JavaSMT -->
         <copy todir="${source.installPathLinuxArm64}">

--- a/doc/Developers-How-to-Release-into-Ivy.md
+++ b/doc/Developers-How-to-Release-into-Ivy.md
@@ -156,6 +156,9 @@ Please provide GMP from http://gmplib.org/ in version 6.3.0 (version 6.2.1 also 
   make -j4
   ```
 
+When using the docker container GMP is already included and can be found
+under `/dependencies/gmp-6.2.1/install` for `x64-linux` and `arm64-linux`.
+
 For linux-arm64, provide JNI headers in a reasonable LTS version.
 Download the zip archive from https://jdk.java.net/ and unpack it into $JDK_DIR_LINUX_ARM64
 (e.g., https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-aarch64_bin.tar.gz).
@@ -182,7 +185,7 @@ ant publish-opensmt \
 The build scripts for OpenSMT ... :
 - run for about 20 minutes (we build everything from scratch, two times).
 - download Google-based test components (requires internet access).
-- append the git revision of Bitwuzla.
+- append the git revision of OpenSMT.
 - produce two Linux (x64 and arm64) libraries, and publish them.
 
 Finally, follow the instructions shown in the message at the end of the command.

--- a/doc/Developers-How-to-Release-into-Ivy.md
+++ b/doc/Developers-How-to-Release-into-Ivy.md
@@ -142,7 +142,13 @@ We prefer to build directly on Ubuntu 22.04, where CMake, SWIG, and GCC are suff
 For simple usage, we provide a Docker definition/environment under `/docker`,
 in which the following command can be run.
 
-Please provide GMP from http://gmplib.org/ in version 6.3.0 (version 6.2.1 also works) and build GMP:
+When using the Docker container, dependencies for GMP and JDK are already included for several platforms
+and include the following directories:
+- `/dependencies/gmp-6.2.1/install` for `x64-linux` and `arm64-linux`, and
+- `/dependencies/jdk17-linux-aarch64`.
+
+If you want to build your own dependencies, please apply the following steps:
+Provide GMP from http://gmplib.org/ in version 6.3.0 (version 6.2.1 also works) and build GMP:
 - For linux-x64 in directory $GMP_DIR_LINUX_X64:
   ```
   ./configure --enable-cxx --with-pic --disable-shared --enable-static --enable-fat
@@ -155,10 +161,6 @@ Please provide GMP from http://gmplib.org/ in version 6.3.0 (version 6.2.1 also 
   CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ LD=aarch64-linux-gnu-ld
   make -j4
   ```
-
-When using the docker container GMP is already included and can be found
-under `/dependencies/gmp-6.2.1/install` for `x64-linux` and `arm64-linux`.
-
 For linux-arm64, provide JNI headers in a reasonable LTS version.
 Download the zip archive from https://jdk.java.net/ and unpack it into $JDK_DIR_LINUX_ARM64
 (e.g., https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-aarch64_bin.tar.gz).
@@ -177,10 +179,10 @@ Example:
 ```
 ant publish-opensmt \
     -Dopensmt.path=/workspace/solvers/opensmt/opensmt \
-    -Dopensmt.customRev=2.8.0-sosy0 \
-    -Dgmp-linux-x64.path=/workspace/solvers/gmp/gmp-6.3.0-linux-x64 \
-    -Dgmp-linux-arm64.path=/workspace/solvers/gmp/gmp-6.3.0-linux-arm64 \
-    -Djdk-linux-arm64.path=/workspace/solvers/jdk/openjdk-17.0.2_linux-aarch64_bin/jdk-17.0.2
+    -Dopensmt.customRev=2.9.0 \
+    -Dgmp-linux-x64.path=/dependencies/gmp-6.2.1/install/x64-linux \
+    -Dgmp-linux-arm64.path=/dependencies/gmp-6.2.1/install/arm64-linux \
+    -Djdk-linux-arm64.path=/dependencies/jdk17-linux-aarch64
 ```
 The build scripts for OpenSMT ... :
 - run for about 20 minutes (we build everything from scratch, two times).

--- a/docker/buildUbuntu1804.sh
+++ b/docker/buildUbuntu1804.sh
@@ -8,7 +8,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-podman build -t registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu1804 - < ubuntu1804.Dockerfile
+podman build \
+    --build-arg BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+    -t registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu1804 - < ubuntu1804.Dockerfile
 
 # For pushing to Gitlab registry, please create your personal access token:
 #   https://gitlab.com/-/user_settings/personal_access_tokens

--- a/docker/buildUbuntu2204.sh
+++ b/docker/buildUbuntu2204.sh
@@ -8,7 +8,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-podman build -t registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu2204 - < ubuntu2204.Dockerfile
+podman build \
+    --build-arg BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+    -t registry.gitlab.com/sosy-lab/software/java-smt/develop:ubuntu2204 - < ubuntu2204.Dockerfile
 
 # For pushing to Gitlab registry, please create your personal access token:
 #   https://gitlab.com/-/user_settings/personal_access_tokens

--- a/docker/runUbuntu1804.sh
+++ b/docker/runUbuntu1804.sh
@@ -8,9 +8,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# specific for my system:
-# JavaSMT and all solver files are located in the directory "workspace".
-WORKSPACE=$HOME/workspace
+# JavaSMT and all solver files are located in the directory WORKSPACE.
+# Derive WORKSPACE from the script's location (two directories up from current)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE="$(realpath "${SCRIPT_DIR}/../..")"
 
 podman run -it \
     --mount type=bind,source=${WORKSPACE},target=/workspace \

--- a/docker/runUbuntu2204.sh
+++ b/docker/runUbuntu2204.sh
@@ -8,9 +8,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# specific for my system:
-# JavaSMT and all solver files are located in the directory "workspace".
-WORKSPACE=$HOME/workspace
+# JavaSMT and all solver files are located in the directory WORKSPACE.
+# Derive WORKSPACE from the script's location (two directories up from current)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE="$(realpath "${SCRIPT_DIR}/../..")"
 
 podman run -it \
     --mount type=bind,source=${WORKSPACE},target=/workspace \

--- a/docker/ubuntu1804.Dockerfile
+++ b/docker/ubuntu1804.Dockerfile
@@ -56,7 +56,7 @@ RUN pip3 install --upgrade meson
 # OpenSMT requires swig, gmp, flex and bison
 # - swig needs to built manually to get version 4.1 for unique_ptr support
 # - libpcre2-dev is a dependency of swig
-# - gmp needs to be recompiled to generate PIC code
+# - gmp needs to be recompiled to generate PIC code (see below)
 # - lzip is required to unpack the gmp tar ball
 RUN apt-get update \
  && apt-get install -y \
@@ -64,23 +64,50 @@ RUN apt-get update \
  && apt-get clean
 
 WORKDIR /dependencies
+
+# Install SWIG in a recent enough version
 RUN wget http://prdownloads.sourceforge.net/swig/swig-4.1.1.tar.gz \
  && tar xf swig-4.1.1.tar.gz \
+ && rm swig-4.1.1.tar.gz \
  && cd swig-4.1.1 \
  && ./configure \
  && make -j4 \
  && make install \
- && rm -rf swig-4.1.1.tar.gz swig-4.1.1 \
- && cd --
+ && cd .. \
+ && rm -rf swig-4.1.1
 
+# Install GMP for linux on x64 and arm64
+# We could add another build for windows when needed
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz \
  && tar xf gmp-6.2.1.tar.lz \
+ && rm gmp-6.2.1.tar.lz \
  && cd gmp-6.2.1 \
- && ./configure --enable-cxx --with-pic --disable-shared --enable-fat \
+ && ./configure \
+      --enable-cxx \
+      --with-pic \
+      --disable-shared \
+      --enable-fat \
+      --prefix=/dependencies/gmp-6.2.1/install/x64-linux \
  && make -j4 \
  && make install \
- && rm -rf gmp-6.2.1.tar.lz gmp-6.2.1 \
- && cd --
+ && make clean \
+ && ./configure \
+      --enable-cxx \
+      --with-pic \
+      --disable-shared \
+      --enable-fat \
+      --host=aarch64-linux-gnu \
+      --prefix=/dependencies/gmp-6.2.1/install/arm64-linux \
+ && CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ LD=aarch64-linux-gnu-ld make -j4 \
+ && make install \
+ && make clean
+
+# Install the Jdk for Windows x64
+# Builds for arm64 are only available with an Oracle account and have to be downloaded manually
+RUN wget https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_windows-x64_bin.zip \
+ && unzip openjdk-11+28_windows-x64_bin.zip \
+ && mv jdk-11 jdk11-windows-x64 \
+ && rm openjdk-11+28_windows-x64_bin.zip
 
 # JNI is not found when compiling Boolector in the image, so we need to set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/

--- a/docker/ubuntu1804.Dockerfile
+++ b/docker/ubuntu1804.Dockerfile
@@ -103,11 +103,16 @@ RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz \
  && make clean
 
 # Install the Jdk for Windows x64
-# Builds for arm64 are only available with an Oracle account and have to be downloaded manually
 RUN wget https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_windows-x64_bin.zip \
  && unzip openjdk-11+28_windows-x64_bin.zip \
  && mv jdk-11 jdk11-windows-x64 \
  && rm openjdk-11+28_windows-x64_bin.zip
+
+# Install the Jdk for Linux arm64
+RUN wget https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-aarch64_bin.tar.gz \
+ && tar -xzf openjdk-17.0.2_linux-aarch64_bin.tar.gz \
+ && mv jdk-17.0.2 jdk17-linux-aarch64 \
+ && rm openjdk-17.0.2_linux-aarch64_bin.tar.gz
 
 # JNI is not found when compiling Boolector in the image, so we need to set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/

--- a/docker/ubuntu1804.Dockerfile
+++ b/docker/ubuntu1804.Dockerfile
@@ -116,3 +116,14 @@ RUN wget https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d713
 
 # JNI is not found when compiling Boolector in the image, so we need to set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+
+# set labels for the image
+ARG BUILD_DATE
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.title="JavaSMT solver development"
+LABEL org.opencontainers.image.description="Ubuntu 18.04-based image for JavaSMT solver development"
+LABEL org.opencontainers.image.source="https://github.com/sosy-lab/java-smt"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+# Podman-Specific Label for Auto-Update
+LABEL io.containers.autoupdate=registry

--- a/docker/ubuntu2204.Dockerfile
+++ b/docker/ubuntu2204.Dockerfile
@@ -111,3 +111,14 @@ RUN wget https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d713
 
 # JNI is not found when compiling Boolector in the image, so we need to set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+
+# set labels for the image
+ARG BUILD_DATE
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.title="JavaSMT solver development"
+LABEL org.opencontainers.image.description="Ubuntu 18.04-based image for JavaSMT solver development"
+LABEL org.opencontainers.image.source="https://github.com/sosy-lab/java-smt"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+# Podman-Specific Label for Auto-Update
+LABEL io.containers.autoupdate=registry

--- a/docker/ubuntu2204.Dockerfile
+++ b/docker/ubuntu2204.Dockerfile
@@ -98,11 +98,16 @@ RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz \
  && make clean
 
 # Install the Jdk for Windows x64
-# Builds for arm64 are only available with an Oracle account and have to be downloaded manually
 RUN wget https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_windows-x64_bin.zip \
  && unzip openjdk-11+28_windows-x64_bin.zip \
  && mv jdk-11 jdk11-windows-x64 \
  && rm openjdk-11+28_windows-x64_bin.zip
+
+# Install the Jdk for Linux arm64
+RUN wget https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-aarch64_bin.tar.gz \
+ && tar -xzf openjdk-17.0.2_linux-aarch64_bin.tar.gz \
+ && mv jdk-17.0.2 jdk17-linux-aarch64 \
+ && rm openjdk-17.0.2_linux-aarch64_bin.tar.gz
 
 # JNI is not found when compiling Boolector in the image, so we need to set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/

--- a/docker/ubuntu2204.Dockerfile
+++ b/docker/ubuntu2204.Dockerfile
@@ -51,7 +51,7 @@ RUN pip3 install --upgrade meson
 # OpenSMT requires swig, gmp, flex and bison
 # - swig needs to built manually to get version 4.1 for unique_ptr support
 # - libpcre2-dev is a dependency of swig
-# - gmp needs to be recompiled to generate PIC code
+# - gmp needs to be recompiled to generate PIC code (see below)
 # - lzip is required to unpack the gmp tar ball
 RUN apt-get update \
  && apt-get install -y \
@@ -59,26 +59,49 @@ RUN apt-get update \
  && apt-get clean
 
 WORKDIR /dependencies
+
+# Install SWIG in a recent enough version
 RUN wget http://prdownloads.sourceforge.net/swig/swig-4.1.1.tar.gz \
  && tar xf swig-4.1.1.tar.gz \
+ && rm swig-4.1.1.tar.gz \
  && cd swig-4.1.1 \
  && ./configure \
  && make -j4 \
  && make install \
- && rm -rf swig-4.1.1.tar.gz swig-4.1.1 \
- && cd --
+ && cd .. \
+ && rm -rf swig-4.1.1
 
+# Install GMP for linux on x64 and arm64
+# We could add another build for windows when needed
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz \
  && tar xf gmp-6.2.1.tar.lz \
+ && rm gmp-6.2.1.tar.lz \
  && cd gmp-6.2.1 \
- && ./configure --enable-cxx --with-pic --disable-shared --enable-fat \
+ && ./configure \
+      --enable-cxx \
+      --with-pic \
+      --disable-shared \
+      --enable-fat \
+      --prefix=/dependencies/gmp-6.2.1/install/x64-linux \
  && make -j4 \
  && make install \
- && rm -rf gmp-6.2.1.tar.lz gmp-6.2.1 \
- && cd --
+ && make clean \
+ && ./configure \
+      --enable-cxx \
+      --with-pic \
+      --disable-shared \
+      --enable-fat \
+      --host=aarch64-linux-gnu \
+      --prefix=/dependencies/gmp-6.2.1/install/arm64-linux \
+ && CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ LD=aarch64-linux-gnu-ld make -j4 \
+ && make install \
+ && make clean
 
+# Install the Jdk for Windows x64
+# Builds for arm64 are only available with an Oracle account and have to be downloaded manually
 RUN wget https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_windows-x64_bin.zip \
  && unzip openjdk-11+28_windows-x64_bin.zip \
+ && mv jdk-11 jdk11-windows-x64 \
  && rm openjdk-11+28_windows-x64_bin.zip
 
 # JNI is not found when compiling Boolector in the image, so we need to set JAVA_HOME

--- a/lib/ivy.xml
+++ b/lib/ivy.xml
@@ -188,7 +188,7 @@ SPDX-License-Identifier: Apache-2.0
         <!-- Solver Binaries -->
         <dependency org="org.sosy_lab" name="javasmt-solver-mathsat" rev="5.6.11-sosy1" conf="runtime-mathsat-x64->solver-mathsat-x64; runtime-mathsat-arm64->solver-mathsat-arm64" />
         <dependency org="org.sosy_lab" name="javasmt-solver-z3" rev="4.14.0" conf="runtime-z3-x64->solver-z3-x64; runtime-z3-arm64->solver-z3-arm64; contrib->sources,javadoc" />
-        <dependency org="org.sosy_lab" name="javasmt-solver-opensmt" rev="2.8.0-sosy0-ge831bf23" conf="runtime-opensmt-x64->solver-opensmt-x64; runtime-opensmt-arm64->solver-opensmt-arm64; contrib->sources,javadoc"/>
+        <dependency org="org.sosy_lab" name="javasmt-solver-opensmt" rev="2.8.0-sosy1-ge831bf23" conf="runtime-opensmt-x64->solver-opensmt-x64; runtime-opensmt-arm64->solver-opensmt-arm64; contrib->sources,javadoc"/>
         <dependency org="org.sosy_lab" name="javasmt-solver-optimathsat" rev="1.7.3-sosy1" conf="runtime-optimathsat->solver-optimathsat" />
         <dependency org="org.sosy_lab" name="javasmt-solver-cvc4" rev="1.8-prerelease-2020-06-24-g7825d8f28" conf="runtime-cvc4->solver-cvc4" />
         <dependency org="org.sosy_lab" name="javasmt-solver-cvc5" rev="1.0.5-g4cb2ab9eb" conf="runtime-cvc5->solver-cvc5" />

--- a/lib/ivy.xml
+++ b/lib/ivy.xml
@@ -188,7 +188,7 @@ SPDX-License-Identifier: Apache-2.0
         <!-- Solver Binaries -->
         <dependency org="org.sosy_lab" name="javasmt-solver-mathsat" rev="5.6.11-sosy1" conf="runtime-mathsat-x64->solver-mathsat-x64; runtime-mathsat-arm64->solver-mathsat-arm64" />
         <dependency org="org.sosy_lab" name="javasmt-solver-z3" rev="4.14.0" conf="runtime-z3-x64->solver-z3-x64; runtime-z3-arm64->solver-z3-arm64; contrib->sources,javadoc" />
-        <dependency org="org.sosy_lab" name="javasmt-solver-opensmt" rev="2.8.0-sosy1-ge831bf23" conf="runtime-opensmt-x64->solver-opensmt-x64; runtime-opensmt-arm64->solver-opensmt-arm64; contrib->sources,javadoc"/>
+        <dependency org="org.sosy_lab" name="javasmt-solver-opensmt" rev="2.9.0-gef441e1c" conf="runtime-opensmt-x64->solver-opensmt-x64; runtime-opensmt-arm64->solver-opensmt-arm64; contrib->sources,javadoc"/>
         <dependency org="org.sosy_lab" name="javasmt-solver-optimathsat" rev="1.7.3-sosy1" conf="runtime-optimathsat->solver-optimathsat" />
         <dependency org="org.sosy_lab" name="javasmt-solver-cvc4" rev="1.8-prerelease-2020-06-24-g7825d8f28" conf="runtime-cvc4->solver-cvc4" />
         <dependency org="org.sosy_lab" name="javasmt-solver-cvc5" rev="1.0.5-g4cb2ab9eb" conf="runtime-cvc5->solver-cvc5" />

--- a/lib/native/source/opensmt/api.patch
+++ b/lib/native/source/opensmt/api.patch
@@ -1,5 +1,5 @@
 diff --git a/src/api/Interpret.cc b/src/api/Interpret.cc
-index cd5e32e3..3bca780a 100644
+index 3d3bad4c..daaf1ded 100644
 --- a/src/api/Interpret.cc
 +++ b/src/api/Interpret.cc
 @@ -27,6 +27,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
@@ -24,10 +24,10 @@ index cd5e32e3..3bca780a 100644
  
  PTRef
  Interpret::getParsedFormula()
-@@ -1043,11 +1049,13 @@ void Interpret::comment_formatted(const char* fmt_str, ...) const {
+@@ -1044,11 +1050,13 @@ void Interpret::comment_formatted(const char* fmt_str, ...) const {
  
  
- void Interpret::notify_formatted(bool error, const char* fmt_str, ...) {
+ void Interpret::notify_formatted(bool error, const char* fmt_str, ...) const {
 +    std::stringstream out;
 +
      va_list ap;
@@ -39,7 +39,7 @@ index cd5e32e3..3bca780a 100644
  
      va_start(ap, fmt_str);
      while (true) {
-@@ -1056,25 +1064,29 @@ void Interpret::notify_formatted(bool error, const char* fmt_str, ...) {
+@@ -1057,25 +1065,29 @@ void Interpret::notify_formatted(bool error, const char* fmt_str, ...) const {
              switch (*fmt_str++) {
              case 's':
                  t = va_arg(ap, char *);
@@ -74,9 +74,9 @@ index cd5e32e3..3bca780a 100644
 +    std::cout << out.str();
  }
  
- void Interpret::notify_success() {
+ void Interpret::notify_success() const {
 diff --git a/src/api/Interpret.h b/src/api/Interpret.h
-index dcc930a9..77e0b402 100644
+index c0b42e2d..e86986cc 100644
 --- a/src/api/Interpret.h
 +++ b/src/api/Interpret.h
 @@ -138,6 +138,7 @@ class Interpret {
@@ -108,10 +108,10 @@ index dcc930a9..77e0b402 100644
  
      int interpFile(FILE* in);
 diff --git a/src/api/MainSolver.h b/src/api/MainSolver.h
-index 01fc6ad3..05d5ee2f 100644
+index 6ce4d184..30f879f5 100644
 --- a/src/api/MainSolver.h
 +++ b/src/api/MainSolver.h
-@@ -103,7 +103,7 @@ public:
+@@ -112,7 +112,7 @@ public:
      // I.e., *excluding* popped assertions
      vec<PTRef> getCurrentAssertions() const;
      // Returns just a view to the assertions
@@ -120,10 +120,10 @@ index 01fc6ad3..05d5ee2f 100644
  
      vec<PTRef> const & getAssertionsAtCurrentLevel() const { return getAssertionsAtLevel(getAssertionLevel()); }
      vec<PTRef> const & getAssertionsAtLevel(std::size_t) const;
-diff --git a/src/common/FastRational.cc b/src/common/FastRational.cc
+diff --git a/src/common/numbers/FastRational.cc b/src/common/numbers/FastRational.cc
 index 68566c05..563fe045 100644
---- a/src/common/FastRational.cc
-+++ b/src/common/FastRational.cc
+--- a/src/common/numbers/FastRational.cc
++++ b/src/common/numbers/FastRational.cc
 @@ -15,18 +15,22 @@ namespace opensmt {
  mpq_ptr FastRational::mpqPool::alloc()
  {
@@ -147,10 +147,10 @@ index 68566c05..563fe045 100644
  }
  
  FastRational::FastRational( const char * s, const int base )
-diff --git a/src/common/FastRational.h b/src/common/FastRational.h
+diff --git a/src/common/numbers/FastRational.h b/src/common/numbers/FastRational.h
 index 7948137b..b99e17ef 100644
---- a/src/common/FastRational.h
-+++ b/src/common/FastRational.h
+--- a/src/common/numbers/FastRational.h
++++ b/src/common/numbers/FastRational.h
 @@ -11,6 +11,7 @@ Copyright (c) 2008, 2009 Centre national de la recherche scientifique (CNRS)
  #include <cassert>
  #include <climits>
@@ -168,7 +168,7 @@ index 7948137b..b99e17ef 100644
          std::stack<mpq_ptr, std::vector<mpq_ptr>> pool;
      public:
 diff --git a/src/logics/Logic.cc b/src/logics/Logic.cc
-index 85f06522..ed42501b 100644
+index 7188ce65..16cee996 100644
 --- a/src/logics/Logic.cc
 +++ b/src/logics/Logic.cc
 @@ -9,6 +9,7 @@
@@ -222,7 +222,7 @@ index 85f06522..ed42501b 100644
  SRef Logic::getSortRef(PTRef const tr) const {
      return getSortRef(getPterm(tr).symb());
 diff --git a/src/logics/Logic.h b/src/logics/Logic.h
-index 9a144ee6..dc8ce747 100644
+index 1eff071f..1bb2dbcc 100644
 --- a/src/logics/Logic.h
 +++ b/src/logics/Logic.h
 @@ -59,6 +59,9 @@ public:

--- a/lib/native/source/opensmt/opensmt-wrap.cpp
+++ b/lib/native/source/opensmt/opensmt-wrap.cpp
@@ -629,6 +629,11 @@ SWIGINTERN opensmt::sstat opensmt_sstat_True(){ return s_True; }
 SWIGINTERN opensmt::sstat opensmt_sstat_False(){ return s_False; }
 SWIGINTERN opensmt::sstat opensmt_sstat_Undef(){ return s_Undef; }
 SWIGINTERN opensmt::sstat opensmt_sstat_Error(){ return s_Error; }
+SWIGINTERN std::string opensmt_MainSolver_printResolutionProofSMT2(opensmt::MainSolver *self){
+    std::ostringstream out;
+    self->printResolutionProofSMT2(out);
+    return out.str();
+  }
 SWIGINTERN std::vector< opensmt::PTRef > opensmt_MainSolver_getUnsatCore(opensmt::MainSolver *self){
     std::vector<PTRef> result;
     auto core = self->getUnsatCore();
@@ -5084,6 +5089,40 @@ SWIGEXPORT void JNICALL Java_org_sosy_1lab_java_1smt_solvers_opensmt_api_OsmtNat
       return ;
     }
   }
+}
+
+
+SWIGEXPORT jstring JNICALL Java_org_sosy_1lab_java_1smt_solvers_opensmt_api_OsmtNativeJNI_MainSolver_1printResolutionProofSMT2(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+  jstring jresult = 0 ;
+  opensmt::MainSolver *arg1 = (opensmt::MainSolver *) 0 ;
+  std::string result;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(opensmt::MainSolver **)&jarg1; 
+  {
+    try {
+      result = opensmt_MainSolver_printResolutionProofSMT2(arg1); 
+    }
+    catch(std::exception& e) {
+      jclass exceptionType = jenv->FindClass("java/lang/UnsupportedOperationException");
+      jenv->ThrowNew(exceptionType, e.what());
+      return 0;
+    }
+    catch(OutOfMemoryException& e) {
+      jclass exceptionType = jenv->FindClass("java/lang/OutOfMemoryError");
+      jenv->ThrowNew(exceptionType, "");
+      return 0;
+    }
+    catch(...) {
+      jclass exceptionType = jenv->FindClass("java/lang/RuntimeException");
+      jenv->ThrowNew(exceptionType, "");
+      return 0;
+    }
+  }
+  jresult = jenv->NewStringUTF((&result)->c_str()); 
+  return jresult;
 }
 
 

--- a/lib/native/source/opensmt/src/org/sosy_lab/java_smt/solvers/opensmt/api/MainSolver.java
+++ b/lib/native/source/opensmt/src/org/sosy_lab/java_smt/solvers/opensmt/api/MainSolver.java
@@ -118,6 +118,10 @@ public class MainSolver {
     OsmtNativeJNI.MainSolver_stop(swigCPtr, this);
   }
 
+  public String printResolutionProofSMT2() {
+    return OsmtNativeJNI.MainSolver_printResolutionProofSMT2(swigCPtr, this);
+  }
+
   public VectorPTRef getUnsatCore() {
     return new VectorPTRef(OsmtNativeJNI.MainSolver_getUnsatCore(swigCPtr, this), true);
   }

--- a/lib/native/source/opensmt/src/org/sosy_lab/java_smt/solvers/opensmt/api/OsmtNativeJNI.java
+++ b/lib/native/source/opensmt/src/org/sosy_lab/java_smt/solvers/opensmt/api/OsmtNativeJNI.java
@@ -185,6 +185,7 @@ public class OsmtNativeJNI {
   public final static native long MainSolver_getModel(long jarg1, MainSolver jarg1_);
   public final static native long MainSolver_getInterpolationContext(long jarg1, MainSolver jarg1_);
   public final static native void MainSolver_stop(long jarg1, MainSolver jarg1_);
+  public final static native String MainSolver_printResolutionProofSMT2(long jarg1, MainSolver jarg1_);
   public final static native long MainSolver_getUnsatCore(long jarg1, MainSolver jarg1_);
   public final static native long new_Logic__SWIG_0(int jarg1);
   public final static native void delete_Logic(long jarg1);

--- a/lib/native/source/opensmt/swig/opensmt/ArithLogic.i
+++ b/lib/native/source/opensmt/swig/opensmt/ArithLogic.i
@@ -192,10 +192,10 @@ namespace opensmt {
 %ignore ArithLogic::isIntOne (SymRef sr) const;
 %ignore ArithLogic::isRealOne (SymRef sr) const;
 %ignore ArithLogic::isNumTerm (PTRef tr) const;
-%ignore ArithLogic::checkSortInt (PTRef tr);
-%ignore ArithLogic::checkSortReal (PTRef tr);
-%ignore ArithLogic::checkSortInt (vec< PTRef > const &args);
-%ignore ArithLogic::checkSortReal (vec< PTRef > const &args);
+%ignore ArithLogic::checkSortInt (PTRef tr) const;
+%ignore ArithLogic::checkSortReal (PTRef tr) const;
+%ignore ArithLogic::checkSortInt (vec< PTRef > const &args) const;
+%ignore ArithLogic::checkSortReal (vec< PTRef > const &args) const;
 %ignore ArithLogic::getPlusForSort (SRef sort) const;
 %ignore ArithLogic::getTimesForSort (SRef sort) const;
 %ignore ArithLogic::getMinusForSort (SRef sort) const;
@@ -231,9 +231,9 @@ namespace opensmt {
 %ignore ArithLogic::termSort (vec< PTRef > &v) const override;
 %ignore ArithLogic::removeAuxVars (PTRef) override;
 %ignore ArithLogic::printTerm_ (PTRef tr, bool ext, bool s) const override;
-%ignore ArithLogic::getConstantFromLeq (PTRef);
-%ignore ArithLogic::getTermFromLeq (PTRef);
-%ignore ArithLogic::leqToConstantAndTerm (PTRef);
+%ignore ArithLogic::getConstantFromLeq (PTRef) const;
+%ignore ArithLogic::getTermFromLeq (PTRef) const;
+%ignore ArithLogic::leqToConstantAndTerm (PTRef) const;
 %ignore ArithLogic::getNestedBoolRoots (PTRef) const override;
 }
 

--- a/lib/native/source/opensmt/swig/opensmt/Logic.i
+++ b/lib/native/source/opensmt/swig/opensmt/Logic.i
@@ -166,7 +166,7 @@ namespace opensmt {
 %ignore Logic::declareFun_Pairwise (std::string const &s, SRef rsort, vec< SRef > const &args);
 %ignore Logic::instantiateFunctions (SRef);
 %ignore Logic::instantiateArrayFunctions (SRef);
-%ignore Logic::hasSortSymbol (SortSymbol const &);
+%ignore Logic::hasSortSymbol (SortSymbol const &) const;
 %ignore Logic::peekSortSymbol (SortSymbol const &, SSymRef &) const;
 %ignore Logic::declareSortSymbol (SortSymbol symbol);
 %ignore Logic::getSort (SSymRef, vec< SRef > &&args);
@@ -252,7 +252,7 @@ namespace opensmt {
 %ignore Logic::getNewFacts (PTRef root, MapWithKeys< PTRef, lbool, PTRefHash > &facts);
 %ignore Logic::retrieveSubstitutions (const vec< PtAsgn > &units);
 %ignore Logic::substitutionsTransitiveClosure (SubstMap &substs);
-%ignore Logic::contains (PTRef x, PTRef y);
+%ignore Logic::contains (PTRef x, PTRef y) const;
 %ignore Logic::learnEqTransitivity (PTRef);
 %ignore Logic::removeAuxVars (PTRef tr);
 %ignore Logic::hasQuotableChars (std::string const &name) const;

--- a/lib/native/source/opensmt/swig/opensmt/MainSolver.i
+++ b/lib/native/source/opensmt/swig/opensmt/MainSolver.i
@@ -77,9 +77,15 @@ namespace opensmt {
 %ignore MainSolver::getAssertionsAtCurrentLevel() const;
 %ignore MainSolver::getAssertionsAtLevel(std::size_t) const;
 
-// TODO These were also added recently. Are they useful to us?
 %ignore MainSolver::printResolutionProofSMT2() const;
 %ignore MainSolver::printResolutionProofSMT2(std::ostream &) const;
+%extend MainSolver {
+  std::string printResolutionProofSMT2() {
+    std::ostringstream out;
+    $self->printResolutionProofSMT2(out);
+    return out.str();
+  }
+}
 
 %ignore MainSolver::getUnsatCore() const;
 %ignore MainSolver::printFramesAsQuery() const;

--- a/lib/native/source/opensmt/swig/opensmt/MainSolver.i
+++ b/lib/native/source/opensmt/swig/opensmt/MainSolver.i
@@ -67,7 +67,7 @@ namespace opensmt {
 %ignore MainSolver::getTheory();
 %ignore MainSolver::getTheory() const;
 %ignore MainSolver::getPartitionManager();
-%ignore MainSolver::insertFormula(PTRef, char**);
+%ignore MainSolver::addAssertion(PTRef);
 %ignore MainSolver::initialize();
 %ignore MainSolver::simplifyFormulas();
 
@@ -76,6 +76,9 @@ namespace opensmt {
 %ignore MainSolver::getCurrentAssertionsView() const;
 %ignore MainSolver::getAssertionsAtCurrentLevel() const;
 %ignore MainSolver::getAssertionsAtLevel(std::size_t) const;
+%ignore MainSolver::getAssertionsCount() const;
+%ignore MainSolver::tryAddNamedAssertion(PTRef, std::string const&);
+%ignore MainSolver::tryAddTermNameFor(PTRef, std::string const & name);
 
 %ignore MainSolver::printResolutionProofSMT2() const;
 %ignore MainSolver::printResolutionProofSMT2(std::ostream &) const;


### PR DESCRIPTION
Hello everyone,
this PR will update OpenSMT to version 2.9.0 while also adding the method `MainSolver.printResolutionProofSMT2` to the JNI bindings in preparation for https://github.com/sosy-lab/java-smt/pull/458. There are also some minor simplifications to the build process and the binaries for GMP on x86-linux and arm64-linux are now included in the build container and no longer have to be provided by the maintainer when updating the binaries.