### PR TITLE
Cleanup usage of bound variables

### DIFF
--- a/src/org/sosy_lab/java_smt/api/visitors/BooleanFormulaTransformationVisitor.java
+++ b/src/org/sosy_lab/java_smt/api/visitors/BooleanFormulaTransformationVisitor.java
@@ -38,11 +38,6 @@ public abstract class BooleanFormulaTransformationVisitor
   }
 
   @Override
-  public BooleanFormula visitBoundVar(BooleanFormula var, int deBruijnIdx) {
-    return var;
-  }
-
-  @Override
   public BooleanFormula visitAtom(BooleanFormula pAtom, FunctionDeclaration<BooleanFormula> decl) {
     return pAtom;
   }

--- a/src/org/sosy_lab/java_smt/api/visitors/BooleanFormulaVisitor.java
+++ b/src/org/sosy_lab/java_smt/api/visitors/BooleanFormulaVisitor.java
@@ -41,6 +41,7 @@ public interface BooleanFormulaVisitor<R> {
    * FormulaVisitor#visitQuantifier}.
    */
   @Deprecated(since = "2025.07, because bound variables are never created or used in the visitor")
+  @SuppressWarnings("unused")
   default R visitBoundVar(BooleanFormula var, int deBruijnIdx) {
     throw new UnsupportedOperationException(
         "Bound variables are no longer explicitly visited in JavaSMT. "

--- a/src/org/sosy_lab/java_smt/api/visitors/BooleanFormulaVisitor.java
+++ b/src/org/sosy_lab/java_smt/api/visitors/BooleanFormulaVisitor.java
@@ -31,8 +31,22 @@ public interface BooleanFormulaVisitor<R> {
    */
   R visitConstant(boolean value);
 
-  /** Visit a boolean variable bound by a quantifier. */
-  R visitBoundVar(BooleanFormula var, int deBruijnIdx);
+  /**
+   * Visit a boolean variable bound by a quantifier.
+   *
+   * <p>Since JavaSMT no longer explicitly visits bound variables, and never has done so for most
+   * solvers, this method will be removed in the future. Bound variables are available when visiting
+   * a quantified formula, and can be accessed in {@link #visitQuantifier}. When entering the body
+   * of a quantified formula, bound variables are seen as free variables, as documented in {@link
+   * FormulaVisitor#visitQuantifier}.
+   */
+  @Deprecated(since = "2025.07, because bound variables are never created or used in the visitor")
+  default R visitBoundVar(BooleanFormula var, int deBruijnIdx) {
+    throw new UnsupportedOperationException(
+        "Bound variables are no longer explicitly visited in JavaSMT. "
+            + "Use a combination of 'visitQuantifier' (for the whole quantified formula) and "
+            + "'visitAtom' (for variables in the body) instead.");
+  }
 
   /**
    * Visit a NOT-expression.

--- a/src/org/sosy_lab/java_smt/api/visitors/DefaultBooleanFormulaVisitor.java
+++ b/src/org/sosy_lab/java_smt/api/visitors/DefaultBooleanFormulaVisitor.java
@@ -29,11 +29,6 @@ public abstract class DefaultBooleanFormulaVisitor<R> implements BooleanFormulaV
   }
 
   @Override
-  public R visitBoundVar(BooleanFormula var, int deBruijnIdx) {
-    return visitDefault();
-  }
-
-  @Override
   public R visitAtom(BooleanFormula pAtom, FunctionDeclaration<BooleanFormula> decl) {
     return visitDefault();
   }

--- a/src/org/sosy_lab/java_smt/api/visitors/DefaultFormulaVisitor.java
+++ b/src/org/sosy_lab/java_smt/api/visitors/DefaultFormulaVisitor.java
@@ -30,11 +30,6 @@ public abstract class DefaultFormulaVisitor<R> implements FormulaVisitor<R> {
   }
 
   @Override
-  public R visitBoundVariable(Formula f, int deBruijnIdx) {
-    return visitDefault(f);
-  }
-
-  @Override
   public R visitConstant(Formula f, Object value) {
     return visitDefault(f);
   }

--- a/src/org/sosy_lab/java_smt/api/visitors/FormulaTransformationVisitor.java
+++ b/src/org/sosy_lab/java_smt/api/visitors/FormulaTransformationVisitor.java
@@ -34,11 +34,6 @@ public abstract class FormulaTransformationVisitor implements FormulaVisitor<For
   }
 
   @Override
-  public Formula visitBoundVariable(Formula f, int deBruijnIdx) {
-    return f;
-  }
-
-  @Override
   public Formula visitConstant(Formula f, Object value) {
     return f;
   }

--- a/src/org/sosy_lab/java_smt/api/visitors/FormulaVisitor.java
+++ b/src/org/sosy_lab/java_smt/api/visitors/FormulaVisitor.java
@@ -38,11 +38,22 @@ public interface FormulaVisitor<R> {
    * Visit a variable bound by a quantifier. The variable can have any sort (both boolean and
    * non-boolean).
    *
+   * <p>This method is deprecated because bound variables are no longer explicitly visited. When
+   * entering a quantified formula, bound variables are seen as free variables, as documented in
+   * {@link #visitQuantifier}. When entering the body of a quantified formula, bound variables are
+   * replaced by free variables, and are visited with {@link #visitFreeVariable}.
+   *
    * @param f Formula representing the variable.
    * @param deBruijnIdx de-Bruijn index of the bound variable, which can be used to find the
    *     matching quantifier.
    */
-  R visitBoundVariable(Formula f, int deBruijnIdx);
+  @Deprecated(since = "2025.07, because bound variables are never created or used in the visitor")
+  default R visitBoundVariable(Formula f, int deBruijnIdx) {
+    throw new UnsupportedOperationException(
+        "Bound variables are no longer explicitly visited in JavaSMT. "
+            + "Use a combination of 'visitQuantifier' (for the whole quantified formula) and "
+            + "'visitFreeVariable' (in the body) instead.");
+  }
 
   /**
    * Visit a constant, such as "true"/"false", a numeric constant like "1" or "1.0", a String

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractBooleanFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractBooleanFormulaManager.java
@@ -320,14 +320,6 @@ public abstract class AbstractBooleanFormulaManager<TFormulaInfo, TType, TEnv, T
     }
 
     @Override
-    public R visitBoundVariable(Formula f, int deBruijnIdx) {
-
-      // Only boolean formulas can appear here.
-      assert f instanceof BooleanFormula;
-      return delegate.visitBoundVar((BooleanFormula) f, deBruijnIdx);
-    }
-
-    @Override
     public R visitConstant(Formula f, Object value) {
       checkState(value instanceof Boolean);
       return delegate.visitConstant((boolean) value);

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractQuantifiedFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractQuantifiedFormulaManager.java
@@ -8,6 +8,8 @@
 
 package org.sosy_lab.java_smt.basicimpl;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.collect.Lists;
 import java.util.List;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -41,6 +43,8 @@ public abstract class AbstractQuantifiedFormulaManager<TFormulaInfo, TType, TEnv
   @Override
   public BooleanFormula mkQuantifier(
       Quantifier q, List<? extends Formula> pVariables, BooleanFormula pBody) {
+    checkArgument(
+        !pVariables.isEmpty(), "Missing variables for quantifier '%s' and body '%s'.", q, pBody);
     return wrap(
         mkQuantifier(q, Lists.transform(pVariables, this::extractInfo), extractInfo(pBody)));
   }

--- a/src/org/sosy_lab/java_smt/basicimpl/FormulaTransformationVisitorImpl.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/FormulaTransformationVisitorImpl.java
@@ -42,15 +42,6 @@ final class FormulaTransformationVisitorImpl implements FormulaVisitor<Void> {
   }
 
   @Override
-  public Void visitBoundVariable(Formula f, int deBruijnIdx) {
-    Preconditions.checkNotNull(f);
-
-    // Bound variable transformation is not allowed.
-    pCache.put(f, f);
-    return null;
-  }
-
-  @Override
   public Void visitConstant(Formula f, Object value) {
     Preconditions.checkNotNull(f);
     pCache.put(f, delegate.visitConstant(f, value));

--- a/src/org/sosy_lab/java_smt/basicimpl/RecursiveFormulaVisitorImpl.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/RecursiveFormulaVisitorImpl.java
@@ -65,11 +65,6 @@ final class RecursiveFormulaVisitorImpl implements FormulaVisitor<TraversalProce
   }
 
   @Override
-  public TraversalProcess visitBoundVariable(Formula pF, int pDeBruijnIdx) {
-    return delegate.visitBoundVariable(pF, pDeBruijnIdx);
-  }
-
-  @Override
   public TraversalProcess visitConstant(Formula pF, Object pValue) {
     return delegate.visitConstant(pF, pValue);
   }

--- a/src/org/sosy_lab/java_smt/basicimpl/Tokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/Tokenizer.java
@@ -133,7 +133,7 @@ public final class Tokenizer {
     }
     if (level != 0) {
       // Throw an exception if the brackets don't match
-      throw new IllegalArgumentException();
+      throw new IllegalArgumentException("brackets do not match, too many open brackets");
     }
     return builder.build();
   }

--- a/src/org/sosy_lab/java_smt/example/FormulaClassifier.java
+++ b/src/org/sosy_lab/java_smt/example/FormulaClassifier.java
@@ -254,12 +254,6 @@ public class FormulaClassifier {
     }
 
     @Override
-    public Integer visitBoundVariable(Formula pF, int pDeBruijnIdx) {
-      checkType(pF);
-      return 1;
-    }
-
-    @Override
     public Integer visitConstant(Formula pF, Object pValue) {
       checkType(pF);
       return 0;

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
@@ -393,6 +393,7 @@ public class BitwuzlaFormulaCreator extends FormulaCreator<Term, Sort, Void, Bit
     return bitwuzlaSortToType(pType);
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public <R> R visit(FormulaVisitor<R> visitor, Formula formula, Term f)
       throws UnsupportedOperationException {

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorFormulaCreator.java
@@ -12,15 +12,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Table;
 import com.google.common.primitives.Longs;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
@@ -29,10 +26,8 @@ import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.ArrayFormulaType;
 import org.sosy_lab.java_smt.api.FormulaType.FloatingPointType;
-import org.sosy_lab.java_smt.api.FunctionDeclarationKind;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
-import org.sosy_lab.java_smt.basicimpl.FunctionDeclarationImpl;
 import org.sosy_lab.java_smt.solvers.boolector.BoolectorFormula.BoolectorArrayFormula;
 import org.sosy_lab.java_smt.solvers.boolector.BoolectorFormula.BoolectorBitvectorFormula;
 import org.sosy_lab.java_smt.solvers.boolector.BoolectorFormula.BoolectorBooleanFormula;
@@ -47,9 +42,6 @@ public class BoolectorFormulaCreator extends FormulaCreator<Long, Long, Long, Lo
    * per var name, meaning there is only 1 column per row!
    */
   private final Table<String, Long, Long> formulaCache = HashBasedTable.create();
-
-  // Remember uf sorts, as Boolector does not give them back correctly
-  private final Map<Long, List<Long>> ufArgumentsSortMap = new HashMap<>();
 
   // Possibly we need to split this up into vars, ufs, and arrays
 
@@ -203,50 +195,6 @@ public class BoolectorFormulaCreator extends FormulaCreator<Long, Long, Long, Lo
         "Boolector has no methods to access internal nodes for visitation.");
   }
 
-  // Hopefully a helpful template for when visitor gets implemented
-  // Btor only has bitvec arrays and ufs with bitvecs and arrays of bitvecs
-  // (and quantifier with bitvecs only)
-  @SuppressWarnings({"deprecation", "unused"})
-  private <R> R visit1(FormulaVisitor<R> visitor, Formula formula, Long f) {
-    if (BtorJNI.boolector_is_const(getEnv(), f)) {
-      // Handles all constants (bitvec, bool)
-      String bits = BtorJNI.boolector_get_bits(getEnv(), f);
-      return visitor.visitConstant(formula, convertValue(f, parseBitvector(bits)));
-    } else if (BtorJNI.boolector_is_param(getEnv(), f)) {
-      // Quantifier have their own variables called param.
-      // They can only be bound once! (use them as bitvec)
-      int deBruijnIdx = 0; // TODO: Ask Developers for this because this is WRONG!
-      return visitor.visitBoundVariable(formula, deBruijnIdx);
-    } else if (false) {
-      // Quantifier
-      // there is currently no way to find out if the formula is a quantifier
-      // do we need them separately?
-      /*
-       * return visitor .visitQuantifier( (BoolectorBooleanFormula) formula, quantifier,
-       * boundVariables, new BoolectorBooleanFormula(body, getEnv()));
-       */
-    } else if (BtorJNI.boolector_is_var(getEnv(), f)) {
-      // bitvec var (size 1 is bool!)
-      return visitor.visitFreeVariable(formula, getName(f));
-    } else {
-      ImmutableList.Builder<Formula> args = ImmutableList.builder();
-
-      ImmutableList.Builder<FormulaType<?>> argTypes = ImmutableList.builder();
-
-      return visitor.visitFunction(
-          formula,
-          args.build(),
-          FunctionDeclarationImpl.of(
-              getName(f), getDeclarationKind(f), argTypes.build(), getFormulaType(f), f));
-    } // TODO: fix declaration in visitFunction
-    return null;
-  }
-
-  // TODO: returns kind of formula (add, uf etc....) once methods are provided
-  private FunctionDeclarationKind getDeclarationKind(@SuppressWarnings("unused") long f) {
-    return null;
-  }
-
   @Override
   public Long callFunctionImpl(Long pDeclaration, List<Long> pArgs) {
     Preconditions.checkArgument(
@@ -270,7 +218,6 @@ public class BoolectorFormulaCreator extends FormulaCreator<Long, Long, Long, Lo
     }
     long uf = BtorJNI.boolector_uf(getEnv(), sort, name);
     formulaCache.put(name, sort, uf);
-    ufArgumentsSortMap.put(uf, pArgTypes);
     return uf;
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorFormulaCreator.java
@@ -206,7 +206,7 @@ public class BoolectorFormulaCreator extends FormulaCreator<Long, Long, Long, Lo
   // Hopefully a helpful template for when visitor gets implemented
   // Btor only has bitvec arrays and ufs with bitvecs and arrays of bitvecs
   // (and quantifier with bitvecs only)
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"deprecation", "unused"})
   private <R> R visit1(FormulaVisitor<R> visitor, Formula formula, Long f) {
     if (BtorJNI.boolector_is_const(getEnv(), f)) {
       // Handles all constants (bitvec, bool)

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
@@ -296,6 +296,7 @@ public class CVC4FormulaCreator extends FormulaCreator<Expr, Type, ExprManager, 
     return dequote(e.toString());
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public <R> R visit(FormulaVisitor<R> visitor, Formula formula, final Expr f) {
     checkState(!f.isNull());

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
@@ -369,6 +369,7 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public <R> R visit(FormulaVisitor<R> visitor, Formula formula, final Term f) {
     checkState(!f.isNull());

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5QuantifiedFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5QuantifiedFormulaManager.java
@@ -8,6 +8,8 @@
 
 package org.sosy_lab.java_smt.solvers.cvc5;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import io.github.cvc5.Kind;
 import io.github.cvc5.Solver;
 import io.github.cvc5.Sort;
@@ -63,22 +65,21 @@ public class CVC5QuantifiedFormulaManager
    */
   @Override
   public Term mkQuantifier(Quantifier pQ, List<Term> pVars, Term pBody) {
-    if (pVars.isEmpty()) {
-      throw new IllegalArgumentException("Empty variable list for quantifier.");
-    } else {
-      List<Term> boundVars = new ArrayList<>();
-      Term substBody = pBody;
-      // every free needs a bound copy. As the internal Id is different for every variable, even
-      // with the same name, this is fine.
-      for (Term var : pVars) {
-        Term boundCopy = ((CVC5FormulaCreator) formulaCreator).makeBoundCopy(var);
-        boundVars.add(boundCopy);
-        substBody = substBody.substitute(var, boundCopy);
-      }
+    checkArgument(
+        !pVars.isEmpty(), "Missing variables for quantifier '%s' and body '%s'.", pQ, pBody);
 
-      Kind quant = pQ == Quantifier.EXISTS ? Kind.EXISTS : Kind.FORALL;
-      Term boundVarsList = termManager.mkTerm(Kind.VARIABLE_LIST, boundVars.toArray(new Term[0]));
-      return termManager.mkTerm(quant, boundVarsList, substBody);
+    List<Term> boundVars = new ArrayList<>();
+    Term substBody = pBody;
+    // every free needs a bound copy. As the internal Id is different for every variable, even
+    // with the same name, this is fine.
+    for (Term var : pVars) {
+      Term boundCopy = ((CVC5FormulaCreator) formulaCreator).makeBoundCopy(var);
+      boundVars.add(boundCopy);
+      substBody = substBody.substitute(var, boundCopy);
     }
+
+    Kind quant = pQ == Quantifier.EXISTS ? Kind.EXISTS : Kind.FORALL;
+    Term boundVarsList = termManager.mkTerm(Kind.VARIABLE_LIST, boundVars.toArray(new Term[0]));
+    return termManager.mkTerm(quant, boundVarsList, substBody);
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaCreator.java
@@ -382,6 +382,7 @@ class PrincessFormulaCreator
     return isConstant(pExpr) && pExpr.fun().equals(Rationals$.MODULE$.frac());
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public <R> R visit(FormulaVisitor<R> visitor, final Formula f, final IExpression input) {
     if (input instanceof IIntLit) {

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaCreator.java
@@ -11,7 +11,6 @@ package org.sosy_lab.java_smt.solvers.princess;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.sosy_lab.java_smt.api.QuantifiedFormulaManager.Quantifier.EXISTS;
 import static org.sosy_lab.java_smt.api.QuantifiedFormulaManager.Quantifier.FORALL;
-import static org.sosy_lab.java_smt.solvers.princess.PrincessEnvironment.toITermSeq;
 import static org.sosy_lab.java_smt.solvers.princess.PrincessEnvironment.toSeq;
 import static scala.collection.JavaConverters.asJava;
 import static scala.collection.JavaConverters.asJavaCollection;
@@ -547,13 +546,17 @@ class PrincessFormulaCreator
 
     // substitute the bound variable with index 0 with a new variable, and un-shift the remaining
     // de-Bruijn indices, such that the next nested bound variable has index 0.
-    IFormula substitutedBody = IFormula.subst(body, toITermSeq(substitutionVariable).toList(), -1);
+    IFormula substitutedBody = IFormula.subst(body, asScalaList(substitutionVariable), -1);
 
     return visitor.visitQuantifier(
         f,
         quantifier,
-        List.of(encapsulateWithTypeOf(substitutionVariable)),
+        ImmutableList.of(encapsulateWithTypeOf(substitutionVariable)),
         encapsulateBoolean(substitutedBody));
+  }
+
+  private static scala.collection.immutable.List<ITerm> asScalaList(ITerm substitutionVariable) {
+    return scala.collection.immutable.List$.MODULE$.empty().$colon$colon(substitutionVariable);
   }
 
   /**

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaCreator.java
@@ -546,7 +546,7 @@ class PrincessFormulaCreator
 
     // substitute the bound variable with index 0 with a new variable, and un-shift the remaining
     // de-Bruijn indices, such that the next nested bound variable has index 0.
-    IFormula substitutedBody = IFormula.subst(body, asScalaList(substitutionVariable), -1);
+    IFormula substitutedBody = IExpression.subst(body, asScalaList(substitutionVariable), -1);
 
     return visitor.visitQuantifier(
         f,

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessQuantifiedFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessQuantifiedFormulaManager.java
@@ -14,12 +14,11 @@ import static scala.collection.JavaConverters.asScala;
 import ap.parser.IConstant;
 import ap.parser.IExpression;
 import ap.parser.IFormula;
-import ap.parser.ISortedQuantified;
 import ap.terfor.ConstantTerm;
 import ap.terfor.conjunctions.Quantifier.ALL$;
 import ap.terfor.conjunctions.Quantifier.EX$;
 import ap.types.Sort;
-import java.util.ArrayList;
+import com.google.common.collect.Lists;
 import java.util.List;
 import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractQuantifiedFormulaManager;
@@ -40,24 +39,17 @@ class PrincessQuantifiedFormulaManager
 
   @Override
   public IExpression mkQuantifier(Quantifier q, List<IExpression> vars, IExpression body) {
+    checkArgument(!vars.isEmpty(), "Missing variables for quantifier '%s' and body '%s'.", q, body);
+
     checkArgument(body instanceof IFormula);
     ap.terfor.conjunctions.Quantifier pq = (q == Quantifier.FORALL) ? ALL$.MODULE$ : EX$.MODULE$;
-    if (vars.isEmpty()) {
 
-      // Body already contains bound variables.
-      return new ISortedQuantified(pq, PrincessEnvironment.INTEGER_SORT, (IFormula) body);
-    } else {
-      // TODO: add support for boolean quantification!
-      return IExpression.quanConsts(pq, asScala(toConstantTerm(vars)), (IFormula) body);
-    }
+    // TODO: add support for boolean quantification!
+    return IExpression.quanConsts(pq, asScala(toConstantTerms(vars)), (IFormula) body);
   }
 
-  private List<ConstantTerm> toConstantTerm(List<IExpression> lst) {
-    List<ConstantTerm> retVal = new ArrayList<>(lst.size());
-    for (IExpression f : lst) {
-      retVal.add(((IConstant) f).c());
-    }
-    return retVal;
+  private List<ConstantTerm> toConstantTerms(List<IExpression> lst) {
+    return Lists.transform(lst, f -> ((IConstant) f).c());
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2FormulaCreator.java
@@ -324,6 +324,7 @@ public class Yices2FormulaCreator extends FormulaCreator<Integer, Integer, Long,
     return bound;
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public <R> R visit(FormulaVisitor<R> pVisitor, Formula pFormula, Integer pF) {
     int constructor = yices_term_constructor(pF);

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
@@ -484,6 +484,7 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
     return symbolToString(symbol);
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public <R> R visit(FormulaVisitor<R> visitor, final Formula formula, final Long f) {
     switch (Z3_ast_kind.fromInt(Native.getAstKind(environment, f))) {

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3QuantifiedFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3QuantifiedFormulaManager.java
@@ -29,7 +29,12 @@ class Z3QuantifiedFormulaManager extends AbstractQuantifiedFormulaManager<Long, 
 
   @Override
   public Long mkQuantifier(Quantifier q, List<Long> pVariables, Long pBody) {
-    checkArgument(!pVariables.isEmpty(), "List of quantified variables can not be empty");
+    checkArgument(
+        !pVariables.isEmpty(),
+        "Missing variables for quantifier '%s' and body '%s'.",
+        q,
+        Native.astToString(z3context, pBody));
+
     return Native.mkQuantifierConst(
         z3context,
         q == Quantifier.FORALL,

--- a/src/org/sosy_lab/java_smt/test/FormulaClassifierTest.java
+++ b/src/org/sosy_lab/java_smt/test/FormulaClassifierTest.java
@@ -137,6 +137,27 @@ public class FormulaClassifierTest extends SolverBasedTest0.ParameterizedSolverB
   }
 
   @Test
+  public void test_LRA_2() {
+    requireParser();
+    requireRationals();
+    requireQuantifiers();
+    requireRationals();
+    String query =
+        NUMERAL_VARS
+            + "(assert (and "
+            + "(exists ((a Real) (b Real)) (= (+ y y) (+ a b))) "
+            + "(exists ((a Real) (b Real)) (= (+ y y) (- a b))) "
+            + "))";
+    classifier.visit(mgr.parse(query));
+    if (solverToUse() == Solvers.PRINCESS) {
+      // Princess rewrites the formula and uses '-1' for the negation -> Integer arithmetic
+      assertThat(classifier.toString()).isEqualTo("LIRA");
+    } else {
+      assertThat(classifier.toString()).isEqualTo("LRA");
+    }
+  }
+
+  @Test
   public void test_ABVIRA() {
     requireParser();
     requireArrays();

--- a/src/org/sosy_lab/java_smt/test/SolverTacticsTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverTacticsTest.java
@@ -248,12 +248,6 @@ public class SolverTacticsTest extends SolverBasedTest0.ParameterizedSolverBased
     }
 
     @Override
-    public Void visitBoundVar(BooleanFormula f, int deBruijnIdx) {
-      started = true;
-      return null;
-    }
-
-    @Override
     public Void visitAtom(BooleanFormula pAtom, FunctionDeclaration<BooleanFormula> decl) {
       started = true;
       return null;
@@ -355,12 +349,6 @@ public class SolverTacticsTest extends SolverBasedTest0.ParameterizedSolverBased
 
     @Override
     public Void visitConstant(boolean value) {
-      wasLastVisitNot = false;
-      return null;
-    }
-
-    @Override
-    public Void visitBoundVar(BooleanFormula var, int deBruijnIdx) {
       wasLastVisitNot = false;
       return null;
     }


### PR DESCRIPTION
The usage of bound variables and quantifier usage in the API was never consistent:
- some solvers require bound variables in quantified formulas, some solvers just use regular variables.
- some solvers visit bound variables in formulas, some solvers just handle them as regular variables.
- some solvers can not use an empty list of variables in quantification, Princess does allow this.
This PR unifies the beaviour and marks the corresponding methods as deprecated:
- all solvers provide only free variables toward the API/user
- all sub-formulas are consistent when visiting quantified formulas, e.g. the body of a quantified formula is provided in a bound-free way, e.g, all bound variables are replaced by free counterparts (for Princess, we use a new temporary unique name, other solvers keep the original name of the variable).

The overall goal is an analysis of the blocking error in https://gitlab.com/sosy-lab/software/cpachecker/-/merge_requests/234 which might be caused by solver-specific and non-consistent quantifier handling (Z3 vs. other solver).