### PR TITLE
Enable bitvector tests for "Z3 with interpolation"

### DIFF
--- a/src/org/sosy_lab/java_smt/test/InterpolatingProverTest.java
+++ b/src/org/sosy_lab/java_smt/test/InterpolatingProverTest.java
@@ -244,6 +244,10 @@ public class InterpolatingProverTest extends SolverBasedTest0.ParameterizedSolve
   @Test
   public <T> void binaryBVInterpolation1() throws SolverException, InterruptedException {
     requireBitvectors();
+    assume()
+        .withMessage("Solver %s does not support interpolation over bitvectors", solverToUse())
+        .that(solverToUse())
+        .isNotEqualTo(Solvers.Z3_WITH_INTERPOLATION);
 
     InterpolatingProverEnvironment<T> stack = newEnvironmentForTest();
 
@@ -1046,6 +1050,10 @@ public class InterpolatingProverTest extends SolverBasedTest0.ParameterizedSolve
     requireBitvectors();
     requireInterpolation();
 
+    assume()
+        .withMessage("Solver %s does not support interpolation over bitvectors", solverToUse())
+        .that(solverToUse())
+        .isNotEqualTo(Solvers.Z3_WITH_INTERPOLATION);
     assume()
         .withMessage("Solver %s runs into timeout on this test", solverToUse())
         .that(solverToUse())

--- a/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
+++ b/src/org/sosy_lab/java_smt/test/SolverBasedTest0.java
@@ -241,10 +241,6 @@ public abstract class SolverBasedTest0 {
         .withMessage("Solver %s does not support the theory of bitvectors", solverToUse())
         .that(bvmgr)
         .isNotNull();
-    assume()
-        .withMessage("Solver %s does not support bitvectors for interpolation", solverToUse())
-        .that(solverToUse())
-        .isNotEqualTo(Solvers.Z3_WITH_INTERPOLATION);
   }
 
   protected final void requireBitvectorToInt() {

--- a/src/org/sosy_lab/java_smt/test/SolverVisitorTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverVisitorTest.java
@@ -339,7 +339,9 @@ public class SolverVisitorTest extends SolverBasedTest0.ParameterizedSolverBased
     // Yices does not support integer to bitvector conversions
     assume().that(solver).isNotEqualTo(Solvers.YICES2);
     // CVC4, CVC5 and Z3 will rewrite SBV_TO_INT to a term that only uses unsigned integers
-    assume().that(solver).isNoneOf(Solvers.Z3, Solvers.CVC4, Solvers.CVC5);
+    assume()
+        .that(solver)
+        .isNoneOf(Solvers.Z3, Solvers.Z3_WITH_INTERPOLATION, Solvers.CVC4, Solvers.CVC5);
     // Princess uses mod_casts internally, which makes it hard to figure out when conversion happen
     assume().that(solver).isNotEqualTo(Solvers.PRINCESS);
 


### PR DESCRIPTION
Hello

all bitvector tests are currently disabled for "Z3 with interpolation" as seem to be some issues when interpolating over bitvectors. Most bv test do work on Z3, though, and this PR enables them again, and only blacklists certain tests that also use interpolation