### PR TITLE
Use Solver Native Implementation of Bitvector to IEEE FP for CVC4 and CVC5

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FloatingPointFormulaManager.java
@@ -17,6 +17,7 @@ import edu.stanford.CVC4.FloatingPoint;
 import edu.stanford.CVC4.FloatingPointConvertSort;
 import edu.stanford.CVC4.FloatingPointSize;
 import edu.stanford.CVC4.FloatingPointToFPFloatingPoint;
+import edu.stanford.CVC4.FloatingPointToFPIEEEBitVector;
 import edu.stanford.CVC4.FloatingPointToFPSignedBitVector;
 import edu.stanford.CVC4.FloatingPointToFPUnsignedBitVector;
 import edu.stanford.CVC4.FloatingPointToSBV;
@@ -358,20 +359,10 @@ public class CVC4FloatingPointFormulaManager
 
   @Override
   protected Expr fromIeeeBitvectorImpl(Expr bitvector, FloatingPointType pTargetType) {
-    int mantissaSize = pTargetType.getMantissaSize();
-    int exponentSize = pTargetType.getExponentSize();
-    int size = pTargetType.getTotalSize();
-    assert size == mantissaSize + exponentSize + 1;
-
-    Expr signExtract = exprManager.mkConst(new BitVectorExtract(size - 1, size - 1));
-    Expr exponentExtract = exprManager.mkConst(new BitVectorExtract(size - 2, mantissaSize));
-    Expr mantissaExtract = exprManager.mkConst(new BitVectorExtract(mantissaSize - 1, 0));
-
-    Expr sign = exprManager.mkExpr(Kind.BITVECTOR_EXTRACT, signExtract, bitvector);
-    Expr exponent = exprManager.mkExpr(Kind.BITVECTOR_EXTRACT, exponentExtract, bitvector);
-    Expr mantissa = exprManager.mkExpr(Kind.BITVECTOR_EXTRACT, mantissaExtract, bitvector);
-
-    return exprManager.mkExpr(Kind.FLOATINGPOINT_FP, sign, exponent, mantissa);
+    // This is just named weird, but the CVC4 doc say this is IEEE BV -> FP
+    FloatingPointConvertSort fpConvertSort = new FloatingPointConvertSort(getFPSize(pTargetType));
+    Expr op = exprManager.mkConst(new FloatingPointToFPIEEEBitVector(fpConvertSort));
+    return exprManager.mkExpr(op, bitvector);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FloatingPointFormulaManager.java
@@ -10,7 +10,6 @@ package org.sosy_lab.java_smt.solvers.cvc4;
 
 import com.google.common.collect.ImmutableList;
 import edu.stanford.CVC4.BitVector;
-import edu.stanford.CVC4.BitVectorExtract;
 import edu.stanford.CVC4.Expr;
 import edu.stanford.CVC4.ExprManager;
 import edu.stanford.CVC4.FloatingPoint;

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FloatingPointFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FloatingPointFormulaManager.java
@@ -408,29 +408,18 @@ public class CVC5FloatingPointFormulaManager
   }
 
   @Override
-  protected Term fromIeeeBitvectorImpl(Term bitvector, FloatingPointType pTargetType) {
-    int mantissaSize = pTargetType.getMantissaSize();
-    int exponentSize = pTargetType.getExponentSize();
-    int size = pTargetType.getTotalSize();
-    assert size == mantissaSize + exponentSize + 1;
-
-    Op signExtract;
-    Op exponentExtract;
-    Op mantissaExtract;
+  protected Term fromIeeeBitvectorImpl(Term pBitvector, FloatingPointType pTargetType) {
     try {
-      signExtract = termManager.mkOp(Kind.BITVECTOR_EXTRACT, size - 1, size - 1);
-      exponentExtract = termManager.mkOp(Kind.BITVECTOR_EXTRACT, size - 2, mantissaSize);
-      mantissaExtract = termManager.mkOp(Kind.BITVECTOR_EXTRACT, mantissaSize - 1, 0);
-    } catch (CVC5ApiException e) {
-      throw new IllegalArgumentException(
-          "You tried creating a invalid bitvector extract in term " + bitvector + ".", e);
+      return termManager.mkTerm(
+          termManager.mkOp(
+              Kind.FLOATINGPOINT_TO_FP_FROM_IEEE_BV,
+              pTargetType.getExponentSize(),
+              pTargetType.getMantissaSize() + 1), // add sign bit
+          pBitvector);
+    } catch (CVC5ApiException pE) {
+      // This seems to only be thrown for wrong exponent and mantissa sizes
+      throw new RuntimeException(pE);
     }
-
-    Term sign = termManager.mkTerm(signExtract, bitvector);
-    Term exponent = termManager.mkTerm(exponentExtract, bitvector);
-    Term mantissa = termManager.mkTerm(mantissaExtract, bitvector);
-
-    return termManager.mkTerm(Kind.FLOATINGPOINT_FP, sign, exponent, mantissa);
   }
 
   @Override


### PR DESCRIPTION
This PR changes the implementation of CVC4 and 5 to use their built-in version of `fromIeeeBitvector()`.