### PR TITLE
Add MathSAT5 logic selection via option

### DIFF
--- a/lib/native/source/libmathsat5j/includes/defines.h
+++ b/lib/native/source/libmathsat5j/includes/defines.h
@@ -323,12 +323,7 @@ typedef jlong jjproof;
 typedef jlong jjconf;
 #define CONF_ARG(num) STRUCT_ARG(msat_config, num)
 #define CONF_ARG_VOID(num) STRUCT_ARG_VOID(msat_config, num)
-#define CONF_RETURN \
-  if (retval.repr == NULL) { \
-    throwException(jenv, "java/lang/IllegalArgumentException", "Invalid configuration. MathSAT returned null"); \
-  } \
-  return (jlong)((size_t)(retval.repr)); \
-}
+#define CONF_RETURN STRUCT_RETURN
 
 typedef jlong jjterm;
 #define TERM_ARG(num) STRUCT_ARG(msat_term, num)

--- a/lib/native/source/libmathsat5j/includes/defines.h
+++ b/lib/native/source/libmathsat5j/includes/defines.h
@@ -323,7 +323,12 @@ typedef jlong jjproof;
 typedef jlong jjconf;
 #define CONF_ARG(num) STRUCT_ARG(msat_config, num)
 #define CONF_ARG_VOID(num) STRUCT_ARG_VOID(msat_config, num)
-#define CONF_RETURN STRUCT_RETURN
+#define CONF_RETURN \
+  if (retval.repr == NULL) { \
+    throwException(jenv, "java/lang/IllegalArgumentException", "Invalid configuration. MathSAT returned null"); \
+  } \
+  return (jlong)((size_t)(retval.repr)); \
+}
 
 typedef jlong jjterm;
 #define TERM_ARG(num) STRUCT_ARG(msat_term, num)

--- a/lib/native/source/libmathsat5j/org_sosy_1lab_java_1smt_solvers_mathsat5_Mathsat5NativeApi.c
+++ b/lib/native/source/libmathsat5j/org_sosy_1lab_java_1smt_solvers_mathsat5_Mathsat5NativeApi.c
@@ -90,6 +90,20 @@ CALL0(msat_config, create_config)
 CONF_RETURN
 
 /*
+ * msat_config msat_create_default_config(const char * 	logic)
+ * Creates a new MathSAT configuration with the default settings for the given logic.
+ * Parameters:
+ *  logic	An SMT-LIB logic name
+ * Returns:
+ *  A new configuration. In case of errors, a cfg s.t. MSAT_ERROR_CONFIG(cfg) is true is returned. 
+ *  CONF_RETURN checks this and throws for errors.
+ */
+DEFINE_FUNC(jconf, 1create_1default_1config) WITH_ONE_ARG
+STRING_ARG(1)
+CALL1(msat_config, create_default_config)
+CONF_RETURN
+
+/*
  * void msat_destroy_config(msat_config cfg);
  */
 DEFINE_FUNC(void, 1destroy_1config) WITH_ONE_ARG(jconf)

--- a/lib/native/source/libmathsat5j/org_sosy_1lab_java_1smt_solvers_mathsat5_Mathsat5NativeApi.c
+++ b/lib/native/source/libmathsat5j/org_sosy_1lab_java_1smt_solvers_mathsat5_Mathsat5NativeApi.c
@@ -98,9 +98,10 @@ CONF_RETURN
  *  A new configuration. In case of errors, a cfg s.t. MSAT_ERROR_CONFIG(cfg) is true is returned. 
  *  CONF_RETURN checks this and throws for errors.
  */
-DEFINE_FUNC(jconf, 1create_1default_1config) WITH_ONE_ARG
+DEFINE_FUNC(jconf, 1create_1default_1config) WITH_ONE_ARG(string)
 STRING_ARG(1)
 CALL1(msat_config, create_default_config)
+FREE_STRING_ARG(1)
 CONF_RETURN
 
 /*

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -8,11 +8,13 @@
 
 package org.sosy_lab.java_smt.solvers.mathsat5;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5FormulaManager.getMsatTerm;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_all_sat;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_check_sat;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_check_sat_with_assumptions;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_create_config;
+import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_create_default_config;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_destroy_config;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_destroy_env;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_free_termination_callback;
@@ -62,17 +64,18 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
   protected Mathsat5AbstractProver(
       Mathsat5SolverContext pContext,
       Set<ProverOptions> pOptions,
+      String pLogic,
       Mathsat5FormulaCreator pCreator,
       ShutdownNotifier pShutdownNotifier) {
     super(pOptions);
     context = pContext;
     creator = pCreator;
-    curConfig = buildConfig(pOptions);
+    curConfig = buildConfig(pOptions, checkNotNull(pLogic));
     curEnv = context.createEnvironment(curConfig);
     shutdownNotifier = pShutdownNotifier;
   }
 
-  private long buildConfig(Set<ProverOptions> opts) {
+  private long buildConfig(Set<ProverOptions> opts, String pLogic) {
     Map<String, String> config = new LinkedHashMap<>();
     boolean generateUnsatCore = opts.contains(ProverOptions.GENERATE_UNSAT_CORE);
     config.put("model_generation", opts.contains(ProverOptions.GENERATE_MODELS) ? "true" : "false");
@@ -82,7 +85,13 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
     }
     createConfig(config); // ask subclasses for their options
 
-    long cfg = msat_create_config();
+    long cfg;
+    if (pLogic.isEmpty() || pLogic.equalsIgnoreCase("ALL")) {
+      cfg = msat_create_config();
+    } else {
+      // TODO: input validation for logics in MathSAT5
+      cfg = msat_create_default_config(pLogic);
+    }
     for (Map.Entry<String, String> entry : config.entrySet()) {
       msat_set_option_checked(cfg, entry.getKey(), entry.getValue());
     }
@@ -196,7 +205,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
   @Override
   public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
       Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException {
-    Preconditions.checkNotNull(assumptions);
+    checkNotNull(assumptions);
     checkGenerateUnsatCoresOverAssumptions();
 
     closeAllEvaluators();

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5InterpolatingProver.java
@@ -56,8 +56,9 @@ class Mathsat5InterpolatingProver extends Mathsat5AbstractProver<Integer>
       Mathsat5SolverContext pMgr,
       ShutdownNotifier pShutdownNotifier,
       Mathsat5FormulaCreator creator,
-      Set<ProverOptions> options) {
-    super(pMgr, options, creator, pShutdownNotifier);
+      Set<ProverOptions> options,
+      String pLogic) {
+    super(pMgr, options, pLogic, creator, pShutdownNotifier);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApi.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApi.java
@@ -205,10 +205,21 @@ final class Mathsat5NativeApi {
     return msat_get_interpolant(e, groups_of_a, groups_of_a.length);
   }
 
-  /*
-   * Environment creation
+  /**
+   * Creates a new MathSAT configuration. If you want to set the logic, please use {@link
+   * #msat_create_default_config(String)} instead. Original: msat_config msat_create_config()
    */
   public static native long msat_create_config();
+
+  /**
+   * Creates a new MathSAT configuration with the default settings for the given logic. Original:
+   * msat_config msat_create_default_config(const char * logic)
+   *
+   * @param logic An SMT-LIB logic name
+   * @return A new configuration.
+   * @throws IllegalArgumentException In case of errors.
+   */
+  public static native long msat_create_default_config(final String logic);
 
   public static native void msat_destroy_config(long cfg);
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApiTest.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApiTest.java
@@ -18,6 +18,7 @@ import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_crea
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_decl_get_arity;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_decl_get_name;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_destroy_config;
+import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_destroy_env;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_destroy_model_iterator;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_destroy_proof_manager;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_from_smtlib2;
@@ -61,6 +62,8 @@ import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_term
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_type_equals;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_type_repr;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -70,6 +73,23 @@ import org.sosy_lab.common.NativeLibraries;
 import org.sosy_lab.java_smt.api.SolverException;
 
 public class Mathsat5NativeApiTest extends Mathsat5AbstractNativeApiTest {
+
+  private static final Set<String> LOGICS_TO_TEST =
+      ImmutableSet.of(
+          "",
+          "ALL",
+          "QF_LIA",
+          "QF_LRA",
+          "QF_LIRA",
+          "LIRA",
+          "QF_UFLIA",
+          "QF_UFLRA",
+          "QF_UFLIRA",
+          "QF_ALIA",
+          "QF_ALRA",
+          "QF_ALIRA",
+          "UF_AUFLIRA",
+          "AUFLIRA");
 
   private long const0;
   private long const1;
@@ -101,26 +121,30 @@ public class Mathsat5NativeApiTest extends Mathsat5AbstractNativeApiTest {
   }
 
   @Test
-  public void createEnvironmentWithLogicAll() throws SolverException, InterruptedException {
-    long cfgWithLogic = msat_create_default_config("ALL");
-    msat_set_option_checked(cfgWithLogic, "model_generation", "true");
+  public void createEnvironmentWithLogics() throws SolverException, InterruptedException {
+    for (String logic : LOGICS_TO_TEST) {
+      long cfgWithLogic = msat_create_default_config(logic);
+      msat_set_option_checked(cfgWithLogic, "model_generation", "true");
 
-    long envWithLogic = msat_create_env(cfgWithLogic);
-    msat_destroy_config(cfgWithLogic);
+      long envWithLogic = msat_create_env(cfgWithLogic);
+      msat_destroy_config(cfgWithLogic);
 
-    long const0WithLogic = msat_make_number(envWithLogic, "0");
-    long const1WithLogic = msat_make_number(envWithLogic, "1");
-    long rationalType = msat_get_rational_type(envWithLogic);
-    long varWithLogic = msat_make_variable(envWithLogic, "rat", rationalType);
+      long const0WithLogic = msat_make_number(envWithLogic, "0");
+      long const1WithLogic = msat_make_number(envWithLogic, "1");
+      long rationalType = msat_get_rational_type(envWithLogic);
+      long varWithLogic = msat_make_variable(envWithLogic, "rat", rationalType);
 
-    long sin = msat_make_sin(envWithLogic, varWithLogic);
+      long sin = msat_make_sin(envWithLogic, varWithLogic);
 
-    msat_push_backtrack_point(envWithLogic);
+      msat_push_backtrack_point(envWithLogic);
 
-    msat_assert_formula(envWithLogic, msat_make_equal(envWithLogic, varWithLogic, const0WithLogic));
-    msat_assert_formula(envWithLogic, msat_make_equal(envWithLogic, sin, const0WithLogic));
+      msat_assert_formula(
+          envWithLogic, msat_make_equal(envWithLogic, varWithLogic, const1WithLogic));
+      msat_assert_formula(envWithLogic, msat_make_equal(envWithLogic, sin, const0WithLogic));
 
-    assertThat(msat_check_sat(envWithLogic)).isTrue();
+      assertThat(msat_check_sat(envWithLogic)).isFalse();
+      msat_destroy_env(envWithLogic);
+    }
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApiTest.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApiTest.java
@@ -9,9 +9,11 @@
 package org.sosy_lab.java_smt.solvers.mathsat5;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_assert_formula;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_check_sat;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_create_config;
+import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_create_default_config;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_create_env;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_decl_get_arity;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_decl_get_name;
@@ -96,6 +98,34 @@ public class Mathsat5NativeApiTest extends Mathsat5AbstractNativeApiTest {
     const1 = msat_make_number(env, "1");
     long rationalType = msat_get_rational_type(env);
     var = msat_make_variable(env, "rat", rationalType);
+  }
+
+  @Test
+  public void createEnvironmentWithLogicAll() throws SolverException, InterruptedException {
+    long cfgWithLogic = msat_create_default_config("ALL");
+    msat_set_option_checked(cfgWithLogic, "model_generation", "true");
+
+    long envWithLogic = msat_create_env(cfgWithLogic);
+    msat_destroy_config(cfgWithLogic);
+
+    long const0WithLogic = msat_make_number(envWithLogic, "0");
+    long const1WithLogic = msat_make_number(envWithLogic, "1");
+    long rationalType = msat_get_rational_type(envWithLogic);
+    long varWithLogic = msat_make_variable(envWithLogic, "rat", rationalType);
+
+    long sin = msat_make_sin(envWithLogic, varWithLogic);
+
+    msat_push_backtrack_point(envWithLogic);
+
+    msat_assert_formula(envWithLogic, msat_make_equal(envWithLogic, varWithLogic, const0WithLogic));
+    msat_assert_formula(envWithLogic, msat_make_equal(envWithLogic, sin, const0WithLogic));
+
+    assertThat(msat_check_sat(envWithLogic)).isTrue();
+  }
+
+  @Test
+  public void createConfigWithInvalidLogic() {
+    assertThrows(IllegalArgumentException.class, () -> msat_create_default_config("unfug"));
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApiTest.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApiTest.java
@@ -123,7 +123,9 @@ public class Mathsat5NativeApiTest extends Mathsat5AbstractNativeApiTest {
   @Test
   public void createEnvironmentWithLogics() throws SolverException, InterruptedException {
     for (String logic : LOGICS_TO_TEST) {
+      // Logics just set certain default settings in MathSAT5
       long cfgWithLogic = msat_create_default_config(logic);
+      // Set some option just to check whether there are problems
       msat_set_option_checked(cfgWithLogic, "model_generation", "true");
 
       long envWithLogic = msat_create_env(cfgWithLogic);

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApiTest.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5NativeApiTest.java
@@ -2,14 +2,13 @@
 // an API wrapper for a collection of SMT solvers:
 // https://github.com/sosy-lab/java-smt
 //
-// SPDX-FileCopyrightText: 2020 Dirk Beyer <https://www.sosy-lab.org>
+// SPDX-FileCopyrightText: 2026 Dirk Beyer <https://www.sosy-lab.org>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package org.sosy_lab.java_smt.solvers.mathsat5;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_assert_formula;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_check_sat;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_create_config;
@@ -74,8 +73,10 @@ import org.sosy_lab.java_smt.api.SolverException;
 
 public class Mathsat5NativeApiTest extends Mathsat5AbstractNativeApiTest {
 
+  // Some logics and other strings to test how mathsat reacts to them
   private static final Set<String> LOGICS_TO_TEST =
       ImmutableSet.of(
+          "unfug",
           "",
           "ALL",
           "QF_LIA",
@@ -120,6 +121,7 @@ public class Mathsat5NativeApiTest extends Mathsat5AbstractNativeApiTest {
     var = msat_make_variable(env, "rat", rationalType);
   }
 
+  // MathSAT5 seems to ignore invalid input for logics
   @Test
   public void createEnvironmentWithLogics() throws SolverException, InterruptedException {
     for (String logic : LOGICS_TO_TEST) {
@@ -147,11 +149,6 @@ public class Mathsat5NativeApiTest extends Mathsat5AbstractNativeApiTest {
       assertThat(msat_check_sat(envWithLogic)).isFalse();
       msat_destroy_env(envWithLogic);
     }
-  }
-
-  @Test
-  public void createConfigWithInvalidLogic() {
-    assertThrows(IllegalArgumentException.class, () -> msat_create_default_config("unfug"));
   }
 
   @Test

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
@@ -59,8 +59,9 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
       Mathsat5SolverContext pMgr,
       ShutdownNotifier pShutdownNotifier,
       Mathsat5FormulaCreator creator,
-      Set<ProverOptions> options) {
-    super(pMgr, options, creator, pShutdownNotifier);
+      Set<ProverOptions> options,
+      String pLogic) {
+    super(pMgr, options, pLogic, creator, pShutdownNotifier);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
@@ -88,7 +88,7 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
         description =
             "SMT-LIB logic to configure the SMT solvers (i.e. all Provers created from a"
                 + " SolverContext with this option) with. Default: ALL")
-    private final String logic = "ALL";
+    private String logic = "ALL";
 
     private final @Nullable PathCounterTemplate logfile;
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
@@ -83,6 +83,13 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
     @Option(secure = true, description = "Load less stable optimizing version of mathsat5 solver.")
     boolean loadOptimathsat5 = false;
 
+    @Option(
+        secure = true,
+        description =
+            "SMT-LIB logic to configure the SMT solvers (i.e. all Provers created from a"
+                + " SolverContext with this option) with. Default: ALL")
+    private final String logic = "ALL";
+
     private final @Nullable PathCounterTemplate logfile;
 
     private final ImmutableMap<String, String> furtherOptionsMap;
@@ -287,21 +294,22 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
   @Override
   protected ProverEnvironment newProverEnvironment0(Set<ProverOptions> options) {
     Preconditions.checkState(!closed, "solver context is already closed");
-    return new Mathsat5TheoremProver(this, shutdownNotifier, creator, options);
+    return new Mathsat5TheoremProver(this, shutdownNotifier, creator, options, settings.logic);
   }
 
   @Override
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> options) {
     Preconditions.checkState(!closed, "solver context is already closed");
-    return new Mathsat5InterpolatingProver(this, shutdownNotifier, creator, options);
+    return new Mathsat5InterpolatingProver(
+        this, shutdownNotifier, creator, options, settings.logic);
   }
 
   @Override
   public OptimizationProverEnvironment newOptimizationProverEnvironment0(
       Set<ProverOptions> options) {
     Preconditions.checkState(!closed, "solver context is already closed");
-    return new Mathsat5OptimizationProver(this, shutdownNotifier, creator, options);
+    return new Mathsat5OptimizationProver(this, shutdownNotifier, creator, options, settings.logic);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5TheoremProver.java
@@ -26,8 +26,9 @@ class Mathsat5TheoremProver extends Mathsat5AbstractProver<Void> implements Prov
       Mathsat5SolverContext pMgr,
       ShutdownNotifier pShutdownNotifier,
       Mathsat5FormulaCreator creator,
-      Set<ProverOptions> options) {
-    super(pMgr, options, creator, pShutdownNotifier);
+      Set<ProverOptions> options,
+      String pLogic) {
+    super(pMgr, options, pLogic, creator, pShutdownNotifier);
   }
 
   @Override


### PR DESCRIPTION
This PR adds context wide (i.e. all provers created from a certain context) logic selection via a new option for MathSAT5 with tests. This adds a new function to the wrapper and MathSAT5 needs to be recompiled and re-published for this PR.