### PR TITLE
API change: convert the abstract class "FormulaType" to interface.

### DIFF
--- a/src/org/sosy_lab/java_smt/api/FormulaType.java
+++ b/src/org/sosy_lab/java_smt/api/FormulaType.java
@@ -412,29 +412,25 @@ public interface FormulaType<T extends Formula> {
     }
   }
 
-  @SuppressWarnings("ClassInitializationDeadlock")
   FormulaType<FloatingPointRoundingModeFormula> FloatingPointRoundingModeType =
-      new FloatingPointRoundingModeType();
+      new FormulaType<>() {
 
-  final class FloatingPointRoundingModeType
-      implements FormulaType<FloatingPointRoundingModeFormula> {
+        @Override
+        public boolean isFloatingPointRoundingModeType() {
+          return true;
+        }
 
-    @Override
-    public boolean isFloatingPointRoundingModeType() {
-      return true;
-    }
+        @Override
+        public String toString() {
+          return "FloatingPointRoundingMode";
+        }
 
-    @Override
-    public String toString() {
-      return "FloatingPointRoundingMode";
-    }
-
-    @Override
-    public String toSMTLIBString() {
-      throw new UnsupportedOperationException(
-          "rounding mode is not expected in symbol declarations");
-    }
-  }
+        @Override
+        public String toSMTLIBString() {
+          throw new UnsupportedOperationException(
+              "rounding mode is not expected in symbol declarations");
+        }
+      };
 
   @SuppressWarnings("MethodTypeParameterName")
   static <TD extends Formula, TR extends Formula> ArrayFormulaType<TD, TR> getArrayType(


### PR DESCRIPTION
The idea for this change was brought up in a [comment about potential API changes](https://github.com/sosy-lab/java-smt/pull/611#issuecomment-4058097915).

This change makes JavaSMT more open for user applications, as it allows them to define their own formula types and use them in JavaSMT. This also blocks us from marking this class as "sealed" at some time in the future, because users can inherit from it.

We can discuss benefit and/or negative effects from this change.