### PR TITLE
replace all usages of "List.of" with more readable "ImmutableList.of/copyOf"

### DIFF
--- a/src/org/sosy_lab/java_smt/api/BitvectorFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/BitvectorFormulaManager.java
@@ -8,6 +8,7 @@
 
 package org.sosy_lab.java_smt.api;
 
+import com.google.common.collect.ImmutableList;
 import java.math.BigInteger;
 import java.util.List;
 import org.sosy_lab.java_smt.api.FormulaType.BitvectorType;
@@ -415,6 +416,6 @@ public interface BitvectorFormulaManager {
   BooleanFormula distinct(List<BitvectorFormula> pBits);
 
   default BooleanFormula distinct(BitvectorFormula... pBits) {
-    return distinct(List.of(pBits));
+    return distinct(ImmutableList.copyOf(pBits));
   }
 }

--- a/src/org/sosy_lab/java_smt/api/BooleanFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/BooleanFormulaManager.java
@@ -8,9 +8,9 @@
 
 package org.sosy_lab.java_smt.api;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collector;
 import org.sosy_lab.java_smt.api.visitors.BooleanFormulaTransformationVisitor;
@@ -113,7 +113,7 @@ public interface BooleanFormulaManager {
    * @see #and(BooleanFormula, BooleanFormula)
    */
   default BooleanFormula and(BooleanFormula... bits) {
-    return and(List.of(bits));
+    return and(ImmutableList.copyOf(bits));
   }
 
   /** Return a stream {@link Collector} that creates a conjunction of all elements in the stream. */
@@ -137,7 +137,7 @@ public interface BooleanFormulaManager {
    * @see #or(BooleanFormula, BooleanFormula)
    */
   default BooleanFormula or(BooleanFormula... bits) {
-    return or(List.of(bits));
+    return or(ImmutableList.copyOf(bits));
   }
 
   /** Return a stream {@link Collector} that creates a disjunction of all elements in the stream. */

--- a/src/org/sosy_lab/java_smt/api/UFManager.java
+++ b/src/org/sosy_lab/java_smt/api/UFManager.java
@@ -8,6 +8,7 @@
 
 package org.sosy_lab.java_smt.api;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /** Manager for dealing with uninterpreted functions (UFs). */
@@ -20,7 +21,7 @@ public interface UFManager {
   /** Declare an uninterpreted function. */
   default <T extends Formula> FunctionDeclaration<T> declareUF(
       String name, FormulaType<T> returnType, FormulaType<?>... args) {
-    return declareUF(name, returnType, List.of(args));
+    return declareUF(name, returnType, ImmutableList.copyOf(args));
   }
 
   /**
@@ -38,7 +39,7 @@ public interface UFManager {
    * @see #callUF(FunctionDeclaration, List)
    */
   default <T extends Formula> T callUF(FunctionDeclaration<T> funcType, Formula... args) {
-    return callUF(funcType, List.of(args));
+    return callUF(funcType, ImmutableList.copyOf(args));
   }
 
   /**
@@ -58,6 +59,6 @@ public interface UFManager {
    */
   default <T extends Formula> T declareAndCallUF(
       String name, FormulaType<T> pReturnType, Formula... pArgs) {
-    return declareAndCallUF(name, pReturnType, List.of(pArgs));
+    return declareAndCallUF(name, pReturnType, ImmutableList.copyOf(pArgs));
   }
 }

--- a/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingAssertions.java
+++ b/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingAssertions.java
@@ -9,7 +9,7 @@
 package org.sosy_lab.java_smt.delegate.debugging;
 
 import com.google.common.base.Preconditions;
-import java.util.List;
+import com.google.common.collect.ImmutableList;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
@@ -54,7 +54,7 @@ class DebuggingAssertions {
 
   /** Assert that the function declaration belongs to this context. */
   public void assertDeclarationInContext(FunctionDeclaration<?> pFunctionDeclaration) {
-    if (List.of(FunctionDeclarationKind.VAR, FunctionDeclarationKind.UF)
+    if (ImmutableList.of(FunctionDeclarationKind.VAR, FunctionDeclarationKind.UF)
         .contains(pFunctionDeclaration.getKind())) {
       Preconditions.checkArgument(
           debugInfo.getDeclaredFunctions().contains(pFunctionDeclaration),

--- a/src/org/sosy_lab/java_smt/example/Binoxxo.java
+++ b/src/org/sosy_lab/java_smt/example/Binoxxo.java
@@ -9,6 +9,7 @@
 package org.sosy_lab.java_smt.example;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
@@ -95,7 +96,7 @@ public final class Binoxxo {
           SolverContextFactory.createSolverContext(config, logger, notifier, solver)) {
 
         for (BinoxxoSolver<?> binoxxo :
-            List.of(
+            ImmutableList.of(
                 new IntegerBasedBinoxxoSolver(context), new BooleanBasedBinoxxoSolver(context))) {
           long start = System.currentTimeMillis();
 
@@ -300,7 +301,7 @@ public final class Binoxxo {
       for (int row = 0; row < size; row++) {
         for (int col = 0; col < size - 2; col++) {
           List<IntegerFormula> lst =
-              List.of(symbols[row][col], symbols[row][col + 1], symbols[row][col + 2]);
+              ImmutableList.of(symbols[row][col], symbols[row][col + 1], symbols[row][col + 2]);
           IntegerFormula sum = imgr.sum(lst);
           rules.add(bmgr.or(imgr.equal(one, sum), imgr.equal(two, sum)));
         }
@@ -310,7 +311,7 @@ public final class Binoxxo {
       for (int col = 0; col < size; col++) {
         for (int row = 0; row < size - 2; row++) {
           List<IntegerFormula> lst =
-              List.of(symbols[row][col], symbols[row + 1][col], symbols[row + 2][col]);
+              ImmutableList.of(symbols[row][col], symbols[row + 1][col], symbols[row + 2][col]);
           IntegerFormula sum = imgr.sum(lst);
           rules.add(bmgr.or(imgr.equal(one, sum), imgr.equal(two, sum)));
         }
@@ -398,7 +399,7 @@ public final class Binoxxo {
       for (int row = 0; row < size; row++) {
         for (int col = 0; col < size - 2; col++) {
           List<BooleanFormula> lst =
-              List.of(symbols[row][col], symbols[row][col + 1], symbols[row][col + 2]);
+              ImmutableList.of(symbols[row][col], symbols[row][col + 1], symbols[row][col + 2]);
           rules.add(bmgr.not(bmgr.and(lst)));
           rules.add(bmgr.or(lst));
         }
@@ -408,7 +409,7 @@ public final class Binoxxo {
       for (int col = 0; col < size; col++) {
         for (int row = 0; row < size - 2; row++) {
           List<BooleanFormula> lst =
-              List.of(symbols[row][col], symbols[row + 1][col], symbols[row + 2][col]);
+              ImmutableList.of(symbols[row][col], symbols[row + 1][col], symbols[row + 2][col]);
           rules.add(bmgr.not(bmgr.and(lst)));
           rules.add(bmgr.or(lst));
         }

--- a/src/org/sosy_lab/java_smt/example/Sudoku.java
+++ b/src/org/sosy_lab/java_smt/example/Sudoku.java
@@ -108,7 +108,7 @@ public final class Sudoku {
           SolverContextFactory.createSolverContext(config, logger, notifier, solver)) {
 
         for (SudokuSolver<?> sudoku :
-            List.of(
+            ImmutableList.of(
                 new IntegerBasedSudokuSolver(context),
                 new EnumerationBasedSudokuSolver(context),
                 new BooleanBasedSudokuSolver(context))) {

--- a/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/BitvectorFormulaManagerTest.java
@@ -14,6 +14,7 @@ import static com.google.common.truth.TruthJUnit.assume;
 import static org.junit.Assert.assertThrows;
 import static org.sosy_lab.java_smt.test.ProverEnvironmentSubject.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -392,9 +393,9 @@ public class BitvectorFormulaManagerTest extends SolverBasedTest0.ParameterizedS
     BitvectorFormula a = bvmgr.makeVariable(4, "a");
     BitvectorFormula num3 = bvmgr.makeBitvector(4, 3);
 
-    assertThatFormula(bvmgr.distinct(List.of(a, num3))).isSatisfiable();
-    assertThatFormula(bvmgr.distinct(List.of(a, a))).isUnsatisfiable();
-    assertThatFormula(bvmgr.distinct(List.of(num3, num3))).isUnsatisfiable();
+    assertThatFormula(bvmgr.distinct(ImmutableList.of(a, num3))).isSatisfiable();
+    assertThatFormula(bvmgr.distinct(ImmutableList.of(a, a))).isUnsatisfiable();
+    assertThatFormula(bvmgr.distinct(ImmutableList.of(num3, num3))).isUnsatisfiable();
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/test/DebugModeTest.java
+++ b/src/org/sosy_lab/java_smt/test/DebugModeTest.java
@@ -149,7 +149,7 @@ public class DebugModeTest extends SolverBasedTest0.ParameterizedSolverBasedTest
       BooleanFormula formula = hardProblem.generate(DEFAULT_PROBLEM_SIZE);
 
       // We expect debug mode to throw an exception for all solvers, except CVC4, CVC5 and Yices
-      if (!List.of(Solvers.CVC4, Solvers.YICES2).contains(solverToUse())) {
+      if (!ImmutableList.of(Solvers.CVC4, Solvers.YICES2).contains(solverToUse())) {
         assertThrows(IllegalArgumentException.class, () -> checkFormulaInDebugContext(formula));
       } else {
         checkFormulaInDebugContext(formula);

--- a/src/org/sosy_lab/java_smt/test/InterpolatingProverTest.java
+++ b/src/org/sosy_lab/java_smt/test/InterpolatingProverTest.java
@@ -344,7 +344,7 @@ public class InterpolatingProverTest extends SolverBasedTest0.ParameterizedSolve
 
     // sequential interpolation should always work as expected
     checkItpSequence(ImmutableList.of(A, B, C), itpSeq);
-    checkItpSequence(ImmutableList.of(A, B, C), List.of(itp1, itp2));
+    checkItpSequence(ImmutableList.of(A, B, C), ImmutableList.of(itp1, itp2));
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/test/MixedArithmeticsTest.java
+++ b/src/org/sosy_lab/java_smt/test/MixedArithmeticsTest.java
@@ -16,7 +16,6 @@ import static com.google.common.truth.TruthJUnit.assume;
 import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.junit.Before;
@@ -69,7 +68,7 @@ public class MixedArithmeticsTest extends SolverBasedTest0.ParameterizedSolverBa
   public void createIntegerNumberTest() throws SolverException, InterruptedException {
     IntegerFormula num1 = imgr.makeNumber(1.0);
     for (IntegerFormula num2 :
-        List.of(
+        ImmutableList.of(
             imgr.makeNumber(1.0),
             imgr.makeNumber("1"),
             imgr.makeNumber(1),
@@ -86,7 +85,7 @@ public class MixedArithmeticsTest extends SolverBasedTest0.ParameterizedSolverBa
   public void createRationalNumberTest() throws SolverException, InterruptedException {
     RationalFormula num1 = rmgr.makeNumber(1.0);
     for (RationalFormula num2 :
-        List.of(
+        ImmutableList.of(
             rmgr.makeNumber(1.0),
             rmgr.makeNumber("1"),
             rmgr.makeNumber(1),
@@ -103,7 +102,7 @@ public class MixedArithmeticsTest extends SolverBasedTest0.ParameterizedSolverBa
   public void createRational2NumberTest() throws SolverException, InterruptedException {
     RationalFormula num1 = rmgr.makeNumber(1.5);
     for (RationalFormula num2 :
-        List.of(
+        ImmutableList.of(
             rmgr.makeNumber(1.5),
             rmgr.makeNumber("1.5"),
             rmgr.makeNumber(BigDecimal.valueOf(1.5)),

--- a/src/org/sosy_lab/java_smt/test/SolverThreadLocalityTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverThreadLocalityTest.java
@@ -15,7 +15,6 @@ import static org.sosy_lab.java_smt.test.ProverEnvironmentSubject.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Truth;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -385,7 +384,7 @@ public class SolverThreadLocalityTest extends SolverBasedTest0.ParameterizedSolv
     // Boolector and Bitwuzla do not support integers, so we have to use two different versions
     // for this test.
     BooleanFormula formula =
-        List.of(Solvers.BOOLECTOR, Solvers.BITWUZLA).contains(solverToUse())
+        ImmutableList.of(Solvers.BOOLECTOR, Solvers.BITWUZLA).contains(solverToUse())
             ? bmgr.makeFalse()
             : hardProblem.generate(DEFAULT_PROBLEM_SIZE);
 

--- a/src/org/sosy_lab/java_smt/test/SolverVisitorTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverVisitorTest.java
@@ -556,7 +556,7 @@ public class SolverVisitorTest extends SolverBasedTest0.ParameterizedSolverBased
     checkKind(fpmgr.max(x, y), FunctionDeclarationKind.FP_MAX);
     checkKind(fpmgr.min(x, y), FunctionDeclarationKind.FP_MIN);
     checkKind(fpmgr.sqrt(x), FunctionDeclarationKind.FP_SQRT);
-    if (!List.of(Solvers.CVC4, Solvers.CVC5, Solvers.BITWUZLA)
+    if (!ImmutableList.of(Solvers.CVC4, Solvers.CVC5, Solvers.BITWUZLA)
         .contains(solverToUse())) { // CVC4/CVC5 and bitwuzla do not support this operation
       // On Bitwuzla we replaces "fp_to_bv(fpTerm)" with "newVar" and the adds the assertion
       // "fpTerm = bv_to_fp(newVar)" as a side condition. Unfortunately this workaround will not
@@ -589,7 +589,7 @@ public class SolverVisitorTest extends SolverBasedTest0.ParameterizedSolverBased
           }
         };
 
-    for (int num : List.of(0, 1, 4, 16, 256, 1024)) {
+    for (int num : ImmutableList.of(0, 1, 4, 16, 256, 1024)) {
       Formula bv2fp = fpmgr.fromIeeeBitvector(bvmgr.makeBitvector(16, num), fpType);
       mgr.visit(bv2fp, visitor);
       Formula fp2bv = fpmgr.toIeeeBitvector(fpmgr.makeNumber(num, fpType));

--- a/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/StringFormulaManagerTest.java
@@ -99,7 +99,7 @@ public class StringFormulaManagerTest extends SolverBasedTest0.ParameterizedSolv
 
   private void assertDistinct(IntegerFormula num1, IntegerFormula num2)
       throws SolverException, InterruptedException {
-    assertThatFormula(imgr.distinct(List.of(num1, num2))).isTautological();
+    assertThatFormula(imgr.distinct(ImmutableList.of(num1, num2))).isTautological();
   }
 
   private void assertEqual(StringFormula str1, StringFormula str2)
@@ -1041,7 +1041,7 @@ public class StringFormulaManagerTest extends SolverBasedTest0.ParameterizedSolv
 
     if (solverToUse() == Solvers.PRINCESS) {
       for (String invalidStr :
-          List.of(
+          ImmutableList.of(
               "\\u{10000}",
               Character.toString(0x10000),
               "\\u{2FFFF}",


### PR DESCRIPTION
… to directly show the immutability.

 This might optimise internal operations, e.g.,
 avoid copies from List to other Lists, if all are ImmutableLists.