### PR TITLE
Handle model generation api through implementation delegates

### DIFF
--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -99,6 +99,14 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
         ProverOptions.GENERATE_UNSAT_CORE_OVER_ASSUMPTIONS);
   }
 
+  /**
+   * Checks whether the prover has been closed already. Only to be used if this is the only check
+   * performed in a call.
+   */
+  protected void checkClosed() {
+    Preconditions.checkState(!closed);
+  }
+
   private void checkGenerateInterpolants() {
     Preconditions.checkState(!closed);
     Preconditions.checkState(

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -31,6 +31,7 @@ import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Evaluator;
 import org.sosy_lab.java_smt.api.InterpolatingProverEnvironment;
+import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.OptimizationProverEnvironment;
 import org.sosy_lab.java_smt.api.OptimizationProverEnvironment.OptStatus;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
@@ -285,6 +286,24 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
       }
     }
     return builder.buildOrThrow();
+  }
+
+  @Override
+  public final Model getModel() throws SolverException {
+    checkGenerateModels();
+    return getModelImpl();
+  }
+
+  public abstract Model getModelImpl() throws SolverException;
+
+  @Override
+  public final Evaluator getEvaluator() throws SolverException {
+    checkGenerateModels();
+    return getEvaluatorImpl();
+  }
+
+  public Evaluator getEvaluatorImpl() throws SolverException {
+    return getModel();
   }
 
   /**

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -294,7 +294,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     return getModelImpl();
   }
 
-  public abstract Model getModelImpl() throws SolverException;
+  protected abstract Model getModelImpl() throws SolverException;
 
   @Override
   public final Evaluator getEvaluator() throws SolverException {
@@ -302,7 +302,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     return getEvaluatorImpl();
   }
 
-  public Evaluator getEvaluatorImpl() throws SolverException {
+  protected Evaluator getEvaluatorImpl() throws SolverException {
     return getModel();
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractSolverContext.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractSolverContext.java
@@ -72,7 +72,7 @@ public abstract class AbstractSolverContext implements SolverContext {
   @Override
   public final OptimizationProverEnvironment newOptimizationProverEnvironment(
       ProverOptions... options) {
-    return newOptimizationProverEnvironment0(toSet(options));
+    return new OptimizationProverDelegate(newOptimizationProverEnvironment0(toSet(options)));
   }
 
   protected abstract OptimizationProverEnvironment newOptimizationProverEnvironment0(

--- a/src/org/sosy_lab/java_smt/basicimpl/InterpolatingProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/InterpolatingProverDelegate.java
@@ -10,6 +10,7 @@
 
 package org.sosy_lab.java_smt.basicimpl;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
@@ -31,6 +32,7 @@ class InterpolatingProverDelegate<T> implements InterpolatingProverEnvironment<T
   private final InterpolatingProverEnvironment<T> itpProver;
 
   InterpolatingProverDelegate(InterpolatingProverEnvironment<T> pBaseProver) {
+    checkArgument(pBaseProver instanceof AbstractProver<?>);
     itpProver = checkNotNull(pBaseProver);
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of JavaSMT,
+ * an API wrapper for a collection of SMT solvers:
+ * https://github.com/sosy-lab/java-smt
+ *
+ * SPDX-FileCopyrightText: 2026 Dirk Beyer <https://www.sosy-lab.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.sosy_lab.java_smt.basicimpl;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.rationals.Rational;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.Formula;
+import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.java_smt.api.OptimizationProverEnvironment;
+import org.sosy_lab.java_smt.api.SolverException;
+
+/**
+ * This delegate enables common implementations for methods in {@link OptimizationProverEnvironment}
+ * based on the implementations in the abstract/theorem prover that can not be done using abstract
+ * implementations.
+ */
+public class OptimizationProverDelegate implements OptimizationProverEnvironment {
+
+  private final OptimizationProverEnvironment optimizationProver;
+
+  OptimizationProverDelegate(OptimizationProverEnvironment pBaseProver) {
+    optimizationProver = checkNotNull(pBaseProver);
+  }
+
+  @SuppressWarnings("resource")
+  @Override
+  public int maximize(Formula objective) {
+    getDelegateAsAbstractProver().checkClosed();
+    return optimizationProver.maximize(objective);
+  }
+
+  @SuppressWarnings("resource")
+  @Override
+  public int minimize(Formula objective) {
+    getDelegateAsAbstractProver().checkClosed();
+    return optimizationProver.minimize(objective);
+  }
+
+  @SuppressWarnings("resource")
+  @Override
+  public Optional<Rational> upper(int handle, Rational epsilon) {
+    getDelegateAsAbstractProver().checkGenerateModels();
+    return optimizationProver.upper(handle, epsilon);
+  }
+
+  @SuppressWarnings("resource")
+  @Override
+  public Optional<Rational> lower(int handle, Rational epsilon) {
+    getDelegateAsAbstractProver().checkGenerateModels();
+    return optimizationProver.lower(handle, epsilon);
+  }
+
+  @Override
+  public OptStatus check() throws InterruptedException, SolverException {
+    // We don't need to do anything for check, as it is already handled in AbstractProver
+    return optimizationProver.check();
+  }
+
+  /* ########################## Delegate methods of ProverEnvironment ########################## */
+
+  @SuppressWarnings("resource")
+  @Override
+  public Model getModel() throws SolverException {
+    // getModel does not use a implementation/delegate and needs to be checked here!
+    getDelegateAsAbstractProver().checkGenerateModels();
+    return optimizationProver.getModel();
+  }
+
+  @Override
+  public void pop() {
+    optimizationProver.pop();
+  }
+
+  @Override
+  public @Nullable Void addConstraint(BooleanFormula constraint) throws InterruptedException {
+    return optimizationProver.addConstraint(constraint);
+  }
+
+  @Override
+  public void push() throws InterruptedException {
+    optimizationProver.push();
+  }
+
+  @Override
+  public int size() {
+    return optimizationProver.size();
+  }
+
+  @Override
+  public boolean isUnsat() throws SolverException, InterruptedException {
+    return optimizationProver.isUnsat();
+  }
+
+  @Override
+  public boolean isUnsatWithAssumptions(Collection<BooleanFormula> assumptions)
+      throws SolverException, InterruptedException {
+    return optimizationProver.isUnsatWithAssumptions(assumptions);
+  }
+
+  @Override
+  public List<BooleanFormula> getUnsatCore() {
+    return optimizationProver.getUnsatCore();
+  }
+
+  @Override
+  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
+      Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException {
+    return optimizationProver.unsatCoreOverAssumptions(assumptions);
+  }
+
+  @Override
+  public void close() {
+    optimizationProver.close();
+  }
+
+  @Override
+  public <R> R allSat(AllSatCallback<R> callback, List<BooleanFormula> important)
+      throws InterruptedException, SolverException {
+    return optimizationProver.allSat(callback, important);
+  }
+
+  /* ############################### Utility methods ############################### */
+  @SuppressWarnings("unchecked")
+  private AbstractProver<?> getDelegateAsAbstractProver() {
+    return (AbstractProver<?>) optimizationProver;
+  }
+}

--- a/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
@@ -75,8 +75,6 @@ public class OptimizationProverDelegate implements OptimizationProverEnvironment
   @SuppressWarnings("resource")
   @Override
   public Model getModel() throws SolverException {
-    // getModel does not use a implementation/delegate and needs to be checked here!
-    getDelegateAsAbstractProver().checkGenerateModels();
     return optimizationProver.getModel();
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
@@ -10,6 +10,7 @@
 
 package org.sosy_lab.java_smt.basicimpl;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
@@ -33,6 +34,7 @@ public class OptimizationProverDelegate implements OptimizationProverEnvironment
   private final OptimizationProverEnvironment optimizationProver;
 
   OptimizationProverDelegate(OptimizationProverEnvironment pBaseProver) {
+    checkArgument(pBaseProver instanceof AbstractProver<?>);
     optimizationProver = checkNotNull(pBaseProver);
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/PackageSanityTest.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/PackageSanityTest.java
@@ -18,6 +18,9 @@ public class PackageSanityTest extends AbstractPackageSanityTests {
   {
     setDistinctValues(FormulaType.class, FormulaType.BooleanType, FormulaType.IntegerType);
     setDefault(ShutdownNotifier.class, ShutdownManager.create().getNotifier());
-    ignoreClasses(c -> c.equals(InterpolatingProverDelegate.class));
+    ignoreClasses(
+        c ->
+            c.equals(InterpolatingProverDelegate.class)
+                || c.equals(OptimizationProverDelegate.class));
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -165,8 +165,7 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
    */
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     // special case for Bitwuzla: Models are not permanent and need to be closed
     // before any change is applied to the prover stack. So, we register the Model as Evaluator.
     return registerEvaluator(

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -165,7 +165,7 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
    */
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     // special case for Bitwuzla: Models are not permanent and need to be closed
     // before any change is applied to the prover stack. So, we register the Model as Evaluator.
     return registerEvaluator(

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
@@ -127,8 +127,7 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
   }
 
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
@@ -127,7 +127,7 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
   }
 
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -155,7 +155,7 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
   }
 
   @Override
-  public Evaluator getEvaluatorImpl() {
+  protected Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -143,8 +143,7 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
 
   @SuppressWarnings("resource")
   @Override
-  public CVC4Model getModel() throws SolverException {
-    checkGenerateModels();
+  public CVC4Model getModelImpl() throws SolverException {
     // special case for CVC4: Models are not permanent and need to be closed
     // before any change is applied to the prover stack. So, we register the Model as Evaluator.
     return registerEvaluator(
@@ -156,8 +155,7 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
   }
 
   @Override
-  public Evaluator getEvaluator() {
-    checkGenerateModels();
+  public Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -165,8 +165,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public CVC5Model getModel() throws SolverException {
-    checkGenerateModels();
+  public CVC5Model getModelImpl() throws SolverException {
     // special case for CVC5: Models are not permanent and need to be closed
     // before any change is applied to the prover stack. So, we register the Model as Evaluator.
     return registerEvaluator(
@@ -175,8 +174,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public Evaluator getEvaluator() {
-    checkGenerateModels();
+  public Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -174,7 +174,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public Evaluator getEvaluatorImpl() {
+  protected Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -144,8 +144,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return new CachingModel(new Mathsat5Model(getMsatModel(), creator, this));
   }
 
@@ -159,8 +158,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
 
   @SuppressWarnings("resource")
   @Override
-  public Evaluator getEvaluator() {
-    checkGenerateModels();
+  public Evaluator getEvaluatorImpl() {
     return registerEvaluator(new Mathsat5Evaluator(this, creator, curEnv));
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -144,7 +144,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return new CachingModel(new Mathsat5Model(getMsatModel(), creator, this));
   }
 
@@ -158,7 +158,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
 
   @SuppressWarnings("resource")
   @Override
-  public Evaluator getEvaluatorImpl() {
+  protected Evaluator getEvaluatorImpl() {
     return registerEvaluator(new Mathsat5Evaluator(this, creator, curEnv));
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -152,7 +152,6 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
    * @throws SolverException if an expected MathSAT failure occurs
    */
   protected long getMsatModel() throws SolverException {
-    checkGenerateModels();
     return Mathsat5NativeApi.msat_get_model(curEnv);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
@@ -139,7 +139,7 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
   }
 
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     if (!objectiveMap.isEmpty()) {
       msat_load_objective_model(curEnv, objectiveMap.values().iterator().next());
     }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
@@ -8,7 +8,6 @@
 
 package org.sosy_lab.java_smt.solvers.mathsat5;
 
-import static com.google.common.base.Preconditions.checkState;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5FormulaManager.getMsatTerm;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.MSAT_OPTIMUM;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_assert_formula;
@@ -77,7 +76,6 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
 
   @Override
   public int maximize(Formula objective) {
-    checkState(!closed);
     long objectiveId = msat_make_maximize(curEnv, getMsatTerm(objective));
     msat_assert_objective(curEnv, objectiveId);
     int id = idGenerator.getFreshId(); // mapping needed to avoid long-int-conversion
@@ -87,7 +85,6 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
 
   @Override
   public int minimize(Formula objective) {
-    checkState(!closed);
     long objectiveId = msat_make_minimize(curEnv, getMsatTerm(objective));
     msat_assert_objective(curEnv, objectiveId);
     int id = idGenerator.getFreshId(); // mapping needed to avoid long-int-conversion
@@ -119,15 +116,11 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
 
   @Override
   public Optional<Rational> upper(int handle, Rational epsilon) {
-    checkState(!closed);
-    checkGenerateModels();
     return getValue(handle, epsilon);
   }
 
   @Override
   public Optional<Rational> lower(int handle, Rational epsilon) {
-    checkState(!closed);
-    checkGenerateModels();
     return getValue(handle, epsilon);
   }
 
@@ -147,8 +140,6 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
 
   @Override
   public Model getModel() throws SolverException {
-    checkState(!closed);
-    checkGenerateModels(); // Needed before loading objective model!
     if (!objectiveMap.isEmpty()) {
       msat_load_objective_model(curEnv, objectiveMap.values().iterator().next());
     }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
@@ -139,10 +139,10 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
   }
 
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModelImpl() throws SolverException {
     if (!objectiveMap.isEmpty()) {
       msat_load_objective_model(curEnv, objectiveMap.values().iterator().next());
     }
-    return super.getModel();
+    return super.getModelImpl();
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -117,14 +117,14 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() {
+  protected Model getModelImpl() {
     return registerEvaluator(
         new OpenSmtModel(
             this, creator, Collections2.transform(getAssertedFormulas(), creator::extractInfo)));
   }
 
   @Override
-  public Evaluator getEvaluatorImpl() {
+  protected Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -117,16 +117,14 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() {
-    checkGenerateModels();
+  public Model getModelImpl() {
     return registerEvaluator(
         new OpenSmtModel(
             this, creator, Collections2.transform(getAssertedFormulas(), creator::extractInfo)));
   }
 
   @Override
-  public Evaluator getEvaluator() {
-    checkGenerateModels();
+  public Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
@@ -130,8 +130,7 @@ abstract class PrincessAbstractProver<E> extends AbstractProverWithAllSat<E> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
@@ -130,7 +130,7 @@ abstract class PrincessAbstractProver<E> extends AbstractProverWithAllSat<E> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
@@ -140,8 +140,7 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public org.sosy_lab.java_smt.api.Model getModel() {
-    checkGenerateModels();
+  public org.sosy_lab.java_smt.api.Model getModelImpl() {
     final Model model;
     try {
       model = env.getModel();

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
@@ -207,7 +207,7 @@ abstract class Yices2AbstractProver<T> extends AbstractProverWithAllSat<T>
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
@@ -207,8 +207,7 @@ abstract class Yices2AbstractProver<T> extends AbstractProverWithAllSat<T>
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -116,8 +116,7 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -116,7 +116,7 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3OptimizationProver.java
@@ -8,8 +8,6 @@
 
 package org.sosy_lab.java_smt.solvers.z3;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.z3.Native;
@@ -66,13 +64,11 @@ class Z3OptimizationProver extends Z3AbstractProver implements OptimizationProve
 
   @Override
   public int maximize(Formula objective) {
-    Preconditions.checkState(!closed);
     return Native.optimizeMaximize(z3context, z3optSolver, creator.extractInfo(objective));
   }
 
   @Override
   public int minimize(Formula objective) {
-    checkState(!closed);
     return Native.optimizeMinimize(z3context, z3optSolver, creator.extractInfo(objective));
   }
 
@@ -149,15 +145,11 @@ class Z3OptimizationProver extends Z3AbstractProver implements OptimizationProve
 
   @Override
   public Optional<Rational> upper(int handle, Rational epsilon) {
-    checkState(!closed);
-    checkGenerateModels();
     return round(handle, epsilon, Native::optimizeGetUpperAsVector);
   }
 
   @Override
   public Optional<Rational> lower(int handle, Rational epsilon) {
-    checkState(!closed);
-    checkGenerateModels();
     return round(handle, epsilon, Native::optimizeGetLowerAsVector);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
@@ -121,8 +121,7 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
@@ -121,7 +121,7 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 


### PR DESCRIPTION
Model generating API (e.g. getModel()) was implemented for every solver. Meaning that also all checks that are required before executing solver specific code were added on a per solver basis. Since this is error prone, this PR collects these common checks now in `AbstractProver` and delegates the solver specific implementations to new, internal API that does no longer need to think about these common checks.

Note: i did not remove the default implementations in `BasicProverEnvironment`, as this would potentially break client code that inherits from it.

To be merged after #671 as it is based on its branch.