### PR TITLE
Improve separation logic (CVC4 and CVC5)

### DIFF
--- a/src/org/sosy_lab/java_smt/api/SLFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/api/SLFormulaManager.java
@@ -2,7 +2,7 @@
 // an API wrapper for a collection of SMT solvers:
 // https://github.com/sosy-lab/java-smt
 //
-// SPDX-FileCopyrightText: 2020 Dirk Beyer <https://www.sosy-lab.org>
+// SPDX-FileCopyrightText: 2025 Dirk Beyer <https://www.sosy-lab.org>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,18 +15,73 @@ package org.sosy_lab.java_smt.api;
  * all formulae for one heap need to use matching types (sorts) for the AdressFormulae and
  * ValueFormulae. The user has to take care of this, otherwise the {@link ProverEnvironment}
  * complains at runtime!
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Separation_logic">Separation Logic</a>
+ * @see <a href="https://cacm.acm.org/research/separation-logic/>Separation Logic</a>
+ * @see <a
+ *     href="https://www.cs.cmu.edu/afs/cs.cmu.edu/project/fox-19/member/jcr/www15818As2011/cs818A3-11.html">15-818A3
+ *     Introduction to Separation Logic (6 units) Spring 2011</a>
+ * @see <a href="https://www.philipzucker.com/executable-seperation>Modeling Separation Logic with
+ *     Python Dicts and Z3</a>
  */
 @SuppressWarnings("MethodTypeParameterName")
 public interface SLFormulaManager {
 
+  /**
+   * Creates a formula representing the "separating conjunction" (*) of two Boolean formulas. In
+   * separation logic, the separating conjunction asserts that the two formulas describe disjoint
+   * parts of the heap. It is similar to the logical AND operator, but with the additional
+   * constraint that the memory regions described by the two formulas do not overlap.
+   *
+   * @return a Boolean formula representing the separating conjunction of {@code f1} and {@code f2}.
+   */
   BooleanFormula makeStar(BooleanFormula f1, BooleanFormula f2);
 
+  /**
+   * Creates a formula representing a "points-to" relation in the heap. The "points-to" relation
+   * asserts that a pointer points to a specific value in memory.
+   *
+   * @param <AF> the type of the address formula.
+   * @param <VF> the type of the value formula.
+   * @param ptr the pointer formula.
+   * @param to the value formula.
+   * @return a Boolean formula representing the "points-to" relation.
+   */
   <AF extends Formula, VF extends Formula> BooleanFormula makePointsTo(AF ptr, VF to);
 
+  /**
+   * Creates a formula representing the "magic wand" (-*) operator in separation logic. The "magic
+   * wand" operator asserts that if the first formula holds, then the second formula can be added to
+   * the heap without conflict. It is a form of implication (=>) that takes into account the
+   * disjointness of memory regions.
+   *
+   * @return a Boolean formula representing the "magic wand" of {@code f1} and {@code f2}.
+   */
   BooleanFormula makeMagicWand(BooleanFormula f1, BooleanFormula f2);
 
+  /**
+   * Creates a formula representing an empty heap. The empty heap formula asserts that no memory is
+   * allocated for the given address and value types.
+   *
+   * @param <AF> the type of the address formula.
+   * @param <VF> the type of the value formula.
+   * @param <AT> the type of the address formula type.
+   * @param <VT> the type of the value formula type.
+   * @param pAddressType the type of the address formula.
+   * @param pValueType the type of the value formula.
+   * @return a Boolean formula representing an empty heap.
+   */
   <AF extends Formula, VF extends Formula, AT extends FormulaType<AF>, VT extends FormulaType<VF>>
-      BooleanFormula makeEmptyHeap(AT pAdressType, VT pValueType);
+      BooleanFormula makeEmptyHeap(AT pAddressType, VT pValueType);
 
+  /**
+   * Creates a formula representing the "nil" element for a given address type. The "nil" element is
+   * used to represent a null pointer or an unallocated memory address.
+   *
+   * @param <AF> the type of the address formula.
+   * @param <AT> the type of the address formula type.
+   * @param pAdressType the type of the address formula.
+   * @return a formula representing the "nil" element for the given address type.
+   */
   <AF extends Formula, AT extends FormulaType<AF>> AF makeNilElement(AT pAdressType);
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -29,7 +29,7 @@ import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
 public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
 
-  private final boolean generateModels;
+  protected final boolean generateModels;
   private final boolean generateAllSat;
   protected final boolean generateUnsatCores;
   private final boolean generateUnsatCoresOverAssumptions;

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4SLFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4SLFormulaManager.java
@@ -45,6 +45,14 @@ public class CVC4SLFormulaManager extends AbstractSLFormulaManager<Expr, Type, E
 
   @Override
   protected Expr makeNilElement(Type pType) {
+    // TODO CVC4 bindings for Java do not support creation of SEP_NIL via mkTerm.
+    //  It is unclear whether this method ever worked.
+    //  CVC4 is deprecated and we will not investigate here.
+    //
+    // Executing this method will cause the following exception:
+    //     Illegal argument detected: CVC4::Expr CVC4::ExprManager::mkExpr(CVC4::Kind, CVC4::Expr)
+    //     `kind' is a bad argument; ... Only operator-style expressions are made with mkExpr();
+    //     to make variables and constants, see mkVar(), mkBoundVar(), and mkConst().
     return exprManager.mkExpr(Kind.SEP_NIL, pType.mkGroundTerm());
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5InterpolatingProver.java
@@ -48,7 +48,7 @@ public class CVC5InterpolatingProver extends CVC5AbstractProver<String>
       CVC5FormulaCreator pFormulaCreator,
       ShutdownNotifier pShutdownNotifier,
       int randomSeed,
-      Set<ProverOptions> pOptions,
+      ImmutableSet<ProverOptions> pOptions,
       FormulaManager pMgr,
       ImmutableMap<String, String> pFurtherOptionsMap,
       boolean pValidateInterpolants) {
@@ -66,13 +66,13 @@ public class CVC5InterpolatingProver extends CVC5AbstractProver<String>
    * produce-interpolants which is set here. From CVC5AbstractProver Line 66
    */
   @Override
-  protected void setSolverOptions(
+  protected Solver getNewSolver(
       int randomSeed,
       Set<ProverOptions> pOptions,
-      ImmutableMap<String, String> pFurtherOptionsMap,
-      Solver pSolver) {
-    super.setSolverOptions(randomSeed, pOptions, pFurtherOptionsMap, pSolver);
-    pSolver.setOption("produce-interpolants", "true");
+      ImmutableMap<String, String> pFurtherOptionsMap) {
+    Solver newSolver = super.getNewSolver(randomSeed, pOptions, pFurtherOptionsMap);
+    newSolver.setOption("produce-interpolants", "true");
+    return newSolver;
   }
 
   @Override
@@ -184,8 +184,7 @@ public class CVC5InterpolatingProver extends CVC5AbstractProver<String>
     Term phiMinus = bmgr.andImpl(formulasB);
 
     // Uses a separate Solver instance to leave the original solver-context unmodified
-    Solver itpSolver = new Solver(termManager);
-    setSolverOptions(seed, solverOptions, furtherOptionsMap, itpSolver);
+    Solver itpSolver = getNewSolver(seed, solverOptions, furtherOptionsMap);
 
     Term interpolant;
     try {
@@ -225,9 +224,8 @@ public class CVC5InterpolatingProver extends CVC5AbstractProver<String>
         Sets.difference(interpolantSymbols, intersection));
 
     // build and check both Craig interpolation formulas with the generated interpolant.
-    Solver validationSolver = new Solver(termManager);
     // interpolation option is not required for validation
-    super.setSolverOptions(seed, solverOptions, furtherOptionsMap, validationSolver);
+    Solver validationSolver = getNewSolver(seed, solverOptions, furtherOptionsMap);
     try {
       validationSolver.push();
       validationSolver.assertFormula(termManager.mkTerm(Kind.IMPLIES, phiPlus, interpolant));

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
@@ -14,6 +14,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Splitter.MapSplitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.github.cvc5.CVC5ApiRecoverableException;
 import io.github.cvc5.Solver;
 import io.github.cvc5.TermManager;
@@ -221,7 +222,7 @@ public final class CVC5SolverContext extends AbstractSolverContext {
         creator,
         shutdownNotifier,
         randomSeed,
-        pOptions,
+        ImmutableSet.copyOf(pOptions),
         getFormulaManager(),
         settings.furtherOptionsMap);
   }
@@ -239,7 +240,7 @@ public final class CVC5SolverContext extends AbstractSolverContext {
         creator,
         shutdownNotifier,
         randomSeed,
-        pOptions,
+        ImmutableSet.copyOf(pOptions),
         getFormulaManager(),
         settings.furtherOptionsMap,
         settings.validateInterpolants);

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5TheoremProver.java
@@ -9,7 +9,7 @@
 package org.sosy_lab.java_smt.solvers.cvc5;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Set;
+import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
@@ -24,8 +24,8 @@ class CVC5TheoremProver extends CVC5AbstractProver<Void>
   protected CVC5TheoremProver(
       CVC5FormulaCreator pFormulaCreator,
       ShutdownNotifier pShutdownNotifier,
-      @SuppressWarnings("unused") int randomSeed,
-      Set<ProverOptions> pOptions,
+      int randomSeed,
+      ImmutableSet<ProverOptions> pOptions,
       FormulaManager pMgr,
       ImmutableMap<String, String> pFurtherOptionsMap) {
     super(pFormulaCreator, pShutdownNotifier, randomSeed, pOptions, pMgr, pFurtherOptionsMap);

--- a/src/org/sosy_lab/java_smt/test/BooleanFormulaSubject.java
+++ b/src/org/sosy_lab/java_smt/test/BooleanFormulaSubject.java
@@ -12,6 +12,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assert_;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.FluentIterable;
 import com.google.common.truth.Fact;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.SimpleSubjectBuilder;
@@ -69,9 +70,12 @@ public final class BooleanFormulaSubject extends Subject {
     return assert_().about(booleanFormulasOf(context));
   }
 
-  private void checkIsUnsat(final BooleanFormula subject, final Fact expected)
+  private void checkIsUnsat(
+      final BooleanFormula subject, final Fact expected, ProverOptions... options)
       throws SolverException, InterruptedException {
-    try (ProverEnvironment prover = context.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
+    options =
+        FluentIterable.of(ProverOptions.GENERATE_MODELS, options).toArray(ProverOptions.class);
+    try (ProverEnvironment prover = context.newProverEnvironment(options)) {
 
       prover.push(subject);
       if (prover.isUnsat()) {
@@ -94,7 +98,8 @@ public final class BooleanFormulaSubject extends Subject {
   /**
    * Check that the subject is unsatisfiable. Will show a model (satisfying assignment) on failure.
    */
-  public void isUnsatisfiable() throws SolverException, InterruptedException {
+  public void isUnsatisfiable(ProverOptions... options)
+      throws SolverException, InterruptedException {
     if (context.getFormulaManager().getBooleanFormulaManager().isTrue(formulaUnderTest)) {
       failWithoutActual(
           Fact.fact("expected to be", "unsatisfiable"),
@@ -102,11 +107,11 @@ public final class BooleanFormulaSubject extends Subject {
       return;
     }
 
-    checkIsUnsat(formulaUnderTest, Fact.simpleFact("expected to be unsatisfiable"));
+    checkIsUnsat(formulaUnderTest, Fact.simpleFact("expected to be unsatisfiable"), options);
   }
 
   /** Check that the subject is satisfiable. Will show an unsat core on failure. */
-  public void isSatisfiable() throws SolverException, InterruptedException {
+  public void isSatisfiable(ProverOptions... options) throws SolverException, InterruptedException {
     final BooleanFormulaManager bmgr = context.getFormulaManager().getBooleanFormulaManager();
     if (bmgr.isFalse(formulaUnderTest)) {
       failWithoutActual(
@@ -115,14 +120,14 @@ public final class BooleanFormulaSubject extends Subject {
       return;
     }
 
-    try (ProverEnvironment prover = context.newProverEnvironment()) {
+    try (ProverEnvironment prover = context.newProverEnvironment(options)) {
       prover.push(formulaUnderTest);
       if (!prover.isUnsat()) {
         return; // success
       }
     }
 
-    reportUnsatCoreForUnexpectedUnsatisfiableFormula();
+    reportUnsatCoreForUnexpectedUnsatisfiableFormula(options);
   }
 
   /**
@@ -160,10 +165,11 @@ public final class BooleanFormulaSubject extends Subject {
     reportUnsatCoreForUnexpectedUnsatisfiableFormula();
   }
 
-  private void reportUnsatCoreForUnexpectedUnsatisfiableFormula()
+  private void reportUnsatCoreForUnexpectedUnsatisfiableFormula(ProverOptions... options)
       throws InterruptedException, SolverException, AssertionError {
-    try (ProverEnvironment prover =
-        context.newProverEnvironment(ProverOptions.GENERATE_UNSAT_CORE)) {
+    options =
+        FluentIterable.of(ProverOptions.GENERATE_UNSAT_CORE, options).toArray(ProverOptions.class);
+    try (ProverEnvironment prover = context.newProverEnvironment(options)) {
       // Try to report unsat core for failure message if the solver supports it.
       for (BooleanFormula part :
           context
@@ -199,7 +205,8 @@ public final class BooleanFormulaSubject extends Subject {
    * satisfiability of the subject and unsatisfiability of the negated subject in two steps to
    * improve error messages.
    */
-  public void isTautological() throws SolverException, InterruptedException {
+  public void isTautological(ProverOptions... options)
+      throws SolverException, InterruptedException {
     if (context.getFormulaManager().getBooleanFormulaManager().isFalse(formulaUnderTest)) {
       failWithoutActual(
           Fact.fact("expected to be", "tautological"),
@@ -208,7 +215,8 @@ public final class BooleanFormulaSubject extends Subject {
     }
     checkIsUnsat(
         context.getFormulaManager().getBooleanFormulaManager().not(formulaUnderTest),
-        Fact.fact("expected to be", "tautological"));
+        Fact.fact("expected to be", "tautological"),
+        options);
   }
 
   /**

--- a/src/org/sosy_lab/java_smt/test/SLFormulaManagerTest.java
+++ b/src/org/sosy_lab/java_smt/test/SLFormulaManagerTest.java
@@ -1,0 +1,309 @@
+// This file is part of JavaSMT,
+// an API wrapper for a collection of SMT solvers:
+// https://github.com/sosy-lab/java-smt
+//
+// SPDX-FileCopyrightText: 2025 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.java_smt.test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.FormulaType;
+import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
+import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
+import org.sosy_lab.java_smt.api.SolverException;
+
+public class SLFormulaManagerTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
+
+  private BooleanFormula makeStarAll(List<BooleanFormula> formulas) {
+    return formulas.stream().reduce(slmgr::makeStar).orElse(bmgr.makeTrue());
+  }
+
+  protected void requireSepNil() {
+    assume()
+        .withMessage("Java bindings for solver %s do not support SEP_NIL", solverToUse())
+        .that(solverToUse())
+        .isNotEqualTo(Solvers.CVC4);
+  }
+
+  protected void requireMultipleHeapSorts() {
+    assume()
+        .withMessage(
+            "Java bindings for solver %s do not support multiple heap sorts", solverToUse())
+        .that(solverToUse())
+        .isNotEqualTo(Solvers.CVC4);
+  }
+
+  @Before
+  public void setup() {
+    requireSeparationLogic();
+  }
+
+  @Test
+  public void testStackWithoutSL() throws InterruptedException, SolverException {
+    BooleanFormula noSL = imgr.equal(imgr.makeNumber(1), imgr.makeVariable("x"));
+
+    assertThatFormula(noSL).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testMakeEmp() throws InterruptedException, SolverException {
+    BooleanFormula emptyHeapInt =
+        slmgr.makeEmptyHeap(FormulaType.IntegerType, FormulaType.IntegerType);
+
+    assertThatFormula(emptyHeapInt).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testMakeEmptoP2() throws InterruptedException, SolverException {
+    requireMultipleHeapSorts();
+    // Actually, no solver supports multiple heap sorts. However, our bindings for CVC5
+    // apply non-incremental mode for SL and use distinct solver instances for distinct queries.
+
+    BooleanFormula emptyHeapInt =
+        slmgr.makeEmptyHeap(FormulaType.RationalType, FormulaType.BooleanType);
+    BooleanFormula emptyHeapRat =
+        slmgr.makeEmptyHeap(FormulaType.IntegerType, FormulaType.IntegerType);
+    BooleanFormula query = bmgr.and(emptyHeapInt, emptyHeapRat);
+
+    assertThatFormula(query).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testNotNilPtoNil() throws InterruptedException, SolverException {
+    requireSepNil();
+
+    IntegerFormula nil = slmgr.makeNilElement(FormulaType.IntegerType);
+    BooleanFormula nilPtoNil = slmgr.makePointsTo(nil, nil);
+
+    assertThatFormula(nilPtoNil).isUnsatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testNilPtoValue() throws InterruptedException, SolverException {
+    requireSepNil();
+
+    IntegerFormula nil = slmgr.makeNilElement(FormulaType.IntegerType);
+    IntegerFormula value = imgr.makeNumber(42);
+    BooleanFormula nilPtoValue = slmgr.makePointsTo(nil, value);
+
+    assertThatFormula(nilPtoValue).isUnsatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testXPtoNil() throws InterruptedException, SolverException {
+    requireSepNil();
+
+    IntegerFormula ptr = imgr.makeVariable("p");
+    IntegerFormula nil = slmgr.makeNilElement(FormulaType.IntegerType);
+    BooleanFormula ptoNil = slmgr.makePointsTo(ptr, nil);
+
+    assertThatFormula(ptoNil).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testXPtoValue() throws InterruptedException, SolverException {
+    IntegerFormula ptr = imgr.makeVariable("p");
+    IntegerFormula value = imgr.makeNumber(42);
+    BooleanFormula ptoValue = slmgr.makePointsTo(ptr, value);
+
+    assertThatFormula(ptoValue).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testPPtoNilThenPPtoNil() throws SolverException, InterruptedException {
+    requireSepNil();
+
+    IntegerFormula ptr = imgr.makeVariable("p");
+    IntegerFormula nil = slmgr.makeNilElement(FormulaType.IntegerType);
+    BooleanFormula ptoNil = slmgr.makePointsTo(ptr, nil);
+
+    assertThatFormula(ptoNil).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+
+    // test repeated non-incremental solving in CVC5
+    try (ProverEnvironment prover =
+        context.newProverEnvironment(ProverOptions.ENABLE_SEPARATION_LOGIC)) {
+      prover.push(ptoNil);
+      assertThatEnvironment(prover).isSatisfiable();
+      assertThatEnvironment(prover).isSatisfiable();
+      prover.pop();
+    }
+  }
+
+  @Test
+  public void testPtoNilThenPPto42() throws SolverException, InterruptedException {
+    requireSepNil();
+
+    IntegerFormula ptr = imgr.makeVariable("p");
+    IntegerFormula nil = slmgr.makeNilElement(FormulaType.IntegerType);
+    IntegerFormula value = imgr.makeNumber(42);
+    BooleanFormula ptoNil = slmgr.makePointsTo(ptr, nil);
+    BooleanFormula ptoValue = slmgr.makePointsTo(ptr, value);
+
+    assertThatFormula(ptoNil).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+    assertThatFormula(ptoValue).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+
+    // test repeated non-incremental solving in CVC5
+    try (ProverEnvironment prover =
+        context.newProverEnvironment(ProverOptions.ENABLE_SEPARATION_LOGIC)) {
+      prover.push(ptoNil);
+      assertThatEnvironment(prover).isSatisfiable();
+      prover.pop();
+      prover.push(ptoValue);
+      assertThatEnvironment(prover).isSatisfiable();
+      prover.pop();
+    }
+  }
+
+  @Test
+  public void testPtoAndEmp() throws InterruptedException, SolverException {
+    IntegerFormula ptr = imgr.makeVariable("p");
+    IntegerFormula value = imgr.makeNumber(42);
+    BooleanFormula pto = slmgr.makePointsTo(ptr, value);
+    BooleanFormula emp = slmgr.makeEmptyHeap(FormulaType.IntegerType, FormulaType.IntegerType);
+    BooleanFormula combined = slmgr.makeStar(pto, emp);
+
+    assertThatFormula(combined).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testStar() throws InterruptedException, SolverException {
+    IntegerFormula ptr1 = imgr.makeVariable("ptoP1");
+    IntegerFormula ptr2 = imgr.makeVariable("ptoP2");
+    IntegerFormula value1 = imgr.makeNumber(42);
+    IntegerFormula value2 = imgr.makeNumber(43);
+
+    BooleanFormula ptoP1V1 = slmgr.makePointsTo(ptr1, value1);
+    BooleanFormula ptoP1V2 = slmgr.makePointsTo(ptr1, value2);
+    BooleanFormula ptoP2V1 = slmgr.makePointsTo(ptr2, value1);
+    BooleanFormula ptoP2V2 = slmgr.makePointsTo(ptr2, value2);
+
+    assertThatFormula(slmgr.makeStar(ptoP1V1, ptoP1V1))
+        .isUnsatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+    assertThatFormula(slmgr.makeStar(ptoP1V1, ptoP1V2))
+        .isUnsatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+    assertThatFormula(slmgr.makeStar(ptoP1V1, ptoP2V1))
+        .isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+    assertThatFormula(slmgr.makeStar(ptoP1V1, ptoP2V2))
+        .isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+
+    assertThatFormula(
+            bmgr.implication(
+                slmgr.makeStar(ptoP1V1, ptoP2V2), imgr.distinct(ImmutableList.of(ptr1, ptr2))))
+        .isTautological(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testSimpleTreeValid() throws InterruptedException, SolverException {
+    requireSepNil();
+
+    // lets build a tree:
+    // - each node consists of two integers: left and right
+    // - each node pointer points to the left integer, the right integer is at pointer+1
+    IntegerFormula nil = slmgr.makeNilElement(FormulaType.IntegerType);
+    IntegerFormula one = imgr.makeNumber(1);
+    IntegerFormula root = imgr.makeVariable("root");
+    IntegerFormula left = imgr.makeVariable("left");
+    IntegerFormula right = imgr.makeVariable("right");
+    BooleanFormula ptoRootLeft = slmgr.makePointsTo(root, left);
+    BooleanFormula ptoRootRight = slmgr.makePointsTo(imgr.add(root, one), left);
+    BooleanFormula ptoLeftNil = slmgr.makePointsTo(left, nil);
+    BooleanFormula ptoRightNil = slmgr.makePointsTo(right, nil);
+
+    // tree: (root -> left) * (root+1 -> right) * (left -> nil) * (right -> nil)
+    BooleanFormula sepTree =
+        makeStarAll(ImmutableList.of(ptoRootLeft, ptoRootRight, ptoLeftNil, ptoRightNil));
+
+    assertThatFormula(sepTree).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+    try (ProverEnvironment prover =
+        context.newProverEnvironment(
+            ProverOptions.ENABLE_SEPARATION_LOGIC, ProverOptions.GENERATE_MODELS)) {
+      prover.push(sepTree);
+      assertThatEnvironment(prover).isSatisfiable();
+      try (Model model = prover.getModel()) {
+        // check that root, left and right are different
+        BigInteger valRoot = model.evaluate(root);
+        BigInteger valLeft = model.evaluate(left);
+        BigInteger valRight = model.evaluate(right);
+        BigInteger valNil = model.evaluate(nil);
+        assertThat(ImmutableSet.of(valRoot, valLeft, valRight, valNil)).hasSize(4); // all different
+        assertThat(valRoot.add(BigInteger.ONE)).isNoneOf(valLeft, valRight, valNil);
+      }
+      prover.pop();
+    }
+  }
+
+  @Test
+  public void testSimpleTreeInvalid() throws InterruptedException, SolverException {
+    requireSepNil();
+
+    IntegerFormula nil = slmgr.makeNilElement(FormulaType.IntegerType);
+    IntegerFormula root = imgr.makeVariable("root");
+    IntegerFormula left = imgr.makeVariable("left");
+    IntegerFormula right = imgr.makeVariable("right");
+    BooleanFormula ptoRootLeft = slmgr.makePointsTo(root, left);
+    BooleanFormula ptoRootRight = slmgr.makePointsTo(imgr.add(root, imgr.makeNumber(1)), right);
+    BooleanFormula ptoLeftNil = slmgr.makePointsTo(left, nil);
+    BooleanFormula ptoLeftRight = slmgr.makePointsTo(left, right);
+
+    // tree: (root -> left) * (root+1 -> right) * (left -> nil) * (left -> right)
+    BooleanFormula sepTree =
+        makeStarAll(ImmutableList.of(ptoRootLeft, ptoRootRight, ptoLeftNil, ptoLeftRight));
+
+    // left has two different values -> invalid
+    assertThatFormula(sepTree).isUnsatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testListValid() throws InterruptedException, SolverException {
+    requireSepNil();
+
+    IntegerFormula nil = slmgr.makeNilElement(FormulaType.IntegerType);
+    List<IntegerFormula> nodes = new ArrayList<>();
+    for (int i = 0; i <= 10; i++) {
+      nodes.add(imgr.makeVariable("n" + i));
+    }
+    List<BooleanFormula> ptos = new ArrayList<>();
+    for (int i = 0; i < nodes.size() - 1; i++) {
+      ptos.add(slmgr.makePointsTo(nodes.get(i), nodes.get(i + 1)));
+    }
+    BooleanFormula ptoLastNil = slmgr.makePointsTo(Iterables.getLast(nodes), nil);
+
+    // list: n1 -> n2 -> ... -> nil
+    BooleanFormula sepTree = slmgr.makeStar(makeStarAll(ptos), ptoLastNil);
+    assertThatFormula(sepTree).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+
+  @Test
+  public void testListValidCycle() throws InterruptedException, SolverException {
+    List<IntegerFormula> nodes = new ArrayList<>();
+    for (int i = 0; i <= 10; i++) {
+      nodes.add(imgr.makeVariable("n" + i));
+    }
+    List<BooleanFormula> ptos = new ArrayList<>();
+    for (int i = 0; i < nodes.size() - 1; i++) {
+      ptos.add(slmgr.makePointsTo(nodes.get(i), nodes.get(i + 1)));
+    }
+    BooleanFormula ptoLastNil =
+        slmgr.makePointsTo(Iterables.getLast(nodes), Iterables.getFirst(nodes, null));
+
+    // list: (n1 -> n2 -> ... -> n10) * cycle: (n10 -> n1)
+    BooleanFormula sepTree = slmgr.makeStar(makeStarAll(ptos), ptoLastNil);
+    assertThatFormula(sepTree).isSatisfiable(ProverOptions.ENABLE_SEPARATION_LOGIC);
+  }
+}

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -47,6 +47,7 @@ import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.QuantifiedFormulaManager;
 import org.sosy_lab.java_smt.api.RationalFormulaManager;
+import org.sosy_lab.java_smt.api.SLFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
@@ -104,6 +105,7 @@ public abstract class SolverBasedTest0 {
   protected @Nullable FloatingPointFormulaManager fpmgr;
   protected @Nullable StringFormulaManager smgr;
   protected @Nullable EnumerationFormulaManager emgr;
+  protected @Nullable SLFormulaManager slmgr;
   protected ShutdownManager shutdownManager = ShutdownManager.create();
 
   protected ShutdownNotifier shutdownNotifierToUse() {
@@ -191,6 +193,11 @@ public abstract class SolverBasedTest0 {
       emgr = mgr.getEnumerationFormulaManager();
     } catch (UnsupportedOperationException e) {
       emgr = null;
+    }
+    try {
+      slmgr = mgr.getSLFormulaManager();
+    } catch (UnsupportedOperationException e) {
+      slmgr = null;
     }
   }
 
@@ -303,6 +310,13 @@ public abstract class SolverBasedTest0 {
     assume()
         .withMessage("Solver %s does not support the theory of enumerations", solverToUse())
         .that(emgr)
+        .isNotNull();
+  }
+
+  protected final void requireSeparationLogic() {
+    assume()
+        .withMessage("Solver %s does not support the theory of separation logic", solverToUse())
+        .that(slmgr)
         .isNotNull();
   }
 


### PR DESCRIPTION
Our implementation for SL seems to have been broken since a long time.

This PR improves the situation:
- for CVC4, which is deprecated, we noticed a broken method for SEP_NIL (i.e., the NULL element in SL) in the bindings. There is currently  no way to fix it. :cry: 
- for CVC5, we properly implement the required options for solving SL queries and fix the behaviour of the non-incremental solver stack used for SL in CVC5.
- we add tests for SL, which were missing since the initial implementation. :cry: 