### PR TITLE
Cvc5: Fix parsing bug

### DIFF
--- a/src/org/sosy_lab/java_smt/basicimpl/FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/FormulaCreator.java
@@ -581,13 +581,4 @@ public abstract class FormulaCreator<TFormulaInfo, TType, TEnv, TFuncDecl> {
       @SuppressWarnings("unused") TFormulaInfo pAdditionalF, TFormulaInfo pF) {
     return convertValue(pF);
   }
-
-  /** Variable names (symbols) can be wrapped with "|". This function removes those chars. */
-  public String dequote(String s) {
-    int l = s.length();
-    if (s.charAt(0) == '|' && s.charAt(l - 1) == '|') {
-      return s.substring(1, l - 1);
-    }
-    return s;
-  }
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/Tokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/Tokenizer.java
@@ -23,6 +23,15 @@ public final class Tokenizer {
 
   private Tokenizer() {}
 
+  /** Variable names (symbols) can be wrapped with "|". This function removes those chars. */
+  public static String dequote(String s) {
+    int l = s.length();
+    if (s.charAt(0) == '|' && s.charAt(l - 1) == '|') {
+      return s.substring(1, l - 1);
+    }
+    return s;
+  }
+
   /**
    * Split up a sequence of lisp expressions.
    *

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
@@ -56,6 +56,7 @@ import org.sosy_lab.java_smt.api.StringFormula;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
 import org.sosy_lab.java_smt.basicimpl.FunctionDeclarationImpl;
+import org.sosy_lab.java_smt.basicimpl.Tokenizer;
 import org.sosy_lab.java_smt.solvers.cvc4.CVC4Formula.CVC4ArrayFormula;
 import org.sosy_lab.java_smt.solvers.cvc4.CVC4Formula.CVC4BitvectorFormula;
 import org.sosy_lab.java_smt.solvers.cvc4.CVC4Formula.CVC4BooleanFormula;
@@ -299,12 +300,12 @@ public class CVC4FormulaCreator extends FormulaCreator<Expr, Type, ExprManager, 
     return new CVC4RegexFormula(pTerm);
   }
 
-  String getName(Expr e) {
+  static String getName(Expr e) {
     checkState(!e.isNull());
     if (!e.isConst() && !e.isVariable()) {
       e = e.getOperator();
     }
-    return dequote(e.toString());
+    return Tokenizer.dequote(e.toString());
   }
 
   @SuppressWarnings("deprecation")

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4Model.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4Model.java
@@ -120,7 +120,7 @@ public class CVC4Model extends AbstractModel<Expr, Type, ExprManager> {
         creator.encapsulateWithTypeOf(pKeyExpr),
         creator.encapsulateWithTypeOf(valueExpr),
         creator.encapsulateBoolean(creator.getEnv().mkExpr(Kind.EQUAL, pKeyExpr, valueExpr)),
-        ((CVC4FormulaCreator) creator).getName(pKeyExpr),
+        CVC4FormulaCreator.getName(pKeyExpr),
         creator.convertValue(pKeyExpr, valueExpr),
         argumentInterpretationBuilder.build());
   }
@@ -211,7 +211,7 @@ public class CVC4Model extends AbstractModel<Expr, Type, ExprManager> {
             creator.encapsulateWithTypeOf(pKeyExpr),
             creator.encapsulateWithTypeOf(valueExpr),
             creator.encapsulateBoolean(creator.getEnv().mkExpr(Kind.EQUAL, pKeyExpr, valueExpr)),
-            ((CVC4FormulaCreator) creator).getName(pKeyExpr),
+            CVC4FormulaCreator.getName(pKeyExpr),
             creator.convertValue(pKeyExpr, valueExpr),
             argumentInterpretationBuilder.build()));
   }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
@@ -65,6 +65,7 @@ import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.api.visitors.TraversalProcess;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
 import org.sosy_lab.java_smt.basicimpl.FunctionDeclarationImpl;
+import org.sosy_lab.java_smt.basicimpl.Tokenizer;
 import org.sosy_lab.java_smt.solvers.cvc5.CVC5Formula.CVC5ArrayFormula;
 import org.sosy_lab.java_smt.solvers.cvc5.CVC5Formula.CVC5BitvectorFormula;
 import org.sosy_lab.java_smt.solvers.cvc5.CVC5Formula.CVC5BooleanFormula;
@@ -383,10 +384,10 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
       // Functions are packaged like this: (functionName arg1 arg2 ...)
       // But can use |(name)| to enable () inside of the variable name
       // TODO what happens for function names containing whitespace?
-      String dequoted = dequote(repr);
+      String dequoted = Tokenizer.dequote(repr);
       return Iterables.get(Splitter.on(' ').split(dequoted.substring(1)), 0);
     } else {
-      return dequote(repr);
+      return Tokenizer.dequote(repr);
     }
   }
 
@@ -457,7 +458,7 @@ public class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, 
         return visitor.visitQuantifier((BooleanFormula) formula, quant, freeVars, fBody);
 
       } else if (f.getKind() == Kind.CONSTANT) {
-        return visitor.visitFreeVariable(formula, dequote(f.toString()));
+        return visitor.visitFreeVariable(formula, Tokenizer.dequote(f.toString()));
 
       } else if (f.getKind() == Kind.APPLY_CONSTRUCTOR) {
         checkState(

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Parser.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Parser.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.sosy_lab.common.collect.Collections3;
+import org.sosy_lab.java_smt.basicimpl.Tokenizer;
 
 class CVC5Parser {
 
@@ -251,7 +252,7 @@ class CVC5Parser {
    * cached one is recorded in the given substitutions map.
    */
   private void registerNewTermSymbols(Term declaration, Map<Term, Term> substitutions) {
-    final String parsedTermString = creator.dequote(declaration.toString());
+    final String parsedTermString = Tokenizer.dequote(declaration.toString());
     final Sort parsedSort = declaration.getSort();
     final String parsedSortString = parsedSort.toString();
 

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtFormulaCreator.java
@@ -21,6 +21,7 @@ import org.sosy_lab.java_smt.api.FunctionDeclarationKind;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
 import org.sosy_lab.java_smt.basicimpl.FunctionDeclarationImpl;
+import org.sosy_lab.java_smt.basicimpl.Tokenizer;
 import org.sosy_lab.java_smt.solvers.opensmt.OpenSmtFormula.OpenSmtArrayFormula;
 import org.sosy_lab.java_smt.solvers.opensmt.OpenSmtFormula.OpenSmtBooleanFormula;
 import org.sosy_lab.java_smt.solvers.opensmt.OpenSmtFormula.OpenSmtIntegerFormula;
@@ -358,7 +359,7 @@ public final class OpenSmtFormulaCreator extends FormulaCreator<PTRef, SRef, Log
 
     if (logic.isVar(f)) {
       String varName = logic.getSymName(logic.getSymRef(f));
-      return visitor.visitFreeVariable(formula, dequote(varName));
+      return visitor.visitFreeVariable(formula, Tokenizer.dequote(varName));
     }
 
     String varName = logic.getSymName(logic.getSymRef(f));

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaCreator.java
@@ -33,6 +33,7 @@ import org.sosy_lab.java_smt.api.FunctionDeclarationKind;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
 import org.sosy_lab.java_smt.basicimpl.FunctionDeclarationImpl;
+import org.sosy_lab.java_smt.basicimpl.Tokenizer;
 
 class SmtInterpolFormulaCreator extends FormulaCreator<Term, Sort, Script, FunctionSymbol> {
 
@@ -212,7 +213,7 @@ class SmtInterpolFormulaCreator extends FormulaCreator<Term, Sort, Script, Funct
         } else if (app.equals(environment.getTheory().mFalse)) {
           return visitor.visitConstant(f, false);
         } else if (func.getDefinition() == null) {
-          return visitor.visitFreeVariable(f, dequote(input.toString()));
+          return visitor.visitFreeVariable(f, Tokenizer.dequote(input.toString()));
         } else {
           throw new UnsupportedOperationException("Unexpected nullary function " + input);
         }
@@ -254,7 +255,7 @@ class SmtInterpolFormulaCreator extends FormulaCreator<Term, Sort, Script, Funct
       assert t instanceof ApplicationTerm;
       return ((ApplicationTerm) t).getFunction().getName();
     } else {
-      return dequote(t.toString());
+      return Tokenizer.dequote(t.toString());
     }
   }
 


### PR DESCRIPTION
Hello,

our CVC5 parsing code has an issue that allows duplicate versions of the same variable to be created. The problem is that quotes are not removed from symbols when looking them up in the variable cache. Because of a new variable may be created when looking up a quoted symbol, even though the variable already exists without the quotes