### PR TITLE
OpenSMT: Fix parallel build

### DIFF
--- a/build/build-publish-solvers/solver-opensmt.xml
+++ b/build/build-publish-solvers/solver-opensmt.xml
@@ -73,6 +73,7 @@ SPDX-License-Identifier: Apache-2.0
              It keeps old build commands and previous cmake-flags. -->
         <delete dir="${opensmt.path}/build" quiet="true"/>
         <exec executable="make" dir="${opensmt.path}" failonerror="false" resultproperty="build.returnCode">
+            <env key="CMAKE_BUILD_PARALLEL_LEVEL" value="8"/>
             <arg value="INSTALL_DIR=${opensmt.installPath}"/>
             <!-- The next arg is ONE large parameter. If executed manually outside of ant, please wrap it in quotes. -->
             <arg value="CMAKE_FLAGS=
@@ -80,7 +81,6 @@ SPDX-License-Identifier: Apache-2.0
               -DGMP_LIBRARY=${gmp-linux-x64.path}/lib/libgmp.a
               -DGMPXX_LIBRARY=${gmp-linux-x64.path}/lib/libgmpxx.a
               -DGMP_INCLUDE_DIR=${gmp-linux-x64.path}/include"/>
-            <arg value="-j8"/>
             <arg value="install"/>
         </exec>
 
@@ -121,6 +121,7 @@ SPDX-License-Identifier: Apache-2.0
              It keeps old build commands and previous cmake-flags. -->
         <delete dir="${opensmt.path}/build" quiet="true"/>
         <exec executable="make" dir="${opensmt.path}" failonerror="false" resultproperty="build.returnCode">
+            <env key="CMAKE_BUILD_PARALLEL_LEVEL" value="8"/>
             <arg value="INSTALL_DIR=${opensmt.installPath}"/>
             <!-- The next arg is ONE large parameter. If executed manually outside of ant, please wrap it in quotes. -->
             <arg value="CMAKE_FLAGS=
@@ -130,7 +131,6 @@ SPDX-License-Identifier: Apache-2.0
               -DGMP_LIBRARY=${gmp-linux-arm64.path}/lib/libgmp.a
               -DGMPXX_LIBRARY=${gmp-linux-arm64.path}/lib/libgmpxx.a
               -DGMP_INCLUDE_DIR=${gmp-linux-arm64.path}/include"/>
-            <arg value="-j8"/>
             <arg value="install"/>
         </exec>
 


### PR DESCRIPTION
Hello,

it turns out that the Makefile in OpenSMT is just a wrapper for CMake, and we need to set a flag there to get a parallel build. I've tested it with the new flag on my machine and the build now seems to be ~4 times faster