### PR TITLE
Make (SMTLIB) Tokenizer iterable via a new iterator to make SMTLIB operators more efficient

### DIFF
--- a/src/org/sosy_lab/java_smt/api/FormulaType.java
+++ b/src/org/sosy_lab/java_smt/api/FormulaType.java
@@ -638,7 +638,7 @@ public abstract class FormulaType<T extends Formula> {
       checkArgument(m.find());
       return FormulaType.getBitvectorTypeWithSize(Integer.parseInt(m.group(1)));
     } else if (t.startsWith("(Array")) {
-      var tokens = Tokenizer.tokenizeToList(t.substring(1, t.length() - 1));
+      var tokens = Tokenizer.of(t.substring(1, t.length() - 1)).toImmutableList();
       checkArgument(tokens.size() == 3);
       var domain = fromSMTLIBString(tokens.get(1));
       var range = fromSMTLIBString(tokens.get(2));

--- a/src/org/sosy_lab/java_smt/api/FormulaType.java
+++ b/src/org/sosy_lab/java_smt/api/FormulaType.java
@@ -638,7 +638,7 @@ public abstract class FormulaType<T extends Formula> {
       checkArgument(m.find());
       return FormulaType.getBitvectorTypeWithSize(Integer.parseInt(m.group(1)));
     } else if (t.startsWith("(Array")) {
-      var tokens = Tokenizer.tokenize(t.substring(1, t.length() - 1));
+      var tokens = Tokenizer.tokenizeToList(t.substring(1, t.length() - 1));
       checkArgument(tokens.size() == 3);
       var domain = fromSMTLIBString(tokens.get(1));
       var range = fromSMTLIBString(tokens.get(2));

--- a/src/org/sosy_lab/java_smt/api/FormulaType.java
+++ b/src/org/sosy_lab/java_smt/api/FormulaType.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.NumeralFormula.RationalFormula;
-import org.sosy_lab.java_smt.basicimpl.Tokenizer;
+import org.sosy_lab.java_smt.basicimpl.SMTLibTokenizer;
 
 /**
  * Type of a formula.
@@ -638,7 +638,7 @@ public abstract class FormulaType<T extends Formula> {
       checkArgument(m.find());
       return FormulaType.getBitvectorTypeWithSize(Integer.parseInt(m.group(1)));
     } else if (t.startsWith("(Array")) {
-      var tokens = Tokenizer.of(t.substring(1, t.length() - 1)).toImmutableList();
+      var tokens = SMTLibTokenizer.of(t.substring(1, t.length() - 1)).toImmutableList();
       checkArgument(tokens.size() == 3);
       var domain = fromSMTLIBString(tokens.get(1));
       var range = fromSMTLIBString(tokens.get(2));

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java
@@ -374,16 +374,26 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
     // The fallback implementation splits the input into declarations and assertions,
     // and parses each assertion separately,
     // which is not very efficient, but it works for simple cases and is better than nothing
-    List<String> tokens = Tokenizer.tokenizeToList(formulaStr);
-
-    List<String> declarationTokens = tokens.stream().filter(Tokenizer::isDeclarationToken).toList();
-    List<String> definitionTokens = tokens.stream().filter(Tokenizer::isDefinitionToken).toList();
-    List<String> assertTokens = tokens.stream().filter(Tokenizer::isAssertToken).toList();
+    ImmutableList.Builder<String> declarationTokens = ImmutableList.builder();
+    ImmutableList.Builder<String> definitionTokens = ImmutableList.builder();
+    ImmutableList.Builder<String> assertTokens = ImmutableList.builder();
+    for (String token : Tokenizer.of(formulaStr)) {
+      if (Tokenizer.isDeclarationToken(token)) {
+        declarationTokens.add(token);
+      }
+      if (Tokenizer.isDefinitionToken(token)) {
+        definitionTokens.add(token);
+      }
+      if (Tokenizer.isAssertToken(token)) {
+        assertTokens.add(token);
+      }
+    }
     String definitions =
-        Joiner.on("").join(declarationTokens) + Joiner.on("").join(definitionTokens);
+        Joiner.on("").join(declarationTokens.build())
+            + Joiner.on("").join(definitionTokens.build());
 
     return Collections3.transformedImmutableListCopy(
-        assertTokens, assertion -> parseImpl(definitions + assertion));
+        assertTokens.build(), assertion -> parseImpl(definitions + assertion));
   }
 
   /**
@@ -395,17 +405,14 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
    * only occur as the last command.
    */
   private String sanitize(String formulaStr) {
-    List<String> tokens = Tokenizer.tokenizeToList(formulaStr);
-
-    StringBuilder builder = new StringBuilder();
-
     // SMTLIB2ProgramStateMachine models and tracks that the SMTLIB2 query conforms to the rules
     // outlined in the standard, i.e. which command can follow on which etc.
     // We allow a slightly more lenient version than the standard, allowing implicit logic
     // selection, as most solvers export and support SMTLIB2 like this.
     SMTLIB2ProgramStateMachine smtLibStateMachine = new SMTLIB2ProgramStateMachine(false);
+    StringBuilder builder = new StringBuilder();
 
-    for (String token : tokens) {
+    for (String token : Tokenizer.of(formulaStr)) {
       if (Tokenizer.isSetInfoToken(token)) {
         // set-info call is allowed to be the very first command in the benchmark, but can also
         // appear repeatedly throughout a SMT2 program

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java
@@ -374,7 +374,7 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
     // The fallback implementation splits the input into declarations and assertions,
     // and parses each assertion separately,
     // which is not very efficient, but it works for simple cases and is better than nothing
-    List<String> tokens = Tokenizer.tokenize(formulaStr);
+    List<String> tokens = Tokenizer.tokenizeToList(formulaStr);
 
     List<String> declarationTokens = tokens.stream().filter(Tokenizer::isDeclarationToken).toList();
     List<String> definitionTokens = tokens.stream().filter(Tokenizer::isDefinitionToken).toList();
@@ -395,7 +395,7 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
    * only occur as the last command.
    */
   private String sanitize(String formulaStr) {
-    List<String> tokens = Tokenizer.tokenize(formulaStr);
+    List<String> tokens = Tokenizer.tokenizeToList(formulaStr);
 
     StringBuilder builder = new StringBuilder();
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractFormulaManager.java
@@ -377,14 +377,14 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
     ImmutableList.Builder<String> declarationTokens = ImmutableList.builder();
     ImmutableList.Builder<String> definitionTokens = ImmutableList.builder();
     ImmutableList.Builder<String> assertTokens = ImmutableList.builder();
-    for (String token : Tokenizer.of(formulaStr)) {
-      if (Tokenizer.isDeclarationToken(token)) {
+    for (String token : SMTLibTokenizer.of(formulaStr)) {
+      if (SMTLibTokenizer.isDeclarationToken(token)) {
         declarationTokens.add(token);
       }
-      if (Tokenizer.isDefinitionToken(token)) {
+      if (SMTLibTokenizer.isDefinitionToken(token)) {
         definitionTokens.add(token);
       }
-      if (Tokenizer.isAssertToken(token)) {
+      if (SMTLibTokenizer.isAssertToken(token)) {
         assertTokens.add(token);
       }
     }
@@ -412,8 +412,8 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
     SMTLIB2ProgramStateMachine smtLibStateMachine = new SMTLIB2ProgramStateMachine(false);
     StringBuilder builder = new StringBuilder();
 
-    for (String token : Tokenizer.of(formulaStr)) {
-      if (Tokenizer.isSetInfoToken(token)) {
+    for (String token : SMTLibTokenizer.of(formulaStr)) {
+      if (SMTLibTokenizer.isSetInfoToken(token)) {
         // set-info call is allowed to be the very first command in the benchmark, but can also
         // appear repeatedly throughout a SMT2 program
         // Technically it is even required to be the very first command, and it must set the
@@ -421,7 +421,7 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
         // TODO: check that version >= 2 for attribute :smt-lib-version?
         smtLibStateMachine.applyGSIOCommand();
 
-      } else if (Tokenizer.isSetLogicToken(token)) {
+      } else if (SMTLibTokenizer.isSetLogicToken(token)) {
         // (set-logic ...) commands must appear before an assertion is made. They may appear
         // throughout an SMT-LIB2 program to set the 'current logic' to a new logic, but the 'reset'
         // command has to be used before doing so every time.
@@ -430,34 +430,34 @@ public abstract class AbstractFormulaManager<TFormulaInfo, TType, TEnv, TFuncDec
         // echo, reset, reset-assertions, get-info, get-option, set-info, set-option
         smtLibStateMachine.applySetLogicCommand();
 
-      } else if (Tokenizer.isExitToken(token)) {
+      } else if (SMTLibTokenizer.isExitToken(token)) {
         // Skip the (exit) command at the end of the input
         smtLibStateMachine.applyExitCommand();
 
-      } else if (Tokenizer.isDeclarationToken(token)
-          || Tokenizer.isDefinitionToken(token)
-          || Tokenizer.isAssertToken(token)) {
+      } else if (SMTLibTokenizer.isDeclarationToken(token)
+          || SMTLibTokenizer.isDefinitionToken(token)
+          || SMTLibTokenizer.isAssertToken(token)) {
         // Keep only declaration, definitions and assertion
         smtLibStateMachine.applyAssertDeclareCommands();
         builder.append(token).append('\n');
 
-      } else if (Tokenizer.isForbiddenToken(token)) {
+      } else if (SMTLibTokenizer.isForbiddenToken(token)) {
         // Throw an exception if the script contains commands like (pop) or (reset) that change the
         // state of the assertion stack.
         // We could keep track of the state of the stack and only consider the formulas that remain
         // on the stack at the end of the script. However, this does not seem worth it at the
         // moment. If needed, this feature can still be added later.
         String message;
-        if (Tokenizer.isPushToken(token)) {
+        if (SMTLibTokenizer.isPushToken(token)) {
           smtLibStateMachine.applyPCommand();
           message = "(push ...)";
-        } else if (Tokenizer.isPopToken(token)) {
+        } else if (SMTLibTokenizer.isPopToken(token)) {
           smtLibStateMachine.applyPCommand();
           message = "(pop ...)";
-        } else if (Tokenizer.isResetAssertionsToken(token)) {
+        } else if (SMTLibTokenizer.isResetAssertionsToken(token)) {
           smtLibStateMachine.applyResetAssertionsCommand();
           message = "(reset-assertions)";
-        } else if (Tokenizer.isResetToken(token)) {
+        } else if (SMTLibTokenizer.isResetToken(token)) {
           smtLibStateMachine.applyResetCommand();
           message = "(reset)";
         } else {

--- a/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
@@ -35,6 +35,16 @@ public final class SMTLibTokenizer implements Iterable<String> {
     input = checkNotNull(inputToTokenize);
   }
 
+  /**
+   * Creates a new {@link SMTLibTokenizer} from the input {@link String}. The resulting {@link
+   * SMTLibTokenizer} is an {@link Iterable} for the SMTLIB tokens. A new {@link Iterator} on the
+   * input can be created with {@link #iterator()}. A {@link ImmutableList} of all tokens can be
+   * created via {@link #toImmutableList()}. Tokenized input is returned sanitized from unnecessary
+   * characters, and checked for basic (but not full) syntactic validity (e.g. that every opened
+   * bracket is also closed in a valid way).
+   *
+   * @param inputToTokenize SMTLIB input {@link String} that may be empty, but not null.
+   */
   public static SMTLibTokenizer of(final String inputToTokenize) {
     return new SMTLibTokenizer(inputToTokenize);
   }
@@ -50,7 +60,8 @@ public final class SMTLibTokenizer implements Iterable<String> {
 
   /**
    * Split up a sequence of lisp expressions into a list of nen-empty tokens. This method simply
-   * uses the {@link TokenizerIterator} and creates a list out of all tokens.
+   * uses the {@link TokenizerIterator} and creates a list out of all tokens. Repeated calls to this
+   * method are inefficient, as a new {@link java.util.List} is created every time it is called.
    *
    * <p>This is used by {@link AbstractFormulaManager#parse(String)} as part of the preprocessing
    * before the input is passed on to the solver. SMT-LIB2 scripts are sequences of commands that

--- a/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
@@ -308,20 +308,6 @@ public final class SMTLibTokenizer implements Iterable<String> {
      * Optional#empty()} if there is none.
      */
     private Optional<String> getNextToken() {
-      while (!endOfInputReached()) {
-        String maybeNextToken = getNextPossiblyEmptyToken();
-        if (!maybeNextToken.isEmpty()) {
-          return Optional.of(maybeNextToken);
-        }
-      }
-      return Optional.empty();
-    }
-
-    /**
-     * Progresses the iterator and returns the next token. These tokens might be empty due to our
-     * lenient way of interpreting SMTLIB.
-     */
-    private String getNextPossiblyEmptyToken() {
       StringBuilder tokenBuilder = new StringBuilder();
       String token = null;
 
@@ -430,11 +416,18 @@ public final class SMTLibTokenizer implements Iterable<String> {
       }
 
       if (token == null) {
-        // This is always the empty token. Can only happen at tWe need to fix this first.he end of
-        // the input.
+        // Might happen at the end of an SMTLIB program
         token = tokenBuilder.toString();
       }
-      return token;
+
+      if (token.isEmpty()) {
+        if (endOfInputReached()) {
+          return Optional.empty();
+        } else {
+          return getNextToken();
+        }
+      }
+      return Optional.of(token);
     }
   }
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
@@ -243,7 +243,6 @@ public final class SMTLibTokenizer implements Iterable<String> {
   public static final class TokenizerIterator implements Iterator<String> {
 
     private final String input;
-    private final int inputLength;
 
     // To avoid empty string returns we have a 1-lookahead. If this is ever empty, we don't have
     // a next element!
@@ -272,23 +271,16 @@ public final class SMTLibTokenizer implements Iterable<String> {
      */
     private TokenizerIterator(final String inputToTokenize) {
       input = inputToTokenize;
-      inputLength = input.length();
 
       // Generate first token if possible. There might be none, in which case isNext() needs to
       // return 'false' immediately.
-      while (nextToken.isEmpty() && !endOfInputReached()) {
-        String maybeFirstToken = getNextPossiblyEmptyToken();
-        // Can be optimized by returning null for empty tokens in getNextPossiblyEmptyToken()
-        if (!maybeFirstToken.isEmpty()) {
-          nextToken = Optional.of(maybeFirstToken);
-        }
-      }
+      nextToken = getNextToken();
     }
 
     private boolean endOfInputReached() {
       // As long as pos is smaller than inputLength, we are not at the end of the input. This
       // does not tell us that there is still tokens left! There might be input that we skip!
-      return pos >= inputLength;
+      return pos >= input.length();
     }
 
     @Override
@@ -303,21 +295,32 @@ public final class SMTLibTokenizer implements Iterable<String> {
       }
 
       String currentToken = nextToken.orElseThrow();
-      nextToken = Optional.empty();
 
       // Get lookahead if possible
-      while (!endOfInputReached()) {
-        String maybeNextToken = getNextPossiblyEmptyToken();
-        // Can be optimized by returning null for empty tokens in getNextPossiblyEmptyToken()
-        if (!maybeNextToken.isEmpty()) {
-          nextToken = Optional.of(maybeNextToken);
-          break;
-        }
-      }
+      nextToken = getNextToken();
+
       // nextToken may be present or empty!
       return checkNotNull(currentToken);
     }
 
+    /**
+     * Progresses the iterator and returns the next non-empty token in the iterator, or {@link
+     * Optional#empty()} if there is none.
+     */
+    private Optional<String> getNextToken() {
+      while (!endOfInputReached()) {
+        String maybeNextToken = getNextPossiblyEmptyToken();
+        if (!maybeNextToken.isEmpty()) {
+          return Optional.of(maybeNextToken);
+        }
+      }
+      return Optional.empty();
+    }
+
+    /**
+     * Progresses the iterator and returns the next token. These tokens might be empty due to our
+     * lenient way of interpreting SMTLIB.
+     */
     private String getNextPossiblyEmptyToken() {
       StringBuilder tokenBuilder = new StringBuilder();
       String token = null;
@@ -342,7 +345,7 @@ public final class SMTLibTokenizer implements Iterable<String> {
             // We have a double quote: Check that it's not followed by another and actually closes
             // the string.
             Optional<Character> n =
-                (pos == inputLength - 1) ? Optional.empty() : Optional.of(input.charAt(pos + 1));
+                (pos == input.length() - 1) ? Optional.empty() : Optional.of(input.charAt(pos + 1));
             if (n.isEmpty() || n.orElseThrow() != '"') {
               // Close the string
               tokenBuilder.append(c);

--- a/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
@@ -93,6 +93,14 @@ public final class SMTLibTokenizer implements Iterable<String> {
     return matchesOneOf(token, "set-logic");
   }
 
+  /**
+   * Check if the token is <code>(set-info ..)</code>.
+   *
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
+   */
   public static boolean isSetInfoToken(String token) {
     return matchesOneOf(token, "set-info");
   }

--- a/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
@@ -27,16 +27,16 @@ import java.util.Optional;
  * turn an SMT-LIB2 script into a string of input tokens efficiently. Alternatively, a {@link
  * ImmutableList} of all tokens can be created with {@link #toImmutableList()}.
  */
-public final class Tokenizer implements Iterable<String> {
+public final class SMTLibTokenizer implements Iterable<String> {
 
   private final String input;
 
-  private Tokenizer(final String inputToTokenize) {
+  private SMTLibTokenizer(final String inputToTokenize) {
     input = checkNotNull(inputToTokenize);
   }
 
-  public static Tokenizer of(final String inputToTokenize) {
-    return new Tokenizer(inputToTokenize);
+  public static SMTLibTokenizer of(final String inputToTokenize) {
+    return new SMTLibTokenizer(inputToTokenize);
   }
 
   /** Variable names (symbols) can be wrapped with "|". This function removes those chars. */
@@ -84,7 +84,7 @@ public final class Tokenizer implements Iterable<String> {
   /**
    * Check if the token is <code>(set-logic ..)</code>.
    *
-   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
    * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
    * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
    * #toImmutableList()}.
@@ -100,7 +100,7 @@ public final class Tokenizer implements Iterable<String> {
   /**
    * Check if the token is a function or variable declaration.
    *
-   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
    * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
    * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
    * #toImmutableList()}.
@@ -112,7 +112,7 @@ public final class Tokenizer implements Iterable<String> {
   /**
    * Check if the token is a function definition.
    *
-   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
    * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
    * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
    * #toImmutableList()}.
@@ -124,7 +124,7 @@ public final class Tokenizer implements Iterable<String> {
   /**
    * Check if the token is an <code>(assert ...)</code>.
    *
-   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
    * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
    * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
    * #toImmutableList()}.
@@ -136,7 +136,7 @@ public final class Tokenizer implements Iterable<String> {
   /**
    * Check if the token is an <code>(push ...)</code>.
    *
-   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
    * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
    * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
    * #toImmutableList()}.
@@ -148,7 +148,7 @@ public final class Tokenizer implements Iterable<String> {
   /**
    * Check if the token is an <code>(pop ...)</code>.
    *
-   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
    * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
    * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
    * #toImmutableList()}.
@@ -160,7 +160,7 @@ public final class Tokenizer implements Iterable<String> {
   /**
    * Check if the token is an <code>(reset-assertions ...)</code>.
    *
-   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
    * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
    * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
    * #toImmutableList()}.
@@ -172,7 +172,7 @@ public final class Tokenizer implements Iterable<String> {
   /**
    * Check if the token is an <code>(reset)</code>.
    *
-   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
    * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
    * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
    * #toImmutableList()}.
@@ -184,7 +184,7 @@ public final class Tokenizer implements Iterable<String> {
   /**
    * Check if the token is <code>(exit)</code>.
    *
-   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
    * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
    * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
    * #toImmutableList()}.
@@ -209,7 +209,7 @@ public final class Tokenizer implements Iterable<String> {
    * When a forbidden token is found parsing should be aborted by throwing an {@link
    * IllegalArgumentException} exception.
    *
-   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * <p>Use {@link SMTLibTokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
    * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
    * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
    * #toImmutableList()}.

--- a/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/SMTLibTokenizer.java
@@ -40,7 +40,7 @@ public final class SMTLibTokenizer implements Iterable<String> {
   }
 
   /** Variable names (symbols) can be wrapped with "|". This function removes those chars. */
-  public static String dequote(String s) {
+  public static String dequoteSMTLib(String s) {
     int l = s.length();
     if (s.charAt(0) == '|' && s.charAt(l - 1) == '|') {
       return s.substring(1, l - 1);

--- a/src/org/sosy_lab/java_smt/basicimpl/Tokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/Tokenizer.java
@@ -10,8 +10,12 @@
 
 package org.sosy_lab.java_smt.basicimpl;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.collect.ImmutableList;
-import java.util.List;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 /**
@@ -33,7 +37,8 @@ public final class Tokenizer {
   }
 
   /**
-   * Split up a sequence of lisp expressions.
+   * Split up a sequence of lisp expressions into a list of nen-empty tokens. This method simply
+   * uses the {@link TokenizerIterator} and creates a list out of all tokens.
    *
    * <p>This is used by {@link AbstractFormulaManager#parse(String)} as part of the preprocessing
    * before the input is passed on to the solver. SMT-LIB2 scripts are sequences of commands that
@@ -42,121 +47,15 @@ public final class Tokenizer {
    * <p>As an example <code>tokenize("(define-const a Int)(assert (= a 0)")</code> will return the
    * sequence <code>["(define-const a Int)", "(assert (= a 0))"]</code>
    */
-  public static List<String> tokenize(String input) {
+  public static ImmutableList<String> tokenizeToList(String input) {
     ImmutableList.Builder<String> builder = ImmutableList.builder();
-    boolean inComment = false;
-    boolean inString = false;
-    boolean inQuoted = false;
+    TokenizerIterator iter = new TokenizerIterator(input);
 
-    int level = 0;
-    int pos = 0;
-
-    StringBuilder token = new StringBuilder();
-    while (pos < input.length()) {
-      char c = input.charAt(pos);
-      if (inComment) {
-        if (c == '\n') {
-          // End of a comment
-          inComment = false;
-          if (level > 0) {
-            // If we're in an expression we need to replace the entire comment (+ the newline) with
-            // some whitespace. Otherwise, symbols might get merged across line-wraps. This is not
-            // a problem at the top-level where all terms are surrounded by brackets.
-            token.append(c);
-          }
-        }
-
-      } else if (inString) {
-        if (c == '"') {
-          // We have a double quote: Check that it's not followed by another and actually closes
-          // the string.
-          Optional<Character> n =
-              (pos == input.length() - 1) ? Optional.empty() : Optional.of(input.charAt(pos + 1));
-          if (n.isEmpty() || n.orElseThrow() != '"') {
-            // Close the string
-            token.append(c);
-            inString = false;
-          } else {
-            // Add both quotes to the token and skip one character ahead
-            token.append(c);
-            token.append(n.orElseThrow());
-            pos++;
-          }
-        } else {
-          token.append(c);
-        }
-
-      } else if (inQuoted) {
-        if (c == '|') {
-          // Close the quotes
-          inQuoted = false;
-        }
-        if (c == '\\') {
-          // The SMT-LIB2 standard does not allow backslash inside quoted symbols:
-          // Throw an exception
-          throw new IllegalArgumentException();
-        }
-        token.append(c);
-
-      } else if (c == ';') {
-        // Start of a comment
-        inComment = true;
-
-      } else if (c == '"') {
-        // Start of a string literal
-        inString = true;
-        token.append(c);
-
-      } else if (c == '|') {
-        // Start of a quoted symbol
-        inQuoted = true;
-        token.append(c);
-
-      } else {
-        // Just a regular character outside of comments, quotes or string literals
-        if (level == 0) {
-          // We're at the top-level
-          if (!Character.isWhitespace(c)) {
-            if (c == '(') {
-              // Handle opening brackets
-              token.append("(");
-              level++;
-            } else if (c == ')') {
-              throw new IllegalArgumentException(
-                  "parentheses do not match, unexpected closing parenthesis");
-            } else {
-              token.append(c);
-            }
-          } else {
-            if (!token.isEmpty()) {
-              builder.add(token.toString());
-              token = new StringBuilder();
-            }
-          }
-        } else {
-          // We're inside an r-expression
-          token.append(c);
-          // Handle opening/closing brackets
-          if (c == '(') {
-            level++;
-          }
-          if (c == ')') {
-            if (level == 1) {
-              builder.add(token.toString());
-              token = new StringBuilder();
-            }
-            level--;
-          }
-        }
-      }
-      pos++;
-    }
-    if (level != 0) {
-      // Throw an exception if the brackets don't match
-      throw new IllegalArgumentException("parentheses do not match, too many open parentheses");
-    }
-    if (!token.isEmpty()) {
-      builder.add(token.toString());
+    // TODO: Switch to some one-liner like: iter.forEachRemaining(builder::add);
+    while (iter.hasNext()) {
+      final String token = iter.next();
+      checkState(!token.isEmpty());
+      builder.add(token);
     }
     return builder.build();
   }
@@ -168,7 +67,8 @@ public final class Tokenizer {
   /**
    * Check if the token is <code>(set-logic ..)</code>.
    *
-   * <p>Use {@link #tokenize(String)} to turn an SMT-LIB2 script into a string of input tokens.
+   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
+   * tokens.
    */
   public static boolean isSetLogicToken(String token) {
     return matchesOneOf(token, "set-logic");
@@ -181,7 +81,8 @@ public final class Tokenizer {
   /**
    * Check if the token is a function or variable declaration.
    *
-   * <p>Use {@link #tokenize(String)} to turn an SMT-LIB2 script into a string of input tokens.
+   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
+   * tokens.
    */
   public static boolean isDeclarationToken(String token) {
     return matchesOneOf(token, "declare-const", "declare-fun");
@@ -190,7 +91,8 @@ public final class Tokenizer {
   /**
    * Check if the token is a function definition.
    *
-   * <p>Use {@link #tokenize(String)} to turn an SMT-LIB2 script into a string of input tokens.
+   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
+   * tokens.
    */
   public static boolean isDefinitionToken(String token) {
     return matchesOneOf(token, "define-fun", "define-const");
@@ -199,7 +101,8 @@ public final class Tokenizer {
   /**
    * Check if the token is an <code>(assert ...)</code>.
    *
-   * <p>Use {@link #tokenize(String)} to turn an SMT-LIB2 script into a string of input tokens.
+   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
+   * tokens.
    */
   public static boolean isAssertToken(String token) {
     return matchesOneOf(token, "assert");
@@ -208,7 +111,8 @@ public final class Tokenizer {
   /**
    * Check if the token is an <code>(push ...)</code>.
    *
-   * <p>Use {@link #tokenize(String)} to turn an SMT-LIB2 script into a string of input tokens.
+   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
+   * tokens.
    */
   public static boolean isPushToken(String token) {
     return matchesOneOf(token, "push");
@@ -217,7 +121,8 @@ public final class Tokenizer {
   /**
    * Check if the token is an <code>(pop ...)</code>.
    *
-   * <p>Use {@link #tokenize(String)} to turn an SMT-LIB2 script into a string of input tokens.
+   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
+   * tokens.
    */
   public static boolean isPopToken(String token) {
     return matchesOneOf(token, "pop");
@@ -226,7 +131,8 @@ public final class Tokenizer {
   /**
    * Check if the token is an <code>(reset-assertions ...)</code>.
    *
-   * <p>Use {@link #tokenize(String)} to turn an SMT-LIB2 script into a string of input tokens.
+   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
+   * tokens.
    */
   public static boolean isResetAssertionsToken(String token) {
     return matchesOneOf(token, "reset-assertions");
@@ -235,7 +141,8 @@ public final class Tokenizer {
   /**
    * Check if the token is an <code>(reset)</code>.
    *
-   * <p>Use {@link #tokenize(String)} to turn an SMT-LIB2 script into a string of input tokens.
+   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
+   * tokens.
    */
   public static boolean isResetToken(String token) {
     return matchesOneOf(token, "reset");
@@ -244,7 +151,8 @@ public final class Tokenizer {
   /**
    * Check if the token is <code>(exit)</code>.
    *
-   * <p>Use {@link #tokenize(String)} to turn an SMT-LIB2 script into a string of input tokens.
+   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
+   * tokens.
    */
   public static boolean isExitToken(String token) {
     return matchesOneOf(token, "exit");
@@ -266,12 +174,202 @@ public final class Tokenizer {
    * When a forbidden token is found parsing should be aborted by throwing an {@link
    * IllegalArgumentException} exception.
    *
-   * <p>Use {@link #tokenize(String)} to turn an SMT-LIB2 script into a string of input tokens.
+   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
+   * tokens.
    */
   public static boolean isForbiddenToken(String token) {
     return isPushToken(token)
         || isPopToken(token)
         || isResetAssertionsToken(token)
         || isResetToken(token);
+  }
+
+  public static final class TokenizerIterator implements Iterator<String> {
+
+    private final String input;
+    private final int inputLength;
+
+    // To avoid empty string returns we have a 1-lookahead. If this is ever empty, we don't have
+    // a next element!
+    private Optional<String> nextToken = Optional.empty();
+
+    private boolean inComment = false;
+    private boolean inString = false;
+    private boolean inQuoted = false;
+
+    private int level = 0;
+    private int pos = 0;
+
+    /**
+     * Returns an {@link Iterator} splitting up the given {@link String}, consisting of a sequence
+     * of lisp expressions (i.e. SMTLIB2), into non-empty SMTLIB2 tokens.
+     *
+     * <p>SMT-LIB2 scripts are sequences of commands that are just r-expression. Split them up for
+     * (pre-/post-)processing makes handling easier. This is used by e.g. {@link
+     * AbstractFormulaManager#parse(String)} as part of the preprocessing before the input is passed
+     * on to the solver.
+     *
+     * <p>As an example <code>tokenize("(define-const a Int)(assert (= a 0)")</code> will return the
+     * following tokens: <code>["(define-const a Int)", "(assert (= a 0))"]</code>
+     *
+     * @param inputToTokenize SMTLIB2 {@link String}.
+     */
+    private TokenizerIterator(final String inputToTokenize) {
+      input = inputToTokenize;
+      inputLength = input.length();
+
+      // Generate first token if possible. There might be none, in which case isNext() needs to
+      // return 'false' immediately.
+      while (nextToken.isEmpty() && pos < inputLength) {
+        String maybeFirstToken = getNextPossiblyEmptyToken();
+        // Can be optimized by returning null for empty tokens in getNextPossiblyEmptyToken()
+        if (!maybeFirstToken.isEmpty()) {
+          nextToken = Optional.of(maybeFirstToken);
+        }
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return nextToken.isPresent();
+    }
+
+    @Override
+    public String next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      String currentToken = nextToken.orElseThrow();
+      nextToken = Optional.empty();
+
+      // Get lookahead if possible
+      while (pos < inputLength) {
+        String maybeNextToken = getNextPossiblyEmptyToken();
+        // Can be optimized by returning null for empty tokens in getNextPossiblyEmptyToken()
+        if (!maybeNextToken.isEmpty()) {
+          nextToken = Optional.of(maybeNextToken);
+          break;
+        }
+      }
+      // nextToken may be present or empty!
+      return checkNotNull(currentToken);
+    }
+
+    private String getNextPossiblyEmptyToken() {
+      StringBuilder tokenBuilder = new StringBuilder();
+      String token = null;
+
+      while (token == null && pos < inputLength) {
+        char c = input.charAt(pos);
+        if (inComment) {
+          if (c == '\n') {
+            // End of a comment
+            inComment = false;
+            if (level > 0) {
+              // If we're in an expression we need to replace the entire comment (+ the newline)
+              // with
+              // some whitespace. Otherwise, symbols might get merged across line-wraps. This is not
+              // a problem at the top-level where all terms are surrounded by brackets.
+              tokenBuilder.append(c);
+            }
+          }
+
+        } else if (inString) {
+          if (c == '"') {
+            // We have a double quote: Check that it's not followed by another and actually closes
+            // the string.
+            Optional<Character> n =
+                (pos == inputLength - 1) ? Optional.empty() : Optional.of(input.charAt(pos + 1));
+            if (n.isEmpty() || n.orElseThrow() != '"') {
+              // Close the string
+              tokenBuilder.append(c);
+              inString = false;
+            } else {
+              // Add both quotes to the token and skip one character ahead
+              tokenBuilder.append(c);
+              tokenBuilder.append(n.orElseThrow());
+              pos++;
+            }
+          } else {
+            tokenBuilder.append(c);
+          }
+
+        } else if (inQuoted) {
+          if (c == '|') {
+            // Close the quotes
+            inQuoted = false;
+          }
+          if (c == '\\') {
+            // The SMT-LIB2 standard does not allow backslash inside quoted symbols:
+            // Throw an exception
+            throw new IllegalArgumentException();
+          }
+          tokenBuilder.append(c);
+
+        } else if (c == ';') {
+          // Start of a comment
+          inComment = true;
+
+        } else if (c == '"') {
+          // Start of a string literal
+          inString = true;
+          tokenBuilder.append(c);
+
+        } else if (c == '|') {
+          // Start of a quoted symbol
+          inQuoted = true;
+          tokenBuilder.append(c);
+
+        } else {
+          // Just a regular character outside of comments, quotes or string literals
+          if (level == 0) {
+            // We're at the top-level
+            if (!Character.isWhitespace(c)) {
+              if (c == '(') {
+                // Handle opening brackets
+                tokenBuilder.append("(");
+                level++;
+              } else if (c == ')') {
+                throw new IllegalArgumentException(
+                    "parentheses do not match, unexpected closing parenthesis");
+              } else {
+                tokenBuilder.append(c);
+              }
+            } else {
+              if (!tokenBuilder.isEmpty()) {
+                token = tokenBuilder.toString();
+              }
+            }
+          } else {
+            // We're inside an r-expression
+            tokenBuilder.append(c);
+            // Handle opening/closing brackets
+            if (c == '(') {
+              level++;
+            }
+            if (c == ')') {
+              if (level == 1) {
+                token = tokenBuilder.toString();
+              }
+              level--;
+            }
+          }
+        }
+        pos++;
+      }
+
+      if (level != 0) {
+        // Throw an exception if the brackets don't match
+        throw new IllegalArgumentException("parentheses do not match, too many open parentheses");
+      }
+
+      if (token == null) {
+        // This is always the empty token. Can only happen at tWe need to fix this first.he end of
+        // the input.
+        token = tokenBuilder.toString();
+      }
+      return token;
+    }
   }
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/Tokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/Tokenizer.java
@@ -22,10 +22,22 @@ import java.util.Optional;
  * Helper class for splitting up an SMT-LIB2 file into a string of commands.
  *
  * <p>This is not a full SMTLIB parser, but only provides basic support for SMTLIB commands.
+ *
+ * <p>Use this class as an {@link Iterable}, or the {@link Iterator} with {@link #iterator()} to
+ * turn an SMT-LIB2 script into a string of input tokens efficiently. Alternatively, a {@link
+ * ImmutableList} of all tokens can be created with {@link #toImmutableList()}.
  */
-public final class Tokenizer {
+public final class Tokenizer implements Iterable<String> {
 
-  private Tokenizer() {}
+  private final String input;
+
+  private Tokenizer(final String inputToTokenize) {
+    input = checkNotNull(inputToTokenize);
+  }
+
+  public static Tokenizer of(final String inputToTokenize) {
+    return new Tokenizer(inputToTokenize);
+  }
 
   /** Variable names (symbols) can be wrapped with "|". This function removes those chars. */
   public static String dequote(String s) {
@@ -47,7 +59,7 @@ public final class Tokenizer {
    * <p>As an example <code>tokenize("(define-const a Int)(assert (= a 0)")</code> will return the
    * sequence <code>["(define-const a Int)", "(assert (= a 0))"]</code>
    */
-  public static ImmutableList<String> tokenizeToList(String input) {
+  public ImmutableList<String> toImmutableList() {
     ImmutableList.Builder<String> builder = ImmutableList.builder();
     TokenizerIterator iter = new TokenizerIterator(input);
 
@@ -60,6 +72,11 @@ public final class Tokenizer {
     return builder.build();
   }
 
+  @Override
+  public Iterator<String> iterator() {
+    return new TokenizerIterator(input);
+  }
+
   private static boolean matchesOneOf(String token, String... regexp) {
     return token.matches("\\(\\s*(" + String.join("|", regexp) + ")[\\S\\s]*");
   }
@@ -67,8 +84,10 @@ public final class Tokenizer {
   /**
    * Check if the token is <code>(set-logic ..)</code>.
    *
-   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
-   * tokens.
+   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
    */
   public static boolean isSetLogicToken(String token) {
     return matchesOneOf(token, "set-logic");
@@ -81,8 +100,10 @@ public final class Tokenizer {
   /**
    * Check if the token is a function or variable declaration.
    *
-   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
-   * tokens.
+   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
    */
   public static boolean isDeclarationToken(String token) {
     return matchesOneOf(token, "declare-const", "declare-fun");
@@ -91,8 +112,10 @@ public final class Tokenizer {
   /**
    * Check if the token is a function definition.
    *
-   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
-   * tokens.
+   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
    */
   public static boolean isDefinitionToken(String token) {
     return matchesOneOf(token, "define-fun", "define-const");
@@ -101,8 +124,10 @@ public final class Tokenizer {
   /**
    * Check if the token is an <code>(assert ...)</code>.
    *
-   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
-   * tokens.
+   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
    */
   public static boolean isAssertToken(String token) {
     return matchesOneOf(token, "assert");
@@ -111,8 +136,10 @@ public final class Tokenizer {
   /**
    * Check if the token is an <code>(push ...)</code>.
    *
-   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
-   * tokens.
+   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
    */
   public static boolean isPushToken(String token) {
     return matchesOneOf(token, "push");
@@ -121,8 +148,10 @@ public final class Tokenizer {
   /**
    * Check if the token is an <code>(pop ...)</code>.
    *
-   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
-   * tokens.
+   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
    */
   public static boolean isPopToken(String token) {
     return matchesOneOf(token, "pop");
@@ -131,8 +160,10 @@ public final class Tokenizer {
   /**
    * Check if the token is an <code>(reset-assertions ...)</code>.
    *
-   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
-   * tokens.
+   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
    */
   public static boolean isResetAssertionsToken(String token) {
     return matchesOneOf(token, "reset-assertions");
@@ -141,8 +172,10 @@ public final class Tokenizer {
   /**
    * Check if the token is an <code>(reset)</code>.
    *
-   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
-   * tokens.
+   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
    */
   public static boolean isResetToken(String token) {
     return matchesOneOf(token, "reset");
@@ -151,8 +184,10 @@ public final class Tokenizer {
   /**
    * Check if the token is <code>(exit)</code>.
    *
-   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
-   * tokens.
+   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
    */
   public static boolean isExitToken(String token) {
     return matchesOneOf(token, "exit");
@@ -174,8 +209,10 @@ public final class Tokenizer {
    * When a forbidden token is found parsing should be aborted by throwing an {@link
    * IllegalArgumentException} exception.
    *
-   * <p>Use {@link #tokenizeToList(String)} to turn an SMT-LIB2 script into a string of input
-   * tokens.
+   * <p>Use {@link Tokenizer} as an {@link Iterable}, or the {@link Iterator} with {@link
+   * #iterator()} to turn an SMT-LIB2 script into a string of input tokens efficiently.
+   * Alternatively, a {@link ImmutableList} of all tokens can be created with {@link
+   * #toImmutableList()}.
    */
   public static boolean isForbiddenToken(String token) {
     return isPushToken(token)

--- a/src/org/sosy_lab/java_smt/basicimpl/Tokenizer.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/Tokenizer.java
@@ -220,13 +220,19 @@ public final class Tokenizer {
 
       // Generate first token if possible. There might be none, in which case isNext() needs to
       // return 'false' immediately.
-      while (nextToken.isEmpty() && pos < inputLength) {
+      while (nextToken.isEmpty() && !endOfInputReached()) {
         String maybeFirstToken = getNextPossiblyEmptyToken();
         // Can be optimized by returning null for empty tokens in getNextPossiblyEmptyToken()
         if (!maybeFirstToken.isEmpty()) {
           nextToken = Optional.of(maybeFirstToken);
         }
       }
+    }
+
+    private boolean endOfInputReached() {
+      // As long as pos is smaller than inputLength, we are not at the end of the input. This
+      // does not tell us that there is still tokens left! There might be input that we skip!
+      return pos >= inputLength;
     }
 
     @Override
@@ -244,7 +250,7 @@ public final class Tokenizer {
       nextToken = Optional.empty();
 
       // Get lookahead if possible
-      while (pos < inputLength) {
+      while (!endOfInputReached()) {
         String maybeNextToken = getNextPossiblyEmptyToken();
         // Can be optimized by returning null for empty tokens in getNextPossiblyEmptyToken()
         if (!maybeNextToken.isEmpty()) {
@@ -260,7 +266,7 @@ public final class Tokenizer {
       StringBuilder tokenBuilder = new StringBuilder();
       String token = null;
 
-      while (token == null && pos < inputLength) {
+      while (token == null && !endOfInputReached()) {
         char c = input.charAt(pos);
         if (inComment) {
           if (c == '\n') {

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
@@ -85,7 +85,7 @@ final class BitwuzlaFormulaManager
   @Override
   protected List<Term> parseAllImpl(String formulaStr) throws IllegalArgumentException {
     // Split the input string into a list of SMT-LIB2 commands
-    List<String> tokens = Tokenizer.tokenize(formulaStr);
+    List<String> tokens = Tokenizer.tokenizeToList(formulaStr);
 
     Table<String, Sort, Term> cache = creator.getCache();
 

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
@@ -85,7 +85,8 @@ final class BitwuzlaFormulaManager
   @Override
   protected List<Term> parseAllImpl(String formulaStr) throws IllegalArgumentException {
     // Split the input string into a list of SMT-LIB2 commands
-    List<String> tokens = Tokenizer.tokenizeToList(formulaStr);
+    // TODO: refactor this and use the iterator instead of looping through input multiple times
+    List<String> tokens = Tokenizer.of(formulaStr).toImmutableList();
 
     Table<String, Sort, Term> cache = creator.getCache();
 

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
@@ -18,7 +18,7 @@ import java.util.List;
 import org.sosy_lab.common.collect.Collections3;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.basicimpl.AbstractFormulaManager;
-import org.sosy_lab.java_smt.basicimpl.Tokenizer;
+import org.sosy_lab.java_smt.basicimpl.SMTLibTokenizer;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Bitwuzla;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Kind;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Map_TermTerm;
@@ -86,12 +86,14 @@ final class BitwuzlaFormulaManager
   protected List<Term> parseAllImpl(String formulaStr) throws IllegalArgumentException {
     // Split the input string into a list of SMT-LIB2 commands
     // TODO: refactor this and use the iterator instead of looping through input multiple times
-    List<String> tokens = Tokenizer.of(formulaStr).toImmutableList();
+    List<String> tokens = SMTLibTokenizer.of(formulaStr).toImmutableList();
 
     Table<String, Sort, Term> cache = creator.getCache();
 
     Collection<String> assertionCommands =
-        tokens.stream().filter(Tokenizer::isAssertToken).collect(ImmutableList.toImmutableList());
+        tokens.stream()
+            .filter(SMTLibTokenizer::isAssertToken)
+            .collect(ImmutableList.toImmutableList());
     if (assertionCommands.isEmpty()) {
       return ImmutableList.of();
     }
@@ -187,10 +189,10 @@ final class BitwuzlaFormulaManager
       List<String> tokens, Table<String, Sort, Term> cache) {
     ImmutableList.Builder<String> newDeclarations = ImmutableList.builder();
     for (String token : tokens) {
-      if (Tokenizer.isAssertToken(token)) {
+      if (SMTLibTokenizer.isAssertToken(token)) {
         // Skip assertions, they will be parsed at the end together with the declarations
         continue;
-      } else if (Tokenizer.isDeclarationToken(token)) {
+      } else if (SMTLibTokenizer.isDeclarationToken(token)) {
         // FIXME: Do we need to support function definitions here?
         Parser declParser = new Parser(creator.getEnv(), bitwuzlaOption);
         declParser.parse(token, true, false);

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
@@ -270,7 +270,7 @@ class CVC4FormulaCreator extends FormulaCreator<Expr, Type, ExprManager, Expr> {
     if (!e.isConst() && !e.isVariable()) {
       e = e.getOperator();
     }
-    return SMTLibTokenizer.dequote(e.toString());
+    return SMTLibTokenizer.dequoteSMTLib(e.toString());
   }
 
   @SuppressWarnings("deprecation")

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4FormulaCreator.java
@@ -54,7 +54,7 @@ import org.sosy_lab.java_smt.api.StringFormula;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
 import org.sosy_lab.java_smt.basicimpl.FunctionDeclarationImpl;
-import org.sosy_lab.java_smt.basicimpl.Tokenizer;
+import org.sosy_lab.java_smt.basicimpl.SMTLibTokenizer;
 import org.sosy_lab.java_smt.solvers.cvc4.CVC4Formula.CVC4ArrayFormula;
 import org.sosy_lab.java_smt.solvers.cvc4.CVC4Formula.CVC4BitvectorFormula;
 import org.sosy_lab.java_smt.solvers.cvc4.CVC4Formula.CVC4BooleanFormula;
@@ -270,7 +270,7 @@ class CVC4FormulaCreator extends FormulaCreator<Expr, Type, ExprManager, Expr> {
     if (!e.isConst() && !e.isVariable()) {
       e = e.getOperator();
     }
-    return Tokenizer.dequote(e.toString());
+    return SMTLibTokenizer.dequote(e.toString());
   }
 
   @SuppressWarnings("deprecation")

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
@@ -380,10 +380,10 @@ class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, Term> {
       // Functions are packaged like this: (functionName arg1 arg2 ...)
       // But can use |(name)| to enable () inside of the variable name
       // TODO what happens for function names containing whitespace?
-      String dequoted = SMTLibTokenizer.dequote(repr);
+      String dequoted = SMTLibTokenizer.dequoteSMTLib(repr);
       return Iterables.get(Splitter.on(' ').split(dequoted.substring(1)), 0);
     } else {
-      return SMTLibTokenizer.dequote(repr);
+      return SMTLibTokenizer.dequoteSMTLib(repr);
     }
   }
 
@@ -454,7 +454,7 @@ class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, Term> {
         return visitor.visitQuantifier((BooleanFormula) formula, quant, freeVars, fBody);
 
       } else if (f.getKind() == Kind.CONSTANT) {
-        return visitor.visitFreeVariable(formula, SMTLibTokenizer.dequote(f.toString()));
+        return visitor.visitFreeVariable(formula, SMTLibTokenizer.dequoteSMTLib(f.toString()));
 
       } else if (f.getKind() == Kind.APPLY_CONSTRUCTOR) {
         checkState(

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5FormulaCreator.java
@@ -65,7 +65,7 @@ import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.api.visitors.TraversalProcess;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
 import org.sosy_lab.java_smt.basicimpl.FunctionDeclarationImpl;
-import org.sosy_lab.java_smt.basicimpl.Tokenizer;
+import org.sosy_lab.java_smt.basicimpl.SMTLibTokenizer;
 import org.sosy_lab.java_smt.solvers.cvc5.CVC5Formula.CVC5ArrayFormula;
 import org.sosy_lab.java_smt.solvers.cvc5.CVC5Formula.CVC5BitvectorFormula;
 import org.sosy_lab.java_smt.solvers.cvc5.CVC5Formula.CVC5BooleanFormula;
@@ -380,10 +380,10 @@ class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, Term> {
       // Functions are packaged like this: (functionName arg1 arg2 ...)
       // But can use |(name)| to enable () inside of the variable name
       // TODO what happens for function names containing whitespace?
-      String dequoted = Tokenizer.dequote(repr);
+      String dequoted = SMTLibTokenizer.dequote(repr);
       return Iterables.get(Splitter.on(' ').split(dequoted.substring(1)), 0);
     } else {
-      return Tokenizer.dequote(repr);
+      return SMTLibTokenizer.dequote(repr);
     }
   }
 
@@ -454,7 +454,7 @@ class CVC5FormulaCreator extends FormulaCreator<Term, Sort, TermManager, Term> {
         return visitor.visitQuantifier((BooleanFormula) formula, quant, freeVars, fBody);
 
       } else if (f.getKind() == Kind.CONSTANT) {
-        return visitor.visitFreeVariable(formula, Tokenizer.dequote(f.toString()));
+        return visitor.visitFreeVariable(formula, SMTLibTokenizer.dequote(f.toString()));
 
       } else if (f.getKind() == Kind.APPLY_CONSTRUCTOR) {
         checkState(

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Parser.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Parser.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.sosy_lab.common.collect.Collections3;
-import org.sosy_lab.java_smt.basicimpl.Tokenizer;
+import org.sosy_lab.java_smt.basicimpl.SMTLibTokenizer;
 
 class CVC5Parser {
 
@@ -252,7 +252,7 @@ class CVC5Parser {
    * cached one is recorded in the given substitutions map.
    */
   private void registerNewTermSymbols(Term declaration, Map<Term, Term> substitutions) {
-    final String parsedTermString = Tokenizer.dequote(declaration.toString());
+    final String parsedTermString = SMTLibTokenizer.dequote(declaration.toString());
     final Sort parsedSort = declaration.getSort();
     final String parsedSortString = parsedSort.toString();
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Parser.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5Parser.java
@@ -252,7 +252,7 @@ class CVC5Parser {
    * cached one is recorded in the given substitutions map.
    */
   private void registerNewTermSymbols(Term declaration, Map<Term, Term> substitutions) {
-    final String parsedTermString = SMTLibTokenizer.dequote(declaration.toString());
+    final String parsedTermString = SMTLibTokenizer.dequoteSMTLib(declaration.toString());
     final Sort parsedSort = declaration.getSort();
     final String parsedSortString = parsedSort.toString();
 

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtFormulaCreator.java
@@ -341,7 +341,7 @@ final class OpenSmtFormulaCreator extends FormulaCreator<PTRef, SRef, Logic, Sym
 
     if (logic.isVar(f)) {
       String varName = logic.getSymName(logic.getSymRef(f));
-      return visitor.visitFreeVariable(formula, SMTLibTokenizer.dequote(varName));
+      return visitor.visitFreeVariable(formula, SMTLibTokenizer.dequoteSMTLib(varName));
     }
 
     String varName = logic.getSymName(logic.getSymRef(f));

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtFormulaCreator.java
@@ -21,7 +21,7 @@ import org.sosy_lab.java_smt.api.FunctionDeclarationKind;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
 import org.sosy_lab.java_smt.basicimpl.FunctionDeclarationImpl;
-import org.sosy_lab.java_smt.basicimpl.Tokenizer;
+import org.sosy_lab.java_smt.basicimpl.SMTLibTokenizer;
 import org.sosy_lab.java_smt.solvers.opensmt.OpenSmtFormula.OpenSmtArrayFormula;
 import org.sosy_lab.java_smt.solvers.opensmt.OpenSmtFormula.OpenSmtBooleanFormula;
 import org.sosy_lab.java_smt.solvers.opensmt.OpenSmtFormula.OpenSmtIntegerFormula;
@@ -341,7 +341,7 @@ final class OpenSmtFormulaCreator extends FormulaCreator<PTRef, SRef, Logic, Sym
 
     if (logic.isVar(f)) {
       String varName = logic.getSymName(logic.getSymRef(f));
-      return visitor.visitFreeVariable(formula, Tokenizer.dequote(varName));
+      return visitor.visitFreeVariable(formula, SMTLibTokenizer.dequote(varName));
     }
 
     String varName = logic.getSymName(logic.getSymRef(f));

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaCreator.java
@@ -33,7 +33,7 @@ import org.sosy_lab.java_smt.api.FunctionDeclarationKind;
 import org.sosy_lab.java_smt.api.visitors.FormulaVisitor;
 import org.sosy_lab.java_smt.basicimpl.FormulaCreator;
 import org.sosy_lab.java_smt.basicimpl.FunctionDeclarationImpl;
-import org.sosy_lab.java_smt.basicimpl.Tokenizer;
+import org.sosy_lab.java_smt.basicimpl.SMTLibTokenizer;
 
 class SmtInterpolFormulaCreator extends FormulaCreator<Term, Sort, Script, FunctionSymbol> {
 
@@ -210,7 +210,7 @@ class SmtInterpolFormulaCreator extends FormulaCreator<Term, Sort, Script, Funct
         } else if (app.equals(environment.getTheory().mFalse)) {
           return visitor.visitConstant(f, false);
         } else if (func.getDefinition() == null) {
-          return visitor.visitFreeVariable(f, Tokenizer.dequote(input.toString()));
+          return visitor.visitFreeVariable(f, SMTLibTokenizer.dequote(input.toString()));
         } else {
           throw new UnsupportedOperationException("Unexpected nullary function " + input);
         }
@@ -250,7 +250,7 @@ class SmtInterpolFormulaCreator extends FormulaCreator<Term, Sort, Script, Funct
     if (t instanceof ApplicationTerm app && isUF(app)) {
       return app.getFunction().getName();
     } else {
-      return Tokenizer.dequote(t.toString());
+      return SMTLibTokenizer.dequote(t.toString());
     }
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolFormulaCreator.java
@@ -210,7 +210,7 @@ class SmtInterpolFormulaCreator extends FormulaCreator<Term, Sort, Script, Funct
         } else if (app.equals(environment.getTheory().mFalse)) {
           return visitor.visitConstant(f, false);
         } else if (func.getDefinition() == null) {
-          return visitor.visitFreeVariable(f, SMTLibTokenizer.dequote(input.toString()));
+          return visitor.visitFreeVariable(f, SMTLibTokenizer.dequoteSMTLib(input.toString()));
         } else {
           throw new UnsupportedOperationException("Unexpected nullary function " + input);
         }
@@ -250,7 +250,7 @@ class SmtInterpolFormulaCreator extends FormulaCreator<Term, Sort, Script, Funct
     if (t instanceof ApplicationTerm app && isUF(app)) {
       return app.getFunction().getName();
     } else {
-      return SMTLibTokenizer.dequote(t.toString());
+      return SMTLibTokenizer.dequoteSMTLib(t.toString());
     }
   }
 

--- a/src/org/sosy_lab/java_smt/test/SMTLibTokenizerTest.java
+++ b/src/org/sosy_lab/java_smt/test/SMTLibTokenizerTest.java
@@ -15,37 +15,40 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.truth.Truth;
 import org.junit.Test;
-import org.sosy_lab.java_smt.basicimpl.Tokenizer;
+import org.sosy_lab.java_smt.basicimpl.SMTLibTokenizer;
 
-public class TokenizerTest {
+public class SMTLibTokenizerTest {
   @Test
   public void parenthesesTest() {
     // Valid input string
     String validBrackets = "(assert (= 3 (+ 2 1)))";
-    Truth.assertThat(Tokenizer.of(validBrackets).toImmutableList()).containsExactly(validBrackets);
+    Truth.assertThat(SMTLibTokenizer.of(validBrackets).toImmutableList())
+        .containsExactly(validBrackets);
 
     // Same string, but with one too many closing brackets
     String invalidClose = "(assert (= 3 (+ 2 1))))";
     assertThrows(
-        IllegalArgumentException.class, () -> Tokenizer.of(invalidClose).toImmutableList());
+        IllegalArgumentException.class, () -> SMTLibTokenizer.of(invalidClose).toImmutableList());
 
     // Same string, but with a missing closing bracket
     String invalidOpen = "(assert (= 3 (+ 2 1))";
-    assertThrows(IllegalArgumentException.class, () -> Tokenizer.of(invalidOpen).toImmutableList());
+    assertThrows(
+        IllegalArgumentException.class, () -> SMTLibTokenizer.of(invalidOpen).toImmutableList());
 
     // Valid input string with an escaped ')' as part of a comment
     // This should not confuse the tokenizer!
     String inComment = "(assert (= 3;)\n(- 4 1)))";
-    assertThat(Tokenizer.of(inComment).toImmutableList())
+    assertThat(SMTLibTokenizer.of(inComment).toImmutableList())
         .containsExactly("(assert (= 3\n(- 4 1)))");
 
     // Valid input string with an escaped ')' as part of a string literal
     String inString = "(assert (= v \")\"))";
-    assertThat(Tokenizer.of(inString).toImmutableList()).containsExactly(inString);
+    assertThat(SMTLibTokenizer.of(inString).toImmutableList()).containsExactly(inString);
 
     // Valid input string with an escaped ')' as part of a quoted symbol
     String inQuotedSymbol = "(assert (= |)v| 0))";
-    assertThat(Tokenizer.of(inQuotedSymbol).toImmutableList()).containsExactly(inQuotedSymbol);
+    assertThat(SMTLibTokenizer.of(inQuotedSymbol).toImmutableList())
+        .containsExactly(inQuotedSymbol);
   }
 
   @Test
@@ -53,45 +56,49 @@ public class TokenizerTest {
     // Split string between commands
     String splitCmd1 = "(define-const v Int)";
     String splitCmd2 = "(assert (= v (+ 2 1)))";
-    assertThat(Tokenizer.of(splitCmd1 + " \n " + splitCmd2).toImmutableList())
+    assertThat(SMTLibTokenizer.of(splitCmd1 + " \n " + splitCmd2).toImmutableList())
         .containsExactly(splitCmd1, splitCmd2);
 
     // Ignore whitespace between commands
     String skipWhitespace1 = "(define-const \n v Int)";
     String skipWhitespace2 = "(assert \n(= v (+ 2 1)))";
     assertThat(
-            Tokenizer.of(" " + skipWhitespace1 + " \n" + skipWhitespace2 + "\n").toImmutableList())
+            SMTLibTokenizer.of(" " + skipWhitespace1 + " \n" + skipWhitespace2 + "\n")
+                .toImmutableList())
         .containsExactly(skipWhitespace1, skipWhitespace2);
 
     // Copy windows newlines in the commands
     String windowsNewlines = "(define-const\r\nv Int)";
-    assertThat(Tokenizer.of(windowsNewlines).toImmutableList()).containsExactly(windowsNewlines);
+    assertThat(SMTLibTokenizer.of(windowsNewlines).toImmutableList())
+        .containsExactly(windowsNewlines);
 
     // Avoid connecting tokens across line-wraps when comments are removed
     String avoidWrap = "(define-const;comment\nv\nInt)";
-    assertThat(Tokenizer.of(avoidWrap).toImmutableList()).containsExactly("(define-const\nv\nInt)");
+    assertThat(SMTLibTokenizer.of(avoidWrap).toImmutableList())
+        .containsExactly("(define-const\nv\nInt)");
 
     // Copy newline characters in strings
     String inString = "(assert (= v \"\n\"))";
-    assertThat(Tokenizer.of(inString).toImmutableList()).containsExactly(inString);
+    assertThat(SMTLibTokenizer.of(inString).toImmutableList()).containsExactly(inString);
 
     // Copy newline characters in quoted symbols
     String inQuotedSymbol = "(assert (= |\n| 0))";
-    assertThat(Tokenizer.of(inQuotedSymbol).toImmutableList()).containsExactly(inQuotedSymbol);
+    assertThat(SMTLibTokenizer.of(inQuotedSymbol).toImmutableList())
+        .containsExactly(inQuotedSymbol);
   }
 
   @Test
   public void tokenTest() {
     // Tests if (assert... ) command is recognized
     String tokenSMTLIB = "(assert\n(= v (+ 2 1)))";
-    String token = Tokenizer.of(tokenSMTLIB).iterator().next();
+    String token = SMTLibTokenizer.of(tokenSMTLIB).iterator().next();
     assertThat(token).isEqualTo(tokenSMTLIB);
-    assertThat(Tokenizer.isAssertToken(token)).isTrue();
+    assertThat(SMTLibTokenizer.isAssertToken(token)).isTrue();
 
     // Test if (assert... ) command is recognized when it goes across several lines
     String stringTokenSMTLIB = "(assert (= v \"\n\"))";
-    String stringToken = Tokenizer.of(stringTokenSMTLIB).iterator().next();
+    String stringToken = SMTLibTokenizer.of(stringTokenSMTLIB).iterator().next();
     assertThat(stringToken).isEqualTo(stringTokenSMTLIB);
-    assertThat(Tokenizer.isAssertToken(stringToken)).isTrue();
+    assertThat(SMTLibTokenizer.isAssertToken(stringToken)).isTrue();
   }
 }

--- a/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
@@ -531,7 +531,7 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
     // Boolector will fail this anyway since bools are bitvecs for btor
     TruthJUnit.assume().that(solver).isNotEqualTo(Solvers.BOOLECTOR);
 
-    String lastCommand = getLast(Tokenizer.tokenize(dump));
+    String lastCommand = getLast(Tokenizer.tokenizeToList(dump));
     assertWithMessage("last line(s) of <\n%s>", dump).that(lastCommand).startsWith("(assert ");
     assertWithMessage("last line(s) of <\n%s>", dump).that(lastCommand).endsWith(")");
   }

--- a/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
@@ -31,7 +31,7 @@ import org.sosy_lab.java_smt.api.FormulaType;
 import org.sosy_lab.java_smt.api.FunctionDeclaration;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.SolverException;
-import org.sosy_lab.java_smt.basicimpl.Tokenizer;
+import org.sosy_lab.java_smt.basicimpl.SMTLibTokenizer;
 
 @SuppressWarnings("checkstyle:linelength")
 public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
@@ -531,7 +531,7 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
     // Boolector will fail this anyway since bools are bitvecs for btor
     TruthJUnit.assume().that(solver).isNotEqualTo(Solvers.BOOLECTOR);
 
-    String lastCommand = getLast(Tokenizer.of(dump).toImmutableList());
+    String lastCommand = getLast(SMTLibTokenizer.of(dump).toImmutableList());
     assertWithMessage("last line(s) of <\n%s>", dump).that(lastCommand).startsWith("(assert ");
     assertWithMessage("last line(s) of <\n%s>", dump).that(lastCommand).endsWith(")");
   }

--- a/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverFormulaIOTest.java
@@ -531,7 +531,7 @@ public class SolverFormulaIOTest extends SolverBasedTest0.ParameterizedSolverBas
     // Boolector will fail this anyway since bools are bitvecs for btor
     TruthJUnit.assume().that(solver).isNotEqualTo(Solvers.BOOLECTOR);
 
-    String lastCommand = getLast(Tokenizer.tokenizeToList(dump));
+    String lastCommand = getLast(Tokenizer.of(dump).toImmutableList());
     assertWithMessage("last line(s) of <\n%s>", dump).that(lastCommand).startsWith("(assert ");
     assertWithMessage("last line(s) of <\n%s>", dump).that(lastCommand).endsWith(")");
   }

--- a/src/org/sosy_lab/java_smt/test/TokenizerTest.java
+++ b/src/org/sosy_lab/java_smt/test/TokenizerTest.java
@@ -22,28 +22,28 @@ public class TokenizerTest {
   public void parenthesesTest() {
     // Valid input string
     String validBrackets = "(assert (= 3 (+ 2 1)))";
-    Truth.assertThat(Tokenizer.tokenize(validBrackets)).containsExactly(validBrackets);
+    Truth.assertThat(Tokenizer.tokenizeToList(validBrackets)).containsExactly(validBrackets);
 
     // Same string, but with one too many closing brackets
     String invalidClose = "(assert (= 3 (+ 2 1))))";
-    assertThrows(IllegalArgumentException.class, () -> Tokenizer.tokenize(invalidClose));
+    assertThrows(IllegalArgumentException.class, () -> Tokenizer.tokenizeToList(invalidClose));
 
     // Same string, but with a missing closing bracket
     String invalidOpen = "(assert (= 3 (+ 2 1))";
-    assertThrows(IllegalArgumentException.class, () -> Tokenizer.tokenize(invalidOpen));
+    assertThrows(IllegalArgumentException.class, () -> Tokenizer.tokenizeToList(invalidOpen));
 
     // Valid input string with an escaped ')' as part of a comment
     // This should not confuse the tokenizer!
     String inComment = "(assert (= 3;)\n(- 4 1)))";
-    assertThat(Tokenizer.tokenize(inComment)).containsExactly("(assert (= 3\n(- 4 1)))");
+    assertThat(Tokenizer.tokenizeToList(inComment)).containsExactly("(assert (= 3\n(- 4 1)))");
 
     // Valid input string with an escaped ')' as part of a string literal
     String inString = "(assert (= v \")\"))";
-    assertThat(Tokenizer.tokenize(inString)).containsExactly(inString);
+    assertThat(Tokenizer.tokenizeToList(inString)).containsExactly(inString);
 
     // Valid input string with an escaped ')' as part of a quoted symbol
     String inQuotedSymbol = "(assert (= |)v| 0))";
-    assertThat(Tokenizer.tokenize(inQuotedSymbol)).containsExactly(inQuotedSymbol);
+    assertThat(Tokenizer.tokenizeToList(inQuotedSymbol)).containsExactly(inQuotedSymbol);
   }
 
   @Test
@@ -51,43 +51,43 @@ public class TokenizerTest {
     // Split string between commands
     String splitCmd1 = "(define-const v Int)";
     String splitCmd2 = "(assert (= v (+ 2 1)))";
-    assertThat(Tokenizer.tokenize(splitCmd1 + " \n " + splitCmd2))
+    assertThat(Tokenizer.tokenizeToList(splitCmd1 + " \n " + splitCmd2))
         .containsExactly(splitCmd1, splitCmd2);
 
     // Ignore whitespace between commands
     String skipWhitespace1 = "(define-const \n v Int)";
     String skipWhitespace2 = "(assert \n(= v (+ 2 1)))";
-    assertThat(Tokenizer.tokenize(" " + skipWhitespace1 + " \n" + skipWhitespace2 + "\n"))
+    assertThat(Tokenizer.tokenizeToList(" " + skipWhitespace1 + " \n" + skipWhitespace2 + "\n"))
         .containsExactly(skipWhitespace1, skipWhitespace2);
 
     // Copy windows newlines in the commands
     String windowsNewlines = "(define-const\r\nv Int)";
-    assertThat(Tokenizer.tokenize(windowsNewlines)).containsExactly(windowsNewlines);
+    assertThat(Tokenizer.tokenizeToList(windowsNewlines)).containsExactly(windowsNewlines);
 
     // Avoid connecting tokens across line-wraps when comments are removed
     String avoidWrap = "(define-const;comment\nv\nInt)";
-    assertThat(Tokenizer.tokenize(avoidWrap)).containsExactly("(define-const\nv\nInt)");
+    assertThat(Tokenizer.tokenizeToList(avoidWrap)).containsExactly("(define-const\nv\nInt)");
 
     // Copy newline characters in strings
     String inString = "(assert (= v \"\n\"))";
-    assertThat(Tokenizer.tokenize(inString)).containsExactly(inString);
+    assertThat(Tokenizer.tokenizeToList(inString)).containsExactly(inString);
 
     // Copy newline characters in quoted symbols
     String inQuotedSymbol = "(assert (= |\n| 0))";
-    assertThat(Tokenizer.tokenize(inQuotedSymbol)).containsExactly(inQuotedSymbol);
+    assertThat(Tokenizer.tokenizeToList(inQuotedSymbol)).containsExactly(inQuotedSymbol);
   }
 
   @Test
   public void tokenTest() {
     // Tests if (assert... ) command is recognized
     String tokenSMTLIB = "(assert\n(= v (+ 2 1)))";
-    String token = Tokenizer.tokenize(tokenSMTLIB).get(0);
+    String token = Tokenizer.tokenizeToList(tokenSMTLIB).get(0);
     assertThat(token).isEqualTo(tokenSMTLIB);
     assertThat(Tokenizer.isAssertToken(token)).isTrue();
 
     // Test if (assert... ) command is recognized when it goes across several lines
     String stringTokenSMTLIB = "(assert (= v \"\n\"))";
-    String stringToken = Tokenizer.tokenize(stringTokenSMTLIB).get(0);
+    String stringToken = Tokenizer.tokenizeToList(stringTokenSMTLIB).get(0);
     assertThat(stringToken).isEqualTo(stringTokenSMTLIB);
     assertThat(Tokenizer.isAssertToken(stringToken)).isTrue();
   }

--- a/src/org/sosy_lab/java_smt/test/TokenizerTest.java
+++ b/src/org/sosy_lab/java_smt/test/TokenizerTest.java
@@ -22,28 +22,30 @@ public class TokenizerTest {
   public void parenthesesTest() {
     // Valid input string
     String validBrackets = "(assert (= 3 (+ 2 1)))";
-    Truth.assertThat(Tokenizer.tokenizeToList(validBrackets)).containsExactly(validBrackets);
+    Truth.assertThat(Tokenizer.of(validBrackets).toImmutableList()).containsExactly(validBrackets);
 
     // Same string, but with one too many closing brackets
     String invalidClose = "(assert (= 3 (+ 2 1))))";
-    assertThrows(IllegalArgumentException.class, () -> Tokenizer.tokenizeToList(invalidClose));
+    assertThrows(
+        IllegalArgumentException.class, () -> Tokenizer.of(invalidClose).toImmutableList());
 
     // Same string, but with a missing closing bracket
     String invalidOpen = "(assert (= 3 (+ 2 1))";
-    assertThrows(IllegalArgumentException.class, () -> Tokenizer.tokenizeToList(invalidOpen));
+    assertThrows(IllegalArgumentException.class, () -> Tokenizer.of(invalidOpen).toImmutableList());
 
     // Valid input string with an escaped ')' as part of a comment
     // This should not confuse the tokenizer!
     String inComment = "(assert (= 3;)\n(- 4 1)))";
-    assertThat(Tokenizer.tokenizeToList(inComment)).containsExactly("(assert (= 3\n(- 4 1)))");
+    assertThat(Tokenizer.of(inComment).toImmutableList())
+        .containsExactly("(assert (= 3\n(- 4 1)))");
 
     // Valid input string with an escaped ')' as part of a string literal
     String inString = "(assert (= v \")\"))";
-    assertThat(Tokenizer.tokenizeToList(inString)).containsExactly(inString);
+    assertThat(Tokenizer.of(inString).toImmutableList()).containsExactly(inString);
 
     // Valid input string with an escaped ')' as part of a quoted symbol
     String inQuotedSymbol = "(assert (= |)v| 0))";
-    assertThat(Tokenizer.tokenizeToList(inQuotedSymbol)).containsExactly(inQuotedSymbol);
+    assertThat(Tokenizer.of(inQuotedSymbol).toImmutableList()).containsExactly(inQuotedSymbol);
   }
 
   @Test
@@ -51,43 +53,44 @@ public class TokenizerTest {
     // Split string between commands
     String splitCmd1 = "(define-const v Int)";
     String splitCmd2 = "(assert (= v (+ 2 1)))";
-    assertThat(Tokenizer.tokenizeToList(splitCmd1 + " \n " + splitCmd2))
+    assertThat(Tokenizer.of(splitCmd1 + " \n " + splitCmd2).toImmutableList())
         .containsExactly(splitCmd1, splitCmd2);
 
     // Ignore whitespace between commands
     String skipWhitespace1 = "(define-const \n v Int)";
     String skipWhitespace2 = "(assert \n(= v (+ 2 1)))";
-    assertThat(Tokenizer.tokenizeToList(" " + skipWhitespace1 + " \n" + skipWhitespace2 + "\n"))
+    assertThat(
+            Tokenizer.of(" " + skipWhitespace1 + " \n" + skipWhitespace2 + "\n").toImmutableList())
         .containsExactly(skipWhitespace1, skipWhitespace2);
 
     // Copy windows newlines in the commands
     String windowsNewlines = "(define-const\r\nv Int)";
-    assertThat(Tokenizer.tokenizeToList(windowsNewlines)).containsExactly(windowsNewlines);
+    assertThat(Tokenizer.of(windowsNewlines).toImmutableList()).containsExactly(windowsNewlines);
 
     // Avoid connecting tokens across line-wraps when comments are removed
     String avoidWrap = "(define-const;comment\nv\nInt)";
-    assertThat(Tokenizer.tokenizeToList(avoidWrap)).containsExactly("(define-const\nv\nInt)");
+    assertThat(Tokenizer.of(avoidWrap).toImmutableList()).containsExactly("(define-const\nv\nInt)");
 
     // Copy newline characters in strings
     String inString = "(assert (= v \"\n\"))";
-    assertThat(Tokenizer.tokenizeToList(inString)).containsExactly(inString);
+    assertThat(Tokenizer.of(inString).toImmutableList()).containsExactly(inString);
 
     // Copy newline characters in quoted symbols
     String inQuotedSymbol = "(assert (= |\n| 0))";
-    assertThat(Tokenizer.tokenizeToList(inQuotedSymbol)).containsExactly(inQuotedSymbol);
+    assertThat(Tokenizer.of(inQuotedSymbol).toImmutableList()).containsExactly(inQuotedSymbol);
   }
 
   @Test
   public void tokenTest() {
     // Tests if (assert... ) command is recognized
     String tokenSMTLIB = "(assert\n(= v (+ 2 1)))";
-    String token = Tokenizer.tokenizeToList(tokenSMTLIB).get(0);
+    String token = Tokenizer.of(tokenSMTLIB).iterator().next();
     assertThat(token).isEqualTo(tokenSMTLIB);
     assertThat(Tokenizer.isAssertToken(token)).isTrue();
 
     // Test if (assert... ) command is recognized when it goes across several lines
     String stringTokenSMTLIB = "(assert (= v \"\n\"))";
-    String stringToken = Tokenizer.tokenizeToList(stringTokenSMTLIB).get(0);
+    String stringToken = Tokenizer.of(stringTokenSMTLIB).iterator().next();
     assertThat(stringToken).isEqualTo(stringTokenSMTLIB);
     assertThat(Tokenizer.isAssertToken(stringToken)).isTrue();
   }


### PR DESCRIPTION
This PR adds a `Iterator` implementation for tokenizing SMTLIB Strings based on the existing `Tokenizer` code. `Tokenizer` itself now implements `Iterable`, and gives access to the `Iterator` on demand.

This allows processing of SMTLIB in for-each loops efficiently and without creating multiple `Collection`s in the process.