### PR TITLE
optimize GitHub-CI workflow by ensuring that all project dependencies are downloaded only once per CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ on:
     branches: [ master ]
 
 env:
-  # Use a project-local directory for the Ivy cache to make it easy to share across platforms.
+  # Use a project-local relative directory for the Ivy cache to make it easy to share across platforms.
   # We place it inside the workspace so it's identical for Linux, macOS, and Windows.
-  IVY_CACHE_DIR: ${{ github.workspace }}/.ivy2-cache
+  IVY_CACHE_DIR: .ivy2-cache
 
 jobs:
   dependencies:


### PR DESCRIPTION
 Currently, our CI matrix consists of >20 jobs (Linux, macOS, and Windows across various Java versions and architectures). On new branches or when the cache expires, each of these jobs independently triggers a full download of dependencies via Ivy. This results in significant redundant network traffic and slow CI start times.

We solve this with a dedicated dependency job that runs at the start of the workflow. It performs a complete ant build-dependencies to fetch everything needed for all platforms. We cache the Ivy dependencies from a project-local directory (.ivy2-cache). This allows the same cache to be shared across Linux, macOS, and Windows runners. The cache key uses `ivy-shared-${{ github.run_id }}` with a fallback (`ivy-shared-`), ensuring the cache is always fresh.

This should result in a faster CI due to reduced total download time, and sosy-lab.org does not need to deliver >20 times the full dependencies, including all native solver libraries and jars.
