### PR TITLE
MathSAT: Disable enumerations when OptiMathSat is used

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5FormulaCreator.java
@@ -158,7 +158,9 @@ class Mathsat5FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
   private static final Pattern FLOATING_POINT_PATTERN = Pattern.compile("^(\\d+)_(\\d+)_(\\d+)$");
   private static final Pattern BITVECTOR_PATTERN = Pattern.compile("^(\\d+)_(\\d+)$");
 
-  Mathsat5FormulaCreator(final Long msatEnv) {
+  private final boolean usingOptiMathSAT;
+
+  Mathsat5FormulaCreator(final Long msatEnv, boolean pUsingOptiMathSAT5) {
     super(
         msatEnv,
         msat_get_bool_type(msatEnv),
@@ -166,6 +168,7 @@ class Mathsat5FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
         msat_get_rational_type(msatEnv),
         null,
         null);
+    usingOptiMathSAT = pUsingOptiMathSAT5;
   }
 
   @Override
@@ -352,7 +355,8 @@ class Mathsat5FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
       return visitor.visitConstant(formula, getRoundingMode(f));
     } else if (msat_term_is_constant(environment, f)) {
       return visitor.visitFreeVariable(formula, msat_term_repr(f));
-    } else if (msat_is_enum_type(environment, msat_term_get_type(f))) {
+    } else if (!usingOptiMathSAT // OptiMathSAT does not support enumerations
+        && msat_is_enum_type(environment, msat_term_get_type(f))) {
       assert !msat_term_is_constant(environment, f) : "Enumeration constants are no variables";
       assert arity == 0 : "Enumeration constants have no parameters";
       return visitor.visitConstant(formula, msat_term_repr(f));

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
@@ -200,7 +200,7 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
       msatEnv = msat_create_env(msatConf);
     }
     // Create Mathsat5FormulaCreator
-    Mathsat5FormulaCreator creator = new Mathsat5FormulaCreator(msatEnv);
+    Mathsat5FormulaCreator creator = new Mathsat5FormulaCreator(msatEnv, settings.loadOptimathsat5);
 
     // Create managers
     Mathsat5UFManager functionTheory = new Mathsat5UFManager(creator);
@@ -214,8 +214,11 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
     Mathsat5FloatingPointFormulaManager floatingPointTheory =
         new Mathsat5FloatingPointFormulaManager(creator, pFloatingPointRoundingMode);
     Mathsat5ArrayFormulaManager arrayTheory = new Mathsat5ArrayFormulaManager(creator);
-    Mathsat5EnumerationFormulaManager enumerationTheory =
-        new Mathsat5EnumerationFormulaManager(creator);
+    Mathsat5EnumerationFormulaManager enumerationTheory = null;
+    if (!settings.loadOptimathsat5) {
+      // OptiMathSAT does not support enumerations
+      enumerationTheory = new Mathsat5EnumerationFormulaManager(creator);
+    }
     Mathsat5FormulaManager manager =
         new Mathsat5FormulaManager(
             creator,


### PR DESCRIPTION
Hello,
this PR fixes the MathSAT visitor by skipping the  `msat_is_enum_type` call when OptiMathSAT is used. OptiMathSAT does not appear to support enumerations and JavaSMT will crash when we try to call this method in the visitor code