### PR TITLE
Update CVC5 to fix the concurrency issues

### DIFF
--- a/lib/ivy.xml
+++ b/lib/ivy.xml
@@ -193,7 +193,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency org="org.sosy_lab" name="javasmt-solver-opensmt" rev="2.8.0-sosy0-ge831bf23" conf="runtime-opensmt-x64->solver-opensmt-x64; runtime-opensmt-arm64->solver-opensmt-arm64; contrib->sources,javadoc"/>
         <dependency org="org.sosy_lab" name="javasmt-solver-optimathsat" rev="1.7.3-sosy1" conf="runtime-optimathsat->solver-optimathsat" />
         <dependency org="org.sosy_lab" name="javasmt-solver-cvc4" rev="1.8-prerelease-2020-06-24-g7825d8f28" conf="runtime-cvc4->solver-cvc4" />
-        <dependency org="org.sosy_lab" name="javasmt-solver-cvc5" rev="2025-04-03-ee76c36" conf="runtime-cvc5-x64->solver-cvc5-x64; runtime-cvc5-arm64->solver-cvc5-arm64"/>
+        <dependency org="org.sosy_lab" name="javasmt-solver-cvc5" rev="2025-04-24-39b3bbc" conf="runtime-cvc5-x64->solver-cvc5-x64; runtime-cvc5-arm64->solver-cvc5-arm64"/>
         <dependency org="org.sosy_lab" name="javasmt-solver-boolector" rev="3.2.2-g1a89c229" conf="runtime-boolector->solver-boolector" />
         <dependency org="org.sosy_lab" name="javasmt-solver-bitwuzla" rev="0.7.0-13.1-g595512ae" conf="runtime-bitwuzla-x64->solver-bitwuzla-x64; runtime-bitwuzla-arm64->solver-bitwuzla-arm64; contrib->sources,javadoc"/>
 

--- a/lib/ivy.xml
+++ b/lib/ivy.xml
@@ -193,7 +193,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency org="org.sosy_lab" name="javasmt-solver-opensmt" rev="2.8.0-sosy0-ge831bf23" conf="runtime-opensmt-x64->solver-opensmt-x64; runtime-opensmt-arm64->solver-opensmt-arm64; contrib->sources,javadoc"/>
         <dependency org="org.sosy_lab" name="javasmt-solver-optimathsat" rev="1.7.3-sosy1" conf="runtime-optimathsat->solver-optimathsat" />
         <dependency org="org.sosy_lab" name="javasmt-solver-cvc4" rev="1.8-prerelease-2020-06-24-g7825d8f28" conf="runtime-cvc4->solver-cvc4" />
-        <dependency org="org.sosy_lab" name="javasmt-solver-cvc5" rev="2025-04-24-39b3bbc" conf="runtime-cvc5-x64->solver-cvc5-x64; runtime-cvc5-arm64->solver-cvc5-arm64"/>
+        <dependency org="org.sosy_lab" name="javasmt-solver-cvc5" rev="2025-05-16-8aeaa19" conf="runtime-cvc5-x64->solver-cvc5-x64; runtime-cvc5-arm64->solver-cvc5-arm64"/>
         <dependency org="org.sosy_lab" name="javasmt-solver-boolector" rev="3.2.2-g1a89c229" conf="runtime-boolector->solver-boolector" />
         <dependency org="org.sosy_lab" name="javasmt-solver-bitwuzla" rev="0.7.0-13.1-g595512ae" conf="runtime-bitwuzla-x64->solver-bitwuzla-x64; runtime-bitwuzla-arm64->solver-bitwuzla-arm64; contrib->sources,javadoc"/>
 

--- a/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingSolverInformation.java
+++ b/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingSolverInformation.java
@@ -61,7 +61,7 @@ public class DebuggingSolverInformation {
           Solvers.YICES2,
           ConcurrentHashMap.newKeySet());
 
-  private Set<Formula> definedFormulas;
+  private final Set<Formula> definedFormulas;
 
   private final Thread solverThread = Thread.currentThread();
 

--- a/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingSolverInformation.java
+++ b/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingSolverInformation.java
@@ -48,8 +48,6 @@ public class DebuggingSolverInformation {
       Map.of(
           Solvers.PRINCESS,
           ConcurrentHashMap.newKeySet(),
-          Solvers.CVC5,
-          ConcurrentHashMap.newKeySet(),
           Solvers.YICES2,
           ConcurrentHashMap.newKeySet());
 
@@ -59,8 +57,6 @@ public class DebuggingSolverInformation {
   private static final Map<Solvers, Set<Formula>> globalTerms =
       Map.of(
           Solvers.CVC4,
-          ConcurrentHashMap.newKeySet(),
-          Solvers.CVC5,
           ConcurrentHashMap.newKeySet(),
           Solvers.YICES2,
           ConcurrentHashMap.newKeySet());

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5NativeAPITest.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5NativeAPITest.java
@@ -202,7 +202,7 @@ public class CVC5NativeAPITest {
             () -> termManager.mkFloatingPoint(8, 24, bvOneFourth));
     assertThat(e.toString())
         .contains(
-            "invalid argument '((_ int2bv 32) (to_int (/ 1 4)))' for 'val', expected bit-vector"
+            "invalid argument '((_ int_to_bv 32) (to_int (/ 1 4)))' for 'val', expected bit-vector"
                 + " value");
   }
 
@@ -950,7 +950,7 @@ public class CVC5NativeAPITest {
 
     Term quantElim = solver.getQuantifierElimination(assertion);
 
-    assertThat(quantElim.toString()).isEqualTo("(or (= #b01 (bvneg x_bv)) (= #b01 x_bv))");
+    assertThat(quantElim.toString()).isEqualTo("(or (= #b01 (bvneg x_bv)) (= x_bv #b01))");
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
@@ -196,11 +196,7 @@ public final class CVC5SolverContext extends AbstractSolverContext {
 
   @Override
   public String getVersion() {
-    String version = solver.getInfo("version");
-    if (version.startsWith("\"") && version.endsWith("\"")) {
-      version = version.substring(1, version.length() - 1);
-    }
-    return "CVC5 " + version;
+    return "CVC5 " + solver.getVersion();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
@@ -207,8 +207,8 @@ public final class CVC5SolverContext extends AbstractSolverContext {
   public void close() {
     if (creator != null) {
       closed = true;
-      termManager.deletePointer();
       solver.deletePointer();
+      termManager.deletePointer();
       creator = null;
     }
   }

--- a/src/org/sosy_lab/java_smt/test/DebugModeTest.java
+++ b/src/org/sosy_lab/java_smt/test/DebugModeTest.java
@@ -149,7 +149,7 @@ public class DebugModeTest extends SolverBasedTest0.ParameterizedSolverBasedTest
       BooleanFormula formula = hardProblem.generate(DEFAULT_PROBLEM_SIZE);
 
       // We expect debug mode to throw an exception for all solvers, except CVC4, CVC5 and Yices
-      if (!List.of(Solvers.CVC4, Solvers.CVC5, Solvers.YICES2).contains(solverToUse())) {
+      if (!List.of(Solvers.CVC4, Solvers.YICES2).contains(solverToUse())) {
         assertThrows(IllegalArgumentException.class, () -> checkFormulaInDebugContext(formula));
       } else {
         checkFormulaInDebugContext(formula);
@@ -180,7 +180,7 @@ public class DebugModeTest extends SolverBasedTest0.ParameterizedSolverBasedTest
               "id", FormulaType.IntegerType, ImmutableList.of(FormulaType.IntegerType));
 
       // We expect debug mode to throw an exception for all solvers, except Princess, CVC4 and Yices
-      if (!List.of(Solvers.PRINCESS, Solvers.CVC5, Solvers.YICES2).contains(solverToUse())) {
+      if (!List.of(Solvers.PRINCESS, Solvers.YICES2).contains(solverToUse())) {
         assertThrows(IllegalArgumentException.class, () -> checkDeclarationInDebugContext(id));
       } else {
         checkDeclarationInDebugContext(id);

--- a/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverConcurrencyTest.java
@@ -124,11 +124,6 @@ public class SolverConcurrencyTest {
           .that(solver)
           .isNotEqualTo(Solvers.MATHSAT5);
     }
-
-    assume()
-        .withMessage("Solver does not support concurrency without concurrent context.")
-        .that(solver)
-        .isNotEqualTo(Solvers.CVC5);
   }
 
   private void requireConcurrentMultipleStackSupport() {
@@ -303,7 +298,7 @@ public class SolverConcurrencyTest {
     assume()
         .withMessage("Solver does not support translation of formulas")
         .that(solver)
-        .isNoneOf(Solvers.CVC4, Solvers.PRINCESS);
+        .isNoneOf(Solvers.CVC4, Solvers.CVC5, Solvers.PRINCESS);
 
     ConcurrentLinkedQueue<ContextAndFormula> contextAndFormulaList = new ConcurrentLinkedQueue<>();
 
@@ -540,7 +535,7 @@ public class SolverConcurrencyTest {
     assume()
         .withMessage("Solver does not support translation of formulas")
         .that(solver)
-        .isNoneOf(Solvers.CVC4, Solvers.PRINCESS);
+        .isNoneOf(Solvers.CVC4, Solvers.CVC5, Solvers.PRINCESS);
 
     // This is fine! We might access this more than once at a time,
     // but that gives only access to the bucket, which is threadsafe.

--- a/src/org/sosy_lab/java_smt/test/SolverThreadLocalityTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverThreadLocalityTest.java
@@ -350,7 +350,8 @@ public class SolverThreadLocalityTest extends SolverBasedTest0.ParameterizedSolv
             Solvers.Z3,
             Solvers.PRINCESS,
             Solvers.BOOLECTOR,
-            Solvers.BITWUZLA);
+            Solvers.BITWUZLA,
+            Solvers.CVC5);
 
     // FIXME: This test tries to use a formula that was created in a different context. We expect
     //  this test to fail for most solvers, but there should be a unique error message.

--- a/src/org/sosy_lab/java_smt/test/TimeoutTest.java
+++ b/src/org/sosy_lab/java_smt/test/TimeoutTest.java
@@ -65,7 +65,10 @@ public class TimeoutTest extends SolverBasedTest0 {
 
   @Before
   public void setUp() {
-    // FIXME CVC5 has interruptions, but crashes on Windows, probably due to concurrency issues
+    // FIXME CVC5 does not support interruption and will segfault once the timeout is reached
+    //   The issue here seems to be that CVC5SolverContext.close() will free the C++ objects while
+    //   the solver is still running. We could consider finding a work-around for this, or maybe
+    //   ask the developers for a way to interrupt the solver.
     // TODO Add interruption for Princess
     assume()
         .withMessage(solverToUse() + " does not support interruption")


### PR DESCRIPTION
Hello everyone,
the CVC5 developers now seem to have fixed their concurrency issues, and all references to the thread-local NodeManager have now been removed, see [here](https://github.com/cvc5/cvc5/pull/11816). They have also implemented a fix for a separate race condition in the JNI bindings that was reported by us [here](https://github.com/cvc5/cvc5/issues/10256). This means we should now be able to pass CVC5 terms and solver instances from one thread to another without running into any issues.

In this PR we updates the binaries to the latest daily release that includes the fixes. This will close #310 and #347. Issue #469 may also be fixed by it, but we should look at this separately.