### PR TITLE
Bitwuzla: Optimize memory usage

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -169,7 +169,12 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
     checkGenerateModels();
     // special case for Bitwuzla: Models are not permanent and need to be closed
     // before any change is applied to the prover stack. So, we register the Model as Evaluator.
-    return getEvaluatorWithoutChecks();
+    return registerEvaluator(
+        new BitwuzlaModel(
+            env,
+            this,
+            creator,
+            Collections2.transform(getAssertedFormulas(), creator::extractInfo)));
   }
 
   /**
@@ -225,15 +230,9 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
     super.close();
   }
 
-  @SuppressWarnings("resource")
   @Override
-  protected BitwuzlaModel getEvaluatorWithoutChecks() {
-    return registerEvaluator(
-        new BitwuzlaModel(
-            env,
-            this,
-            creator,
-            Collections2.transform(getAssertedFormulas(), creator::extractInfo)));
+  protected BitwuzlaEvaluator getEvaluatorWithoutChecks() {
+    return registerEvaluator(new BitwuzlaEvaluator(this, creator));
   }
 
   public boolean isClosed() {

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -230,6 +230,7 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
     super.close();
   }
 
+  @SuppressWarnings("resource")
   @Override
   protected BitwuzlaEvaluator getEvaluatorWithoutChecks() {
     return registerEvaluator(new BitwuzlaEvaluator(this, creator));

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaEvaluator.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaEvaluator.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of JavaSMT,
+ * an API wrapper for a collection of SMT solvers:
+ * https://github.com/sosy-lab/java-smt
+ *
+ * SPDX-FileCopyrightText: 2026 Dirk Beyer <https://www.sosy-lab.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.sosy_lab.java_smt.solvers.bitwuzla;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import org.jspecify.annotations.Nullable;
+import org.sosy_lab.java_smt.basicimpl.AbstractEvaluator;
+import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
+import org.sosy_lab.java_smt.solvers.bitwuzla.api.Sort;
+import org.sosy_lab.java_smt.solvers.bitwuzla.api.Term;
+import org.sosy_lab.java_smt.solvers.bitwuzla.api.TermManager;
+
+class BitwuzlaEvaluator extends AbstractEvaluator<Term, Sort, TermManager> {
+  private final BitwuzlaAbstractProver<?> prover;
+
+  protected BitwuzlaEvaluator(
+      BitwuzlaAbstractProver<?> pProver, FormulaCreator<Term, Sort, TermManager, ?> creator) {
+    super(pProver, creator);
+    prover = pProver;
+  }
+
+  @Override
+  protected @Nullable Term evalImpl(Term formula) {
+    checkState(!isClosed());
+    checkState(!prover.isClosed(), "Cannot use model after prover is closed");
+    return prover.env.get_value(formula);
+  }
+}

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
@@ -15,6 +15,7 @@ import static org.sosy_lab.java_smt.api.FormulaType.getFloatingPointTypeFromSize
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Table;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
@@ -22,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -29,6 +31,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -631,6 +634,41 @@ class BitwuzlaFormulaCreator extends FormulaCreator<Term, Sort, TermManager, Bit
     }
 
     return transformedImmutableSetCopy(usedConstraintVariables, constraintsForVariables::get);
+  }
+
+  @Override
+  public void extractVariablesAndUFs(
+      final Formula pFormula,
+      final boolean extractUF,
+      final BiConsumer<String, Formula> pConsumer) {
+    ImmutableSet.Builder<Term> builder = ImmutableSet.builder();
+    var cache = new HashSet<Term>();
+    var work = new ArrayDeque<>(ImmutableList.of(extractInfo(pFormula)));
+    while (!work.isEmpty()) {
+      var term = work.pop();
+      if (cache.add(term)) {
+        var kind = term.kind();
+        if (kind == Kind.CONSTANT) {
+          builder.add(term);
+        } else if (kind == Kind.APPLY) {
+          if (extractUF) {
+            builder.add(term);
+          }
+          for (int c = 1; c < term.num_children(); c++) {
+            work.push(term.get(c));
+          }
+        } else {
+          for (int c = 0; c < term.num_children(); c++) {
+            work.push(term.get(c));
+          }
+        }
+      }
+    }
+    for (var term : builder.build()) {
+      pConsumer.accept(
+          term.kind() == Kind.APPLY ? term.get(0).symbol() : term.symbol(),
+          encapsulateWithTypeOf(term));
+    }
   }
 
   @Override


### PR DESCRIPTION
Hello,

this PR adds two optimizations for Bitwuzla to bring down memory usage:
- it adds an `Evaluator` to skip model generation in `allSat`
- it further optimizes `extractVariablesAndUFs` to avoid creating unnecessary Java proxies in the visitor

Here are some results from SVCOMP with a 60s time limit: [SV-COMP26_no-overflow](https://github.com/user-attachments/files/26657072/results.2026-04-12_11-51-12.table.html)

The left column is before this PR, the middle is with the new Evaluator, and the right is with the `extractVaraiblesAndUFs` optimization (and the Evaluator)

And here's the scatter plot for a before-after comparison:
<img width="1863" height="829" alt="Screenshot From 2026-04-12 12-16-21" src="https://github.com/user-attachments/assets/4c6cb1af-a610-4e82-be2b-724c75fd0b41" />