### PR TITLE
Add more files to remove for 'ant clean'

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -81,11 +81,13 @@ SPDX-License-Identifier: Apache-2.0
     <!-- Main targets -->
 
     <target name="clean" description="Clean">
-        <property name="jarFiles" value="${class.dir}/** ${ivy.module}-*.jar ivy-*.xml *.jar"/>
+        <property name="jarFiles" value="${class.dir}/** ${source.generated.dir}/** ${ivy.module}-*.jar ivy-*.xml *.jar"/>
+        <property name="docFiles" value="${documentation.javadoc.dir}/** ${z3.javadoc.dir}/**"/>
+        <property name="junitFiles" value="${junit.dir}/** JUnit-coverage/** JUnit.html"/>
         <property name="libraryFiles" value="*.so *.dll *.dylib dist/"/>
 
         <delete includeEmptyDirs="true">
-            <fileset dir="." includes="${libraryFiles} ${jarFiles} Javadoc-z3/"/>
+            <fileset dir="." includes="${libraryFiles} ${jarFiles} ${docFiles} ${junitFiles}"/>
             <fileset dir="lib/native/source/libmathsat5j" includes="*.so *.dll *.o"/>
             <fileset dir="lib/native/source/libbitwuzla" includes="install-linux/ install-linux-x64/ install-linux-arm64/ install-windows/ install-windows-x64/ build/ doc/ *.so *.dll bitwuzla_wrap.o"/>
             <fileset dir="lib/native/source/opensmt" includes="build/ doc/ install-linux-x64/ install-linux-arm64/ *.o *.so version.h"/>


### PR DESCRIPTION
Remove autogenerated code (AutoValue, `.apt-generated`), JavaDoc files and JUnit test results when `ant clean` is called