### PR TITLE
Add a new method toRational() to NumeralFormulaManager

### DIFF
--- a/src/org/sosy_lab/java_smt/api/NumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/NumeralFormulaManager.java
@@ -13,6 +13,7 @@ import java.math.BigInteger;
 import java.util.List;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
+import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 
 /**
  * This interface represents the Numeral Theory.
@@ -106,4 +107,6 @@ public interface NumeralFormulaManager<
    * <p>For rational formulas, SMTlib2 denotes this operation as {@code to_int}.
    */
   IntegerFormula floor(ParamFormulaType formula);
+
+  RationalFormula toRational(ParamFormulaType number);
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractNumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractNumeralFormulaManager.java
@@ -24,6 +24,7 @@ import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.NumeralFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
+import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.NumeralFormulaManager;
 
 /**
@@ -445,4 +446,16 @@ public abstract class AbstractNumeralFormulaManager<
   protected TFormulaInfo toType(TFormulaInfo param) {
     return param;
   }
+
+  @Override
+  public RationalFormula toRational(ParamFormulaType number) {
+    if (number instanceof RationalFormula) {
+      return (RationalFormula) number;
+    } else {
+      return getFormulaCreator()
+          .encapsulate(FormulaType.RationalType, toRational(extractInfo(number)));
+    }
+  }
+
+  protected abstract TFormulaInfo toRational(TFormulaInfo number);
 }

--- a/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingNumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingNumeralFormulaManager.java
@@ -18,6 +18,7 @@ import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.NumeralFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
+import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.NumeralFormulaManager;
 
 @SuppressWarnings("ClassTypeParameterName")
@@ -222,6 +223,15 @@ public class DebuggingNumeralFormulaManager<
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(formula);
     IntegerFormula result = delegate.floor(formula);
+    debugging.addFormulaTerm(result);
+    return result;
+  }
+
+  @Override
+  public RationalFormula toRational(ParamFormulaType formula) {
+    debugging.assertThreadLocal();
+    debugging.assertFormulaInContext(formula);
+    RationalFormula result = delegate.toRational(formula);
     debugging.addFormulaTerm(result);
     return result;
   }

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsNumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsNumeralFormulaManager.java
@@ -18,6 +18,7 @@ import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.NumeralFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
+import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.NumeralFormulaManager;
 
 @SuppressWarnings("ClassTypeParameterName")
@@ -159,5 +160,11 @@ class StatisticsNumeralFormulaManager<
   public IntegerFormula floor(ParamFormulaType pNumber) {
     stats.numericOperations.getAndIncrement();
     return delegate.floor(pNumber);
+  }
+
+  @Override
+  public RationalFormula toRational(ParamFormulaType formula) {
+    stats.numericOperations.getAndIncrement();
+    return delegate.toRational(formula);
   }
 }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedNumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedNumeralFormulaManager.java
@@ -18,6 +18,7 @@ import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.NumeralFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
+import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.NumeralFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
 
@@ -179,6 +180,13 @@ class SynchronizedNumeralFormulaManager<
   public IntegerFormula floor(ParamFormulaType pNumber) {
     synchronized (sync) {
       return delegate.floor(pNumber);
+    }
+  }
+
+  @Override
+  public RationalFormula toRational(ParamFormulaType formula) {
+    synchronized (sync) {
+      return delegate.toRational(formula);
     }
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4NumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4NumeralFormulaManager.java
@@ -186,4 +186,9 @@ abstract class CVC4NumeralFormulaManager<
       return exprManager.mkExpr(Kind.DISTINCT, param);
     }
   }
+
+  @Override
+  public Expr toRational(Expr formula) {
+    return exprManager.mkExpr(Kind.TO_REAL, formula);
+  }
 }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5NumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5NumeralFormulaManager.java
@@ -195,4 +195,9 @@ abstract class CVC5NumeralFormulaManager<
           Kind.DISTINCT, pParam.stream().map(this::toType).toArray(Term[]::new));
     }
   }
+
+  @Override
+  public Term toRational(Term formula) {
+    return termManager.mkTerm(Kind.TO_REAL, formula);
+  }
 }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NumeralFormulaManager.java
@@ -135,4 +135,9 @@ abstract class Mathsat5NumeralFormulaManager<
   protected Long floor(Long pNumber) {
     return msat_make_floor(mathsatEnv, pNumber);
   }
+
+  @Override
+  protected Long toRational(Long pNumber) {
+    return pNumber;
+  }
 }

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtNumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtNumeralFormulaManager.java
@@ -122,4 +122,9 @@ abstract class OpenSmtNumeralFormulaManager<
   protected PTRef distinctImpl(List<PTRef> pParam) {
     return osmtLogic.mkDistinct(new VectorPTRef(pParam));
   }
+
+  @Override
+  public PTRef toRational(PTRef formula) {
+    throw new UnsupportedOperationException("OpenSMT does not support mixed integer-real logic");
+  }
 }

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessNumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessNumeralFormulaManager.java
@@ -44,4 +44,9 @@ abstract class PrincessNumeralFormulaManager<
   protected IExpression distinctImpl(List<IExpression> pNumbers) {
     return IExpression.distinct(asScala(Iterables.filter(pNumbers, ITerm.class)));
   }
+
+  @Override
+  public IExpression toRational(IExpression formula) {
+    return PrincessEnvironment.rationalTheory.int2ring((ITerm) formula);
+  }
 }

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessRationalFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessRationalFormulaManager.java
@@ -54,18 +54,14 @@ public class PrincessRationalFormulaManager
     return false;
   }
 
-  protected IExpression fromInteger(ITerm i) {
-    return PrincessEnvironment.rationalTheory.int2ring(i);
-  }
-
   @Override
   protected IExpression makeNumberImpl(long i) {
-    return fromInteger(ifmgr.makeNumberImpl(i));
+    return toRational(ifmgr.makeNumberImpl(i));
   }
 
   @Override
   protected IExpression makeNumberImpl(BigInteger i) {
-    return fromInteger(ifmgr.makeNumberImpl(i));
+    return toRational(ifmgr.makeNumberImpl(i));
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolNumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolNumeralFormulaManager.java
@@ -174,4 +174,9 @@ abstract class SmtInterpolNumeralFormulaManager<
   public Term lessOrEquals(Term pNumber1, Term pNumber2) {
     return env.term("<=", pNumber1, pNumber2);
   }
+
+  @Override
+  public Term toRational(Term formula) {
+    return env.term("to_real", formula);
+  }
 }

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2NumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2NumeralFormulaManager.java
@@ -136,4 +136,9 @@ abstract class Yices2NumeralFormulaManager<
   protected Integer floor(Integer pNumber) {
     return yices_floor(pNumber);
   }
+
+  @Override
+  public Integer toRational(Integer formula) {
+    return formula;
+  }
 }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3NumeralFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3NumeralFormulaManager.java
@@ -123,4 +123,9 @@ abstract class Z3NumeralFormulaManager<
   protected Long lessOrEquals(Long pNumber1, Long pNumber2) {
     return Native.mkLe(z3context, pNumber1, pNumber2);
   }
+
+  @Override
+  protected Long toRational(Long number) {
+    return Native.mkInt2real(z3context, number);
+  }
 }

--- a/src/org/sosy_lab/java_smt/test/MixedArithmeticsTest.java
+++ b/src/org/sosy_lab/java_smt/test/MixedArithmeticsTest.java
@@ -65,6 +65,20 @@ public class MixedArithmeticsTest extends SolverBasedTest0.ParameterizedSolverBa
     assertThat(mgr.getFormulaType(f.apply(arg)).isIntegerType()).isTrue();
   }
 
+  /**
+   * Same as binary testRationalOperation(), but we expect both arguments, and result to be integer
+   * terms.
+   */
+  private void testIntegerOperation(
+      BiFunction<IntegerFormula, IntegerFormula, IntegerFormula> f,
+      IntegerFormula arg1,
+      IntegerFormula arg2,
+      IntegerFormula expected)
+      throws SolverException, InterruptedException {
+    assertThatFormula(imgr.equal(f.apply(arg1, arg2), expected)).isTautological();
+    assertThat(mgr.getFormulaType(f.apply(arg1, arg2)).isIntegerType()).isTrue();
+  }
+
   @Test
   public void createIntegerNumberTest() throws SolverException, InterruptedException {
     IntegerFormula num1 = imgr.makeNumber(1.0);
@@ -169,6 +183,7 @@ public class MixedArithmeticsTest extends SolverBasedTest0.ParameterizedSolverBa
 
   @Test
   public void divideTest() throws SolverException, InterruptedException {
+    testIntegerOperation(imgr::divide, imgr.makeNumber(5), imgr.makeNumber(2), imgr.makeNumber(2));
     testRationalOperation(
         rmgr::divide, imgr.makeNumber(1), imgr.makeNumber(2), rmgr.makeNumber(0.5));
     testRationalOperation(


### PR DESCRIPTION
Hello everyone,
in this PR we will add a new method `toRational()` to the `NumeralFormulaManager`. It is the counterpart to `floor` (= `to_int` in SMTLIB) and will turn an integer formula into a rational formula. While we've handled the conversion internally so far, having a way to create `to_real` terms directly is useful in the visitor