### PR TITLE
Add Prover Based ShutdownManager

### DIFF
--- a/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
@@ -15,6 +15,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
+import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
 /**
@@ -202,4 +204,18 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
   default boolean registerUserPropagator(UserPropagator propagator) {
     return false;
   }
+
+  /**
+   * Returns the {@link ShutdownManager} registered for this {@link ProverEnvironment}. It is
+   * guaranteed to be a child of the {@link ShutdownNotifier} given to the creating {@link
+   * SolverContext}, resulting in shutdown when the {@link SolverContext}s notifier is shutting
+   * down. The notifier returned here can be shut down independently of the creating contexts
+   * notifier.
+   *
+   * @return a {@link ShutdownManager} who is the child of the {@link ShutdownNotifier} used in the
+   *     creating {@link SolverContext}, that can be used to shut down only this {@link
+   *     ProverEnvironment}.
+   * @throws UnsupportedOperationException if the solver does not support prover specific shutdown.
+   */
+  ShutdownManager getShutdownManagerForProver() throws UnsupportedOperationException;
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -22,6 +22,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
+import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Evaluator;
@@ -47,7 +49,11 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
 
   private static final String TEMPLATE = "Please set the prover option %s.";
 
-  protected AbstractProver(Set<ProverOptions> pOptions) {
+  // Do we even need this?
+  private final ShutdownNotifier contextShutdownNotifier;
+  protected final ShutdownManager proverShutdownManager;
+
+  protected AbstractProver(ShutdownNotifier pShutdownNotifier, Set<ProverOptions> pOptions) {
     generateModels = pOptions.contains(ProverOptions.GENERATE_MODELS);
     generateAllSat = pOptions.contains(ProverOptions.GENERATE_ALL_SAT);
     generateUnsatCores = pOptions.contains(ProverOptions.GENERATE_UNSAT_CORE);
@@ -56,6 +62,9 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     enableSL = pOptions.contains(ProverOptions.ENABLE_SEPARATION_LOGIC);
 
     assertedFormulas.add(LinkedHashMultimap.create());
+
+    contextShutdownNotifier = pShutdownNotifier;
+    proverShutdownManager = ShutdownManager.createWithParent(contextShutdownNotifier);
   }
 
   protected final void checkGenerateModels() {
@@ -157,5 +166,18 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     assertedFormulas.clear();
     closeAllEvaluators();
     closed = true;
+  }
+
+  @Override
+  public ShutdownManager getShutdownManagerForProver() throws UnsupportedOperationException {
+    return getShutdownManagerForProverImpl();
+  }
+
+  protected ShutdownManager getShutdownManagerForProverImpl() throws UnsupportedOperationException {
+    // Override this with the prover specific ShutdownManagers notifier for supporting solvers.
+    // The solver should then use the prover specific ShutdownManagers notifier for stopping
+    // instead of the contexts' notifier!
+    throw new UnsupportedOperationException(
+        "The chosen solver does not support isolated prover " + "shutdown");
   }
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProverWithAllSat.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProverWithAllSat.java
@@ -28,16 +28,14 @@ import org.sosy_lab.java_smt.api.SolverException;
  */
 public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
 
-  protected final ShutdownNotifier shutdownNotifier;
   private final BooleanFormulaManager bmgr;
 
   protected AbstractProverWithAllSat(
       Set<ProverOptions> pOptions,
       BooleanFormulaManager pBmgr,
       ShutdownNotifier pShutdownNotifier) {
-    super(pOptions);
+    super(pShutdownNotifier, pOptions);
     bmgr = pBmgr;
-    shutdownNotifier = pShutdownNotifier;
   }
 
   @Override
@@ -68,7 +66,7 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
       AllSatCallback<R> callback, List<BooleanFormula> importantPredicates)
       throws SolverException, InterruptedException {
     while (!isUnsat()) {
-      shutdownNotifier.shutdownIfNecessary();
+      proverShutdownManager.getNotifier().shutdownIfNecessary();
 
       ImmutableList.Builder<BooleanFormula> valuesOfModel = ImmutableList.builder();
       try (Evaluator evaluator = getEvaluatorWithoutChecks()) {
@@ -88,11 +86,11 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
 
       final ImmutableList<BooleanFormula> values = valuesOfModel.build();
       callback.apply(values);
-      shutdownNotifier.shutdownIfNecessary();
+      proverShutdownManager.getNotifier().shutdownIfNecessary();
 
       BooleanFormula negatedModel = bmgr.not(bmgr.and(values));
       addConstraint(negatedModel);
-      shutdownNotifier.shutdownIfNecessary();
+      proverShutdownManager.getNotifier().shutdownIfNecessary();
     }
   }
 
@@ -113,7 +111,7 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
       Deque<BooleanFormula> valuesOfModel)
       throws SolverException, InterruptedException {
 
-    shutdownNotifier.shutdownIfNecessary();
+    proverShutdownManager.getNotifier().shutdownIfNecessary();
 
     if (isUnsat()) {
       return;

--- a/src/org/sosy_lab/java_smt/basicimpl/withAssumptionsWrapper/BasicProverWithAssumptionsWrapper.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/withAssumptionsWrapper/BasicProverWithAssumptionsWrapper.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Model;
@@ -127,5 +128,10 @@ public class BasicProverWithAssumptionsWrapper<T, P extends BasicProverEnvironme
       throws InterruptedException, SolverException {
     clearAssumptions();
     return delegate.allSat(pCallback, pImportant);
+  }
+
+  @Override
+  public ShutdownManager getShutdownManagerForProver() throws UnsupportedOperationException {
+    return delegate.getShutdownManagerForProver();
   }
 }

--- a/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingBasicProverEnvironment.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Model;
@@ -27,6 +28,11 @@ class DebuggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
       BasicProverEnvironment<T> pDelegate, DebuggingAssertions pDebugging) {
     delegate = checkNotNull(pDelegate);
     debugging = pDebugging;
+  }
+
+  @Override
+  public ShutdownManager getShutdownManagerForProver() throws UnsupportedOperationException {
+    return delegate.getShutdownManagerForProver();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingOptimizationProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingOptimizationProverEnvironment.java
@@ -9,6 +9,7 @@
 package org.sosy_lab.java_smt.delegate.debugging;
 
 import java.util.Optional;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.OptimizationProverEnvironment;
@@ -24,6 +25,11 @@ public class DebuggingOptimizationProverEnvironment extends DebuggingBasicProver
     super(pDelegate, pDebugging);
     delegate = pDelegate;
     debugging = pDebugging;
+  }
+
+  @Override
+  public ShutdownManager getShutdownManagerForProver() throws UnsupportedOperationException {
+    return delegate.getShutdownManagerForProver();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/delegate/logging/LoggingBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/logging/LoggingBasicProverEnvironment.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.log.LogManager;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -36,6 +37,11 @@ class LoggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   LoggingBasicProverEnvironment(BasicProverEnvironment<T> pWrapped, LogManager pLogger) {
     wrapped = checkNotNull(pWrapped);
     logger = checkNotNull(pLogger);
+  }
+
+  @Override
+  public ShutdownManager getShutdownManagerForProver() throws UnsupportedOperationException {
+    return wrapped.getShutdownManagerForProver();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsBasicProverEnvironment.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Model;
@@ -33,6 +34,11 @@ class StatisticsBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
     unsatTimer = stats.unsat.getNewTimer();
     allSatTimer = stats.allSat.getNewTimer();
     stats.provers.getAndIncrement();
+  }
+
+  @Override
+  public ShutdownManager getShutdownManagerForProver() throws UnsupportedOperationException {
+    return delegate.getShutdownManagerForProver();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironment.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Model;
@@ -29,6 +30,11 @@ class SynchronizedBasicProverEnvironment<T> implements BasicProverEnvironment<T>
   SynchronizedBasicProverEnvironment(BasicProverEnvironment<T> pDelegate, SolverContext pSync) {
     delegate = checkNotNull(pDelegate);
     sync = checkNotNull(pSync);
+  }
+
+  @Override
+  public ShutdownManager getShutdownManagerForProver() throws UnsupportedOperationException {
+    return delegate.getShutdownManagerForProver();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironmentWithContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironmentWithContext.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FormulaManager;
@@ -142,6 +143,11 @@ class SynchronizedBasicProverEnvironmentWithContext<T> implements BasicProverEnv
     synchronized (sync) {
       return delegate.allSat(callback, translate(pImportant, manager, otherManager));
     }
+  }
+
+  @Override
+  public ShutdownManager getShutdownManagerForProver() throws UnsupportedOperationException {
+    return delegate.getShutdownManagerForProver();
   }
 
   private class AllSatCallbackWithContext<R> implements AllSatCallback<R> {

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedInterpolatingProverEnvironmentWithContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedInterpolatingProverEnvironmentWithContext.java
@@ -12,6 +12,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
 import java.util.List;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FormulaManager;
 import org.sosy_lab.java_smt.api.InterpolatingProverEnvironment;
@@ -31,6 +32,11 @@ class SynchronizedInterpolatingProverEnvironmentWithContext<T>
       FormulaManager pOtherManager) {
     super(pDelegate, pSync, pManager, pOtherManager);
     delegate = checkNotNull(pDelegate);
+  }
+
+  @Override
+  public ShutdownManager getShutdownManagerForProver() throws UnsupportedOperationException {
+    return delegate.getShutdownManagerForProver();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaTheoremProver.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Model;
@@ -38,7 +39,10 @@ class BitwuzlaTheoremProver extends AbstractProverWithAllSat<Void> implements Pr
       new Terminator() {
         @Override
         public boolean terminate() {
-          return shutdownNotifier.shouldShutdown(); // shutdownNotifer is defined in the superclass
+          return proverShutdownManager
+              .getNotifier()
+              .shouldShutdown(); // shutdownNotifer is defined in the
+          // superclass
         }
       };
   private final Bitwuzla env;
@@ -119,7 +123,8 @@ class BitwuzlaTheoremProver extends AbstractProverWithAllSat<Void> implements Pr
       return false;
     } else if (resultValue == Result.UNSAT) {
       return true;
-    } else if (resultValue == Result.UNKNOWN && shutdownNotifier.shouldShutdown()) {
+    } else if (resultValue == Result.UNKNOWN
+        && proverShutdownManager.getNotifier().shouldShutdown()) {
       throw new InterruptedException();
     } else {
       throw new SolverException("Bitwuzla returned UNKNOWN.");
@@ -244,6 +249,11 @@ class BitwuzlaTheoremProver extends AbstractProverWithAllSat<Void> implements Pr
             this,
             creator,
             Collections2.transform(getAssertedFormulas(), creator::extractInfo)));
+  }
+
+  @Override
+  protected ShutdownManager getShutdownManagerForProverImpl() throws UnsupportedOperationException {
+    return proverShutdownManager;
   }
 
   public boolean isClosed() {

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorAbstractProver.java
@@ -49,7 +49,7 @@ abstract class BoolectorAbstractProver<T> extends AbstractProverWithAllSat<T> {
     this.manager = manager;
     this.creator = creator;
     this.btor = btor;
-    terminationCallback = shutdownNotifier::shouldShutdown;
+    terminationCallback = proverShutdownManager.getNotifier()::shouldShutdown;
     terminationCallbackHelper = addTerminationCallback();
 
     isAnyStackAlive = pIsAnyStackAlive;

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -202,11 +203,12 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
     }
 
     Result result;
-    try (ShutdownHook hook = new ShutdownHook(shutdownNotifier, smtEngine::interrupt)) {
-      shutdownNotifier.shutdownIfNecessary();
+    try (ShutdownHook hook =
+        new ShutdownHook(proverShutdownManager.getNotifier(), smtEngine::interrupt)) {
+      proverShutdownManager.getNotifier().shutdownIfNecessary();
       result = smtEngine.checkSat();
     }
-    shutdownNotifier.shutdownIfNecessary();
+    proverShutdownManager.getNotifier().shutdownIfNecessary();
     return convertSatResult(result);
   }
 
@@ -259,5 +261,10 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
       exprManager.delete();
     }
     super.close();
+  }
+
+  @Override
+  protected ShutdownManager getShutdownManagerForProverImpl() throws UnsupportedOperationException {
+    return proverShutdownManager;
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -203,7 +203,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
 
     /* Shutdown currently not possible in CVC5. */
     Result result = solver.checkSat();
-    shutdownNotifier.shutdownIfNecessary();
+    proverShutdownManager.getNotifier().shutdownIfNecessary();
     return convertSatResult(result);
   }
 
@@ -251,4 +251,10 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
     }
     super.close();
   }
+
+  /* TODO: revisit once CVC5 supports interruption
+  @Override
+  protected ShutdownManager getShutdownManagerForProverImpl() throws UnsupportedOperationException {
+    return proverShutdownManager;
+  }*/
 }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
@@ -46,7 +46,6 @@ import org.sosy_lab.java_smt.api.OptimizationProverEnvironment;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.basicimpl.AbstractNumeralFormulaManager.NonLinearArithmetic;
 import org.sosy_lab.java_smt.basicimpl.AbstractSolverContext;
-import org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.TerminationCallback;
 
 public final class Mathsat5SolverContext extends AbstractSolverContext {
 
@@ -96,7 +95,6 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
   private final long randomSeed;
 
   private final ShutdownNotifier shutdownNotifier;
-  private final TerminationCallback terminationTest;
   private final Mathsat5FormulaCreator creator;
   private boolean closed = false;
 
@@ -120,12 +118,6 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
     this.randomSeed = randomSeed;
     this.shutdownNotifier = shutdownNotifier;
     this.creator = creator;
-
-    terminationTest =
-        () -> {
-          shutdownNotifier.shutdownIfNecessary();
-          return false;
-        };
   }
 
   private static void logLicenseInfo(LogManager logger) {
@@ -297,15 +289,6 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
       msat_destroy_env(creator.getEnv());
       msat_destroy_config(mathsatConfig);
     }
-  }
-
-  /**
-   * Get a termination callback for the current context. The callback can be registered upfront,
-   * i.e., before calling a possibly expensive computation in the solver to allow a proper shutdown.
-   */
-  TerminationCallback getTerminationTest() {
-    Preconditions.checkState(!closed, "solver context is already closed");
-    return terminationTest;
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
@@ -52,7 +52,6 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
   protected final FormulaCreator<Term, Sort, Script, FunctionSymbol> creator;
   protected final SmtInterpolFormulaManager mgr;
   protected final Deque<PersistentMap<String, BooleanFormula>> annotatedTerms = new ArrayDeque<>();
-  protected final ShutdownNotifier shutdownNotifier;
 
   private static final String PREFIX = "term_"; // for termnames
   private static final UniqueIdGenerator termIdGenerator =
@@ -63,11 +62,10 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
       Script pEnv,
       Set<ProverOptions> options,
       ShutdownNotifier pShutdownNotifier) {
-    super(options);
+    super(pShutdownNotifier, options);
     mgr = pMgr;
     creator = pMgr.getFormulaCreator();
     env = pEnv;
-    shutdownNotifier = pShutdownNotifier;
     annotatedTerms.add(PathCopyingPersistentTreeMap.of());
   }
 
@@ -109,7 +107,7 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
     // by using a shutdown listener. However, SmtInterpol resets the
     // mStopEngine flag in DPLLEngine before starting to solve,
     // so we check here, too.
-    shutdownNotifier.shutdownIfNecessary();
+    proverShutdownManager.getNotifier().shutdownIfNecessary();
 
     LBool result = env.checkSat();
     switch (result) {
@@ -127,7 +125,9 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
             // SMTInterpol catches OOM, but we want to have it thrown.
             throw new OutOfMemoryError("Out of memory during SMTInterpol operation");
           case CANCELLED:
-            shutdownNotifier.shutdownIfNecessary(); // expected if we requested termination
+            proverShutdownManager
+                .getNotifier()
+                .shutdownIfNecessary(); // expected if we requested termination
             throw new SMTLIBException("checkSat returned UNKNOWN with unexpected reason " + reason);
           default:
             throw new SMTLIBException("checkSat returned UNKNOWN with unexpected reason " + reason);
@@ -244,10 +244,17 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
     // by using a shutdown listener. However, SmtInterpol resets the
     // mStopEngine flag in DPLLEngine before starting to solve,
     // so we check here, too.
-    shutdownNotifier.shutdownIfNecessary();
+    proverShutdownManager.getNotifier().shutdownIfNecessary();
     for (Term[] model : env.checkAllsat(importantTerms)) {
       callback.apply(Collections3.transformedImmutableListCopy(model, creator::encapsulateBoolean));
     }
     return callback.getResult();
   }
+
+  /* TODO: the shutdownNotifier is bound to the Script. But this is done in the context. It seems
+       like it might be re-usable after a shutdown.
+  @Override
+  protected ShutdownManager getShutdownManagerForProverImpl() throws UnsupportedOperationException {
+    return proverShutdownManager;
+  }*/
 }

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolInterpolatingProver.java
@@ -100,7 +100,7 @@ class SmtInterpolInterpolatingProver extends SmtInterpolAbstractProver<String>
       }
     } catch (SMTLIBException e) {
       if ("Timeout exceeded".equals(e.getMessage())) {
-        shutdownNotifier.shutdownIfNecessary();
+        proverShutdownManager.getNotifier().shutdownIfNecessary();
       }
       throw new AssertionError(e);
     }

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2TheoremProver.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
@@ -124,9 +125,13 @@ class Yices2TheoremProver extends AbstractProverWithAllSat<Void> implements Prov
       int[] allConstraints = getAllConstraints();
       unsat =
           !yices_check_sat_with_assumptions(
-              curEnv, DEFAULT_PARAMS, allConstraints.length, allConstraints, shutdownNotifier);
+              curEnv,
+              DEFAULT_PARAMS,
+              allConstraints.length,
+              allConstraints,
+              proverShutdownManager.getNotifier());
     } else {
-      unsat = !yices_check_sat(curEnv, DEFAULT_PARAMS, shutdownNotifier);
+      unsat = !yices_check_sat(curEnv, DEFAULT_PARAMS, proverShutdownManager.getNotifier());
       if (unsat && stackSizeToUnsat == Integer.MAX_VALUE) {
         stackSizeToUnsat = size();
         // If sat check is UNSAT and stackSizeToUnsat waS not already set,
@@ -147,7 +152,11 @@ class Yices2TheoremProver extends AbstractProverWithAllSat<Void> implements Prov
     Preconditions.checkState(!closed);
     // TODO handle BooleanFormulaCollection / check for literals
     return !yices_check_sat_with_assumptions(
-        curEnv, DEFAULT_PARAMS, pAssumptions.size(), uncapsulate(pAssumptions), shutdownNotifier);
+        curEnv,
+        DEFAULT_PARAMS,
+        pAssumptions.size(),
+        uncapsulate(pAssumptions),
+        proverShutdownManager.getNotifier());
   }
 
   @SuppressWarnings("resource")
@@ -208,5 +217,10 @@ class Yices2TheoremProver extends AbstractProverWithAllSat<Void> implements Prov
       stackSizeToUnsat = Integer.MAX_VALUE;
     }
     super.close();
+  }
+
+  @Override
+  protected ShutdownManager getShutdownManagerForProverImpl() throws UnsupportedOperationException {
+    return proverShutdownManager;
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.common.UniqueIdGenerator;
 import org.sosy_lab.common.collect.PathCopyingPersistentTreeMap;
@@ -260,5 +261,10 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
     } catch (Z3Exception e) {
       throw creator.handleZ3Exception(e);
     }
+  }
+
+  @Override
+  protected ShutdownManager getShutdownManagerForProverImpl() throws UnsupportedOperationException {
+    return proverShutdownManager;
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
@@ -45,7 +45,7 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
     Native.solverIncRef(z3context, z3solver);
 
     interruptListener = reason -> Native.solverInterrupt(z3context, z3solver);
-    shutdownNotifier.register(interruptListener);
+    proverShutdownManager.getNotifier().register(interruptListener);
 
     long z3params = Native.mkParams(z3context);
     Native.paramsIncRef(z3context, z3params);
@@ -192,7 +192,7 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
         propagator.close();
         propagator = null;
       }
-      shutdownNotifier.unregister(interruptListener);
+      proverShutdownManager.getNotifier().unregister(interruptListener);
     }
     super.close();
   }

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -386,6 +386,17 @@ public abstract class SolverBasedTest0 {
         .isEqualTo(Solvers.Z3);
   }
 
+  /** Skip test if the solvers prover can not be shut down without also stopping the context. */
+  protected final void requireIsolatedProverShutdown() {
+    assume()
+        .withMessage(
+            "Solver %s does not support shutdown of provers without shutting down the "
+                + "context as well",
+            solverToUse())
+        .that(solverToUse())
+        .isNoneOf(Solvers.CVC5, Solvers.BOOLECTOR, Solvers.SMTINTERPOL);
+  }
+
   /**
    * Use this for checking assertions about BooleanFormulas with Truth: <code>
    * assertThatFormula(formula).is...()</code>.

--- a/src/org/sosy_lab/java_smt/test/TimeoutTest.java
+++ b/src/org/sosy_lab/java_smt/test/TimeoutTest.java
@@ -8,6 +8,7 @@
 
 package org.sosy_lab.java_smt.test;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.TruthJUnit.assume;
 import static org.junit.Assert.assertThrows;
 
@@ -24,6 +25,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.api.Tactic;
 import org.sosy_lab.java_smt.solvers.opensmt.Logics;
 
@@ -90,43 +92,97 @@ public class TimeoutTest extends SolverBasedTest0 {
   @Test(timeout = TIMEOUT_MILLISECONDS)
   public void testProverTimeoutInt() throws InterruptedException {
     requireIntegers();
-    testBasicProverTimeoutInt(() -> context.newProverEnvironment());
+    testBasicContextTimeoutInt(() -> context.newProverEnvironment());
   }
 
   @Test(timeout = TIMEOUT_MILLISECONDS)
   public void testProverTimeoutBv() throws InterruptedException {
     requireBitvectors();
+    testBasicContextTimeoutBv(() -> context.newProverEnvironment());
+  }
+
+  // Test shutdown of prover specific shutdown manager. The context should still be usable!
+  @Test(timeout = TIMEOUT_MILLISECONDS)
+  public void testProverInterruptWithSubsequentNewProverUsageBv()
+      throws InterruptedException, SolverException {
+    requireBitvectors();
+    requireIsolatedProverShutdown();
+
     testBasicProverTimeoutBv(() -> context.newProverEnvironment());
+    assertThat(shutdownManager.getNotifier().shouldShutdown()).isFalse();
+
+    HardBitvectorFormulaGenerator gen = new HardBitvectorFormulaGenerator(bvmgr, bmgr);
+    try (BasicProverEnvironment<?> pe = context.newProverEnvironment()) {
+      pe.push(gen.generate(8));
+      assertThat(pe.isUnsat()).isTrue();
+    }
+  }
+
+  // Test shutdown of prover specific shutdown manager. The context should still be usable!
+  @Test(timeout = TIMEOUT_MILLISECONDS)
+  public void testProverInterruptWithSubsequentNewProverUsageInt()
+      throws InterruptedException, SolverException {
+    requireIntegers();
+    requireIsolatedProverShutdown();
+
+    testBasicProverTimeoutInt(() -> context.newProverEnvironment());
+    assertThat(shutdownManager.getNotifier().shouldShutdown()).isFalse();
+
+    HardIntegerFormulaGenerator gen = new HardIntegerFormulaGenerator(imgr, bmgr);
+    try (BasicProverEnvironment<?> pe = context.newProverEnvironment()) {
+      pe.push(gen.generate(8));
+      assertThat(pe.isUnsat()).isTrue();
+    }
   }
 
   @Test(timeout = TIMEOUT_MILLISECONDS)
   public void testInterpolationProverTimeout() throws InterruptedException {
     requireInterpolation();
     requireIntegers();
-    testBasicProverTimeoutInt(() -> context.newProverEnvironmentWithInterpolation());
+    testBasicContextTimeoutInt(() -> context.newProverEnvironmentWithInterpolation());
   }
 
   @Test(timeout = TIMEOUT_MILLISECONDS)
   public void testOptimizationProverTimeout() throws InterruptedException {
     requireOptimization();
     requireIntegers();
-    testBasicProverTimeoutInt(() -> context.newOptimizationProverEnvironment());
+    testBasicContextTimeoutInt(() -> context.newOptimizationProverEnvironment());
   }
 
+  /** Shuts down the shutdown manager of the context. */
+  private void testBasicContextTimeoutInt(Supplier<BasicProverEnvironment<?>> proverConstructor)
+      throws InterruptedException {
+    HardIntegerFormulaGenerator gen = new HardIntegerFormulaGenerator(imgr, bmgr);
+    testBasicContextBasedTimeout(proverConstructor, gen.generate(200));
+  }
+
+  /** Shuts down the shutdown manager of the context. */
+  private void testBasicContextTimeoutBv(Supplier<BasicProverEnvironment<?>> proverConstructor)
+      throws InterruptedException {
+    HardBitvectorFormulaGenerator gen = new HardBitvectorFormulaGenerator(bvmgr, bmgr);
+    testBasicContextBasedTimeout(proverConstructor, gen.generate(200));
+  }
+
+  /**
+   * Shuts down the shutdown manager of the prover. Throws an exception for non-supporting solvers.
+   */
   private void testBasicProverTimeoutInt(Supplier<BasicProverEnvironment<?>> proverConstructor)
       throws InterruptedException {
     HardIntegerFormulaGenerator gen = new HardIntegerFormulaGenerator(imgr, bmgr);
-    testBasicProverTimeout(proverConstructor, gen.generate(200));
+    testBasicProverBasedTimeout(proverConstructor, gen.generate(200));
   }
 
+  /**
+   * Shuts down the shutdown manager of the prover. Throws an exception for non-supporting solvers.
+   */
   private void testBasicProverTimeoutBv(Supplier<BasicProverEnvironment<?>> proverConstructor)
       throws InterruptedException {
     HardBitvectorFormulaGenerator gen = new HardBitvectorFormulaGenerator(bvmgr, bmgr);
-    testBasicProverTimeout(proverConstructor, gen.generate(200));
+    testBasicProverBasedTimeout(proverConstructor, gen.generate(200));
   }
 
   @SuppressWarnings("CheckReturnValue")
-  private void testBasicProverTimeout(
+  private void testBasicContextBasedTimeout(
       Supplier<BasicProverEnvironment<?>> proverConstructor, BooleanFormula instance)
       throws InterruptedException {
     Thread t =
@@ -141,6 +197,27 @@ public class TimeoutTest extends SolverBasedTest0 {
             });
 
     try (BasicProverEnvironment<?> pe = proverConstructor.get()) {
+      pe.push(instance);
+      t.start();
+      assertThrows(InterruptedException.class, pe::isUnsat);
+    }
+  }
+
+  private void testBasicProverBasedTimeout(
+      Supplier<BasicProverEnvironment<?>> proverConstructor, BooleanFormula instance)
+      throws InterruptedException {
+
+    try (BasicProverEnvironment<?> pe = proverConstructor.get()) {
+      Thread t =
+          new Thread(
+              () -> {
+                try {
+                  Thread.sleep(delay);
+                  pe.getShutdownManagerForProver().requestShutdown("Shutdown Request");
+                } catch (InterruptedException exception) {
+                  throw new UnsupportedOperationException("Unexpected interrupt", exception);
+                }
+              });
       pe.push(instance);
       t.start();
       assertThrows(InterruptedException.class, pe::isUnsat);


### PR DESCRIPTION
Most solvers allow either re-usable shutdown or we use shared environments that are created per prover, making them isolated enough to be shut down without stopping the context.

This PR adds a controlled way of shutting down only a single prover with the manager returned by our API IFF it is supported by the solver. These prover shutdown managers are all children of the context given shutdown manager.