### PR TITLE
Add solver and interrupted exceptions to all prover methods

### DIFF
--- a/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/api/BasicProverEnvironment.java
@@ -45,7 +45,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    * Remove one backtracking point/level from the current stack. This removes the latest level
    * including all of its formulas, i.e., all formulas that were added for this backtracking point.
    */
-  void pop();
+  void pop() throws InterruptedException;
 
   /** Add a constraint to the latest backtracking point. */
   @Nullable
@@ -100,7 +100,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    * model might contain additional symbols with their evaluation, if a solver uses its own
    * temporary symbols.
    */
-  Model getModel() throws SolverException;
+  Model getModel() throws SolverException, InterruptedException;
 
   /**
    * Get a temporary view on the current satisfying assignment. This should be called only
@@ -108,7 +108,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    * should no longer be used as soon as any constraints are added to, pushed, or popped from the
    * prover stack.
    */
-  default Evaluator getEvaluator() throws SolverException {
+  default Evaluator getEvaluator() throws SolverException, InterruptedException {
     return getModel();
   }
 
@@ -120,7 +120,8 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    * <p>Note that if you need to iterate multiple times over the model it may be more efficient to
    * use this method instead of {@link #getModel()} (depending on the solver).
    */
-  default ImmutableList<Model.ValueAssignment> getModelAssignments() throws SolverException {
+  default ImmutableList<Model.ValueAssignment> getModelAssignments()
+      throws SolverException, InterruptedException {
     try (Model model = getModel()) {
       return model.asList();
     }
@@ -132,7 +133,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    * <p>This should be called only immediately after an {@link #isUnsat()} call that returned <code>
    * false</code>. Requires the {@link ProverOptions#GENERATE_UNSAT_CORE} option to work.
    */
-  List<BooleanFormula> getUnsatCore();
+  List<BooleanFormula> getUnsatCore() throws InterruptedException;
 
   /**
    * Returns an UNSAT core (if it exists, otherwise {@code Optional.empty()}), over the chosen
@@ -166,9 +167,7 @@ public interface BasicProverEnvironment<T> extends AutoCloseable {
    *
    * @see SolverContext#getStatistics()
    */
-  default ImmutableMap<String, String> getStatistics() {
-    return ImmutableMap.of();
-  }
+  ImmutableMap<String, String> getStatistics() throws InterruptedException;
 
   /**
    * Closes the prover environment. The object should be discarded, and should not be used after

--- a/src/org/sosy_lab/java_smt/api/OptimizationProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/api/OptimizationProverEnvironment.java
@@ -68,7 +68,7 @@ public interface OptimizationProverEnvironment extends BasicProverEnvironment<Vo
    * (epsilon is irrelevant here and can be zero). The model returns the optimal assignment x=9.
    */
   @Override
-  Model getModel() throws SolverException;
+  Model getModel() throws SolverException, InterruptedException;
 
   /** Status of the optimization problem. */
   enum OptStatus {

--- a/src/org/sosy_lab/java_smt/api/OptimizationProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/api/OptimizationProverEnvironment.java
@@ -21,7 +21,7 @@ public interface OptimizationProverEnvironment extends BasicProverEnvironment<Vo
    *
    * @return Objective handle, to be used for retrieving the value.
    */
-  int maximize(Formula objective);
+  int maximize(Formula objective) throws InterruptedException;
 
   /**
    * Add minimization <code>objective</code>.
@@ -30,7 +30,7 @@ public interface OptimizationProverEnvironment extends BasicProverEnvironment<Vo
    *
    * @return Objective handle, to be used for retrieving the value.
    */
-  int minimize(Formula objective);
+  int minimize(Formula objective) throws InterruptedException;
 
   /**
    * Optimize the objective function subject to the previously imposed constraints.
@@ -44,14 +44,14 @@ public interface OptimizationProverEnvironment extends BasicProverEnvironment<Vo
    * @return Upper approximation of the optimized value, or absent optional if the objective is
    *     unbounded.
    */
-  Optional<Rational> upper(int handle, Rational epsilon);
+  Optional<Rational> upper(int handle, Rational epsilon) throws InterruptedException;
 
   /**
    * @param epsilon Value to substitute for the {@code epsilon}.
    * @return Lower approximation of the optimized value, or absent optional if the objective is
    *     unbounded.
    */
-  Optional<Rational> lower(int handle, Rational epsilon);
+  Optional<Rational> lower(int handle, Rational epsilon) throws InterruptedException;
 
   /**
    * {@inheritDoc}

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -82,6 +82,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   }
 
   protected final void checkGenerateAllSat() {
+    // TODO: should this close all evaluators as well?
     Preconditions.checkState(!closed);
     Preconditions.checkState(generateAllSat, TEMPLATE, ProverOptions.GENERATE_ALL_SAT);
   }
@@ -360,6 +361,16 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
    */
   protected abstract Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
       Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException;
+
+  @Override
+  public final <R> R allSat(AllSatCallback<R> callback, List<BooleanFormula> important)
+      throws InterruptedException, SolverException {
+    checkGenerateAllSat();
+    return allSatImpl(callback, important);
+  }
+
+  protected abstract <R> R allSatImpl(AllSatCallback<R> callback, List<BooleanFormula> important)
+      throws InterruptedException, SolverException;
 
   @Override
   public void close() {

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -119,10 +119,14 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     Preconditions.checkState(!closed);
   }
 
+  protected final void shutdownIfNecessary() throws InterruptedException {
+    contextShutdownNotifier.shutdownIfNecessary();
+  }
+
   private void checkGenerateInterpolants() throws InterruptedException {
     // TODO: should this close all evaluators as well?
     Preconditions.checkState(!closed);
-    contextShutdownNotifier.shutdownIfNecessary();
+    shutdownIfNecessary();
     Preconditions.checkState(
         !changedSinceLastSatQuery,
         "Interpolants can only be calculated right after a call to isUnsat()");
@@ -195,7 +199,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   @Override
   public final void pop() throws InterruptedException {
     checkState(!closed);
-    contextShutdownNotifier.shutdownIfNecessary();
+    shutdownIfNecessary();
     checkState(assertedFormulas.size() > 1, "initial level must remain until close");
     assertedFormulas.remove(assertedFormulas.size() - 1); // remove last
     popImpl();
@@ -208,7 +212,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   @CanIgnoreReturnValue
   public final @Nullable T addConstraint(BooleanFormula constraint) throws InterruptedException {
     checkState(!closed);
-    contextShutdownNotifier.shutdownIfNecessary();
+    shutdownIfNecessary();
     T t = addConstraintImpl(constraint);
     setChanged();
     Iterables.getLast(assertedFormulas).put(constraint, t);
@@ -249,6 +253,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
    */
   public final OptStatus check() throws InterruptedException, SolverException {
     checkState(!closed);
+    shutdownIfNecessary();
     wasLastSatCheckSatisfiable = false;
     changedSinceLastSatQuery = false;
     final OptStatus status = checkImpl();

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -325,6 +325,19 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
+  public final List<BooleanFormula> getUnsatCore() {
+    checkGenerateUnsatCores();
+    return getUnsatCoreImpl();
+  }
+
+  /**
+   * @implSpec override and implement if a solver supports UNSAT-CORE generation.
+   */
+  public List<BooleanFormula> getUnsatCoreImpl() {
+    throw new UnsupportedOperationException(UNSAT_CORE_NOT_SUPPORTED);
+  }
+
+  @Override
   public void close() {
     assertedFormulas.clear();
     closeAllEvaluators();

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -127,6 +127,10 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     contextShutdownNotifier.shutdownIfNecessary();
   }
 
+  protected final boolean shouldShutdown() {
+    return contextShutdownNotifier.shouldShutdown();
+  }
+
   private void checkGenerateInterpolants() throws InterruptedException {
     // TODO: should this close all evaluators as well?
     Preconditions.checkState(!closed);

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -99,6 +99,14 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
         ProverOptions.GENERATE_UNSAT_CORE_OVER_ASSUMPTIONS);
   }
 
+  /**
+   * Checks whether the prover has been closed already. Only to be used if this is the only check
+   * performed in a call.
+   */
+  protected void checkClosed() {
+    Preconditions.checkState(!closed);
+  }
+
   private void checkGenerateInterpolants() {
     Preconditions.checkState(!closed);
     Preconditions.checkState(

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
@@ -86,18 +87,23 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   }
 
   protected final void checkGenerateUnsatCores() {
+    // TODO: should this close all evaluators as well?
     Preconditions.checkState(generateUnsatCores, TEMPLATE, ProverOptions.GENERATE_UNSAT_CORE);
     Preconditions.checkState(!closed);
     Preconditions.checkState(!changedSinceLastSatQuery);
     Preconditions.checkState(!wasLastSatCheckSatisfiable);
   }
 
-  protected final void checkGenerateUnsatCoresOverAssumptions() {
+  protected final void checkGenerateUnsatCoresOverAssumptions(
+      Collection<BooleanFormula> assumptions) {
+    // TODO: should this close all evaluators as well?
     Preconditions.checkState(!closed);
+    Preconditions.checkNotNull(assumptions);
     Preconditions.checkState(
         generateUnsatCoresOverAssumptions,
         TEMPLATE,
         ProverOptions.GENERATE_UNSAT_CORE_OVER_ASSUMPTIONS);
+    // TODO: why is there no check for changedSinceLastSatQuery or wasLastSatCheckSatisfiable?
   }
 
   /**
@@ -109,6 +115,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   }
 
   private void checkGenerateInterpolants() {
+    // TODO: should this close all evaluators as well?
     Preconditions.checkState(!closed);
     Preconditions.checkState(
         !changedSinceLastSatQuery,
@@ -333,9 +340,26 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   /**
    * @implSpec override and implement if a solver supports UNSAT-CORE generation.
    */
-  public List<BooleanFormula> getUnsatCoreImpl() {
+  protected List<BooleanFormula> getUnsatCoreImpl() {
     throw new UnsupportedOperationException(UNSAT_CORE_NOT_SUPPORTED);
   }
+
+  @Override
+  public final Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
+      Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException {
+    checkGenerateUnsatCoresOverAssumptions(assumptions);
+    return unsatCoreOverAssumptionsImpl(assumptions);
+  }
+
+  /**
+   * TODO: once javac does not complain if we use a default impl here, add one.
+   *
+   * @implSpec override and implement if a solver supports the generation of UNSAT-COREs over
+   *     assumptions. Else, override and throw a {@link UnsupportedOperationException} with {@link
+   *     BasicProverEnvironment#UNSAT_CORE_WITH_ASSUMPTIONS_NOT_SUPPORTED}
+   */
+  protected abstract Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
+      Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException;
 
   @Override
   public void close() {

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -369,6 +369,10 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     return allSatImpl(callback, important);
   }
 
+  // TODO: move AllSAT basic impl here?
+  /**
+   * @implSpec only override and implement if a solver offers its own AllSAT procedure.
+   */
   protected abstract <R> R allSatImpl(AllSatCallback<R> callback, List<BooleanFormula> important)
       throws InterruptedException, SolverException;
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -187,6 +187,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   @Override
   public int size() {
     checkState(!closed);
+    // TODO: can the solver calls used in the implementations cause interrupts?
     return assertedFormulas.size() - 1;
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -301,7 +301,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     return getModelImpl();
   }
 
-  public abstract Model getModelImpl() throws SolverException;
+  protected abstract Model getModelImpl() throws SolverException;
 
   @Override
   public final Evaluator getEvaluator() throws SolverException {
@@ -309,7 +309,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     return getEvaluatorImpl();
   }
 
-  public Evaluator getEvaluatorImpl() throws SolverException {
+  protected Evaluator getEvaluatorImpl() throws SolverException {
     return getModel();
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -78,31 +78,35 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     contextShutdownNotifier = pContextShutdownNotifier;
   }
 
-  protected final void checkGenerateModels() {
+  protected final void checkGenerateModels() throws InterruptedException {
     Preconditions.checkState(generateModels, TEMPLATE, ProverOptions.GENERATE_MODELS);
     Preconditions.checkState(!closed);
+    shutdownIfNecessary();
     Preconditions.checkState(!changedSinceLastSatQuery);
     Preconditions.checkState(wasLastSatCheckSatisfiable, NO_MODEL_HELP);
   }
 
-  protected final void checkGenerateAllSat() {
+  protected final void checkGenerateAllSat() throws InterruptedException {
     // TODO: should this close all evaluators as well?
     Preconditions.checkState(!closed);
+    shutdownIfNecessary();
     Preconditions.checkState(generateAllSat, TEMPLATE, ProverOptions.GENERATE_ALL_SAT);
   }
 
-  protected final void checkGenerateUnsatCores() {
+  protected final void checkGenerateUnsatCores() throws InterruptedException {
     // TODO: should this close all evaluators as well?
     Preconditions.checkState(generateUnsatCores, TEMPLATE, ProverOptions.GENERATE_UNSAT_CORE);
     Preconditions.checkState(!closed);
+    shutdownIfNecessary();
     Preconditions.checkState(!changedSinceLastSatQuery);
     Preconditions.checkState(!wasLastSatCheckSatisfiable);
   }
 
   protected final void checkGenerateUnsatCoresOverAssumptions(
-      Collection<BooleanFormula> assumptions) {
+      Collection<BooleanFormula> assumptions) throws InterruptedException {
     // TODO: should this close all evaluators as well?
     Preconditions.checkState(!closed);
+    shutdownIfNecessary();
     Preconditions.checkNotNull(assumptions);
     Preconditions.checkState(
         generateUnsatCoresOverAssumptions,
@@ -189,6 +193,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   @Override
   public final void push() throws InterruptedException {
     checkState(!closed);
+    shutdownIfNecessary();
     pushImpl();
     setChanged();
     assertedFormulas.add(LinkedHashMultimap.create());
@@ -226,6 +231,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   @Override
   public final boolean isUnsat() throws SolverException, InterruptedException {
     checkState(!closed);
+    shutdownIfNecessary();
     changedSinceLastSatQuery = false;
     wasLastSatCheckSatisfiable = false;
     final boolean isUnsat = isUnsatImpl();
@@ -393,6 +399,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   @Override
   public final ImmutableMap<String, String> getStatistics() throws InterruptedException {
     Preconditions.checkState(!closed);
+    shutdownIfNecessary();
     return getStatisticsImpl();
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -377,6 +377,19 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
       throws InterruptedException, SolverException;
 
   @Override
+  public final ImmutableMap<String, String> getStatistics() {
+    Preconditions.checkState(!closed);
+    return getStatisticsImpl();
+  }
+
+  /**
+   * @implSpec override and implement for solvers that provide statistics.
+   */
+  protected ImmutableMap<String, String> getStatisticsImpl() {
+    return ImmutableMap.of();
+  }
+
+  @Override
   public void close() {
     assertedFormulas.clear();
     closeAllEvaluators();

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -31,6 +31,7 @@ import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Evaluator;
 import org.sosy_lab.java_smt.api.InterpolatingProverEnvironment;
+import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.OptimizationProverEnvironment;
 import org.sosy_lab.java_smt.api.OptimizationProverEnvironment.OptStatus;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
@@ -285,6 +286,24 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
       }
     }
     return builder.buildOrThrow();
+  }
+
+  @Override
+  public final Model getModel() throws SolverException {
+    checkGenerateModels();
+    return getModelImpl();
+  }
+
+  public abstract Model getModelImpl() throws SolverException;
+
+  @Override
+  public final Evaluator getEvaluator() throws SolverException {
+    checkGenerateModels();
+    return getEvaluatorImpl();
+  }
+
+  public Evaluator getEvaluatorImpl() throws SolverException {
+    return getModel();
   }
 
   /**

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -369,9 +369,9 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     return allSatImpl(callback, important);
   }
 
-  // TODO: move AllSAT basic impl here?
   /**
-   * @implSpec only override and implement if a solver offers its own AllSAT procedure.
+   * @implSpec only override and implement if a solver offers its own AllSAT procedure, otherwise
+   *     inherit {@link AbstractProverWithAllSat} instead of this class.
    */
   protected abstract <R> R allSatImpl(AllSatCallback<R> callback, List<BooleanFormula> important)
       throws InterruptedException, SolverException;

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.java_smt.api.BasicProverEnvironment;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Evaluator;
@@ -54,6 +55,8 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
 
   private final Set<Evaluator> evaluators = new LinkedHashSet<>();
 
+  protected final ShutdownNotifier contextShutdownNotifier;
+
   /**
    * This data-structure tracks all formulas that were asserted on different levels. We can assert a
    * formula multiple times on the same or also distinct levels and return a new ID for each
@@ -63,7 +66,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
 
   private static final String TEMPLATE = "Please set the prover option %s.";
 
-  protected AbstractProver(Set<ProverOptions> pOptions) {
+  protected AbstractProver(Set<ProverOptions> pOptions, ShutdownNotifier pContextShutdownNotifier) {
     generateModels = pOptions.contains(ProverOptions.GENERATE_MODELS);
     generateAllSat = pOptions.contains(ProverOptions.GENERATE_ALL_SAT);
     generateUnsatCores = pOptions.contains(ProverOptions.GENERATE_UNSAT_CORE);
@@ -72,6 +75,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     enableSL = pOptions.contains(ProverOptions.ENABLE_SEPARATION_LOGIC);
 
     assertedFormulas.add(LinkedHashMultimap.create());
+    contextShutdownNotifier = pContextShutdownNotifier;
   }
 
   protected final void checkGenerateModels() {
@@ -115,9 +119,10 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     Preconditions.checkState(!closed);
   }
 
-  private void checkGenerateInterpolants() {
+  private void checkGenerateInterpolants() throws InterruptedException {
     // TODO: should this close all evaluators as well?
     Preconditions.checkState(!closed);
+    contextShutdownNotifier.shutdownIfNecessary();
     Preconditions.checkState(
         !changedSinceLastSatQuery,
         "Interpolants can only be calculated right after a call to isUnsat()");
@@ -127,7 +132,8 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
             + "unsatisfiable.");
   }
 
-  protected final void checkGenerateInterpolants(Collection<T> formulasOfA) {
+  protected final void checkGenerateInterpolants(Collection<T> formulasOfA)
+      throws InterruptedException {
     checkGenerateInterpolants();
     checkArgument(
         getAssertedConstraintIds().containsAll(formulasOfA),
@@ -135,7 +141,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   }
 
   protected final void checkGenerateSeqInterpolants(
-      List<? extends Collection<T>> partitionedFormulas) {
+      List<? extends Collection<T>> partitionedFormulas) throws InterruptedException {
     checkGenerateInterpolants();
     Preconditions.checkArgument(
         !partitionedFormulas.isEmpty(), "at least one partition should be available.");
@@ -146,7 +152,8 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   }
 
   protected final void checkGenerateTreeInterpolants(
-      List<? extends Collection<T>> partitionedFormulas, int[] startOfSubTree) {
+      List<? extends Collection<T>> partitionedFormulas, int[] startOfSubTree)
+      throws InterruptedException {
     checkGenerateSeqInterpolants(partitionedFormulas);
     assert InterpolatingProverEnvironment.checkTreeStructure(
         partitionedFormulas.size(), startOfSubTree);
@@ -186,8 +193,9 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   protected abstract void pushImpl() throws InterruptedException;
 
   @Override
-  public final void pop() {
+  public final void pop() throws InterruptedException {
     checkState(!closed);
+    contextShutdownNotifier.shutdownIfNecessary();
     checkState(assertedFormulas.size() > 1, "initial level must remain until close");
     assertedFormulas.remove(assertedFormulas.size() - 1); // remove last
     popImpl();
@@ -200,6 +208,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   @CanIgnoreReturnValue
   public final @Nullable T addConstraint(BooleanFormula constraint) throws InterruptedException {
     checkState(!closed);
+    contextShutdownNotifier.shutdownIfNecessary();
     T t = addConstraintImpl(constraint);
     setChanged();
     Iterables.getLast(assertedFormulas).put(constraint, t);
@@ -297,7 +306,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public final Model getModel() throws SolverException {
+  public final Model getModel() throws SolverException, InterruptedException {
     checkGenerateModels();
     return getModelImpl();
   }
@@ -305,12 +314,12 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   protected abstract Model getModelImpl() throws SolverException;
 
   @Override
-  public final Evaluator getEvaluator() throws SolverException {
+  public final Evaluator getEvaluator() throws SolverException, InterruptedException {
     checkGenerateModels();
     return getEvaluatorImpl();
   }
 
-  protected Evaluator getEvaluatorImpl() throws SolverException {
+  protected Evaluator getEvaluatorImpl() throws SolverException, InterruptedException {
     return getModel();
   }
 
@@ -333,7 +342,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public final List<BooleanFormula> getUnsatCore() {
+  public final List<BooleanFormula> getUnsatCore() throws InterruptedException {
     checkGenerateUnsatCores();
     return getUnsatCoreImpl();
   }
@@ -377,7 +386,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
       throws InterruptedException, SolverException;
 
   @Override
-  public final ImmutableMap<String, String> getStatistics() {
+  public final ImmutableMap<String, String> getStatistics() throws InterruptedException {
     Preconditions.checkState(!closed);
     return getStatisticsImpl();
   }

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProver.java
@@ -294,7 +294,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     return getModelImpl();
   }
 
-  public abstract Model getModelImpl() throws SolverException;
+  protected abstract Model getModelImpl() throws SolverException;
 
   @Override
   public final Evaluator getEvaluator() throws SolverException {
@@ -302,7 +302,7 @@ public abstract class AbstractProver<T> implements BasicProverEnvironment<T> {
     return getEvaluatorImpl();
   }
 
-  public Evaluator getEvaluatorImpl() throws SolverException {
+  protected Evaluator getEvaluatorImpl() throws SolverException {
     return getModel();
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProverWithAllSat.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProverWithAllSat.java
@@ -29,16 +29,14 @@ import org.sosy_lab.java_smt.api.SolverException;
  */
 public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
 
-  protected final ShutdownNotifier shutdownNotifier;
   private final BooleanFormulaManager bmgr;
 
   protected AbstractProverWithAllSat(
       Set<ProverOptions> pOptions,
       BooleanFormulaManager pBmgr,
       ShutdownNotifier pShutdownNotifier) {
-    super(pOptions);
+    super(pOptions, pShutdownNotifier);
     bmgr = pBmgr;
-    shutdownNotifier = pShutdownNotifier;
   }
 
   @Override
@@ -67,7 +65,7 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
       throws SolverException, InterruptedException {
     final Set<ImmutableList<BooleanFormula>> modelEvaluations = new LinkedHashSet<>();
     while (!isUnsat()) {
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
 
       ImmutableList.Builder<BooleanFormula> valuesOfModel = ImmutableList.builder();
       try (Evaluator evaluator = getEvaluatorWithoutChecks()) {
@@ -92,11 +90,11 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
           "The model evaluation %s was found before. ALLSAT computation did not make progress.",
           values);
       callback.apply(values);
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
 
       BooleanFormula negatedModel = bmgr.not(bmgr.and(values));
       addConstraint(negatedModel);
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
     }
   }
 
@@ -117,7 +115,7 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
       Deque<BooleanFormula> valuesOfModel)
       throws SolverException, InterruptedException {
 
-    shutdownNotifier.shutdownIfNecessary();
+    contextShutdownNotifier.shutdownIfNecessary();
 
     if (isUnsat()) {
       return;
@@ -138,6 +136,7 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
       valuesOfModel.pop();
 
       // negated predicate
+      contextShutdownNotifier.shutdownIfNecessary();
       final BooleanFormula notPredicate = bmgr.not(predicates.get(0));
       valuesOfModel.push(notPredicate);
       push(notPredicate);

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProverWithAllSat.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProverWithAllSat.java
@@ -42,10 +42,8 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
   }
 
   @Override
-  public <R> R allSat(AllSatCallback<R> callback, List<BooleanFormula> importantPredicates)
+  protected <R> R allSatImpl(AllSatCallback<R> callback, List<BooleanFormula> importantPredicates)
       throws InterruptedException, SolverException {
-    checkGenerateAllSat();
-
     push();
     try {
       // try model-based computation of ALLSAT

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProverWithAllSat.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProverWithAllSat.java
@@ -65,7 +65,7 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
       throws SolverException, InterruptedException {
     final Set<ImmutableList<BooleanFormula>> modelEvaluations = new LinkedHashSet<>();
     while (!isUnsat()) {
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
 
       ImmutableList.Builder<BooleanFormula> valuesOfModel = ImmutableList.builder();
       try (Evaluator evaluator = getEvaluatorWithoutChecks()) {
@@ -90,11 +90,11 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
           "The model evaluation %s was found before. ALLSAT computation did not make progress.",
           values);
       callback.apply(values);
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
 
       BooleanFormula negatedModel = bmgr.not(bmgr.and(values));
       addConstraint(negatedModel);
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
     }
   }
 
@@ -115,7 +115,7 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
       Deque<BooleanFormula> valuesOfModel)
       throws SolverException, InterruptedException {
 
-    contextShutdownNotifier.shutdownIfNecessary();
+    shutdownIfNecessary();
 
     if (isUnsat()) {
       return;
@@ -136,7 +136,7 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
       valuesOfModel.pop();
 
       // negated predicate
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
       final BooleanFormula notPredicate = bmgr.not(predicates.get(0));
       valuesOfModel.push(notPredicate);
       push(notPredicate);

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractProverWithAllSat.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractProverWithAllSat.java
@@ -34,8 +34,8 @@ public abstract class AbstractProverWithAllSat<T> extends AbstractProver<T> {
   protected AbstractProverWithAllSat(
       Set<ProverOptions> pOptions,
       BooleanFormulaManager pBmgr,
-      ShutdownNotifier pShutdownNotifier) {
-    super(pOptions, pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(pOptions, pContextShutdownNotifier);
     bmgr = pBmgr;
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/AbstractSolverContext.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/AbstractSolverContext.java
@@ -72,7 +72,7 @@ public abstract class AbstractSolverContext implements SolverContext {
   @Override
   public final OptimizationProverEnvironment newOptimizationProverEnvironment(
       ProverOptions... options) {
-    return newOptimizationProverEnvironment0(toSet(options));
+    return new OptimizationProverDelegate(newOptimizationProverEnvironment0(toSet(options)));
   }
 
   protected abstract OptimizationProverEnvironment newOptimizationProverEnvironment0(

--- a/src/org/sosy_lab/java_smt/basicimpl/InterpolatingProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/InterpolatingProverDelegate.java
@@ -10,6 +10,7 @@
 
 package org.sosy_lab.java_smt.basicimpl;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
@@ -31,6 +32,7 @@ class InterpolatingProverDelegate<T> implements InterpolatingProverEnvironment<T
   private final InterpolatingProverEnvironment<T> itpProver;
 
   InterpolatingProverDelegate(InterpolatingProverEnvironment<T> pBaseProver) {
+    checkArgument(pBaseProver instanceof AbstractProver<?>);
     itpProver = checkNotNull(pBaseProver);
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/InterpolatingProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/InterpolatingProverDelegate.java
@@ -12,6 +12,7 @@ package org.sosy_lab.java_smt.basicimpl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -67,7 +68,7 @@ class InterpolatingProverDelegate<T> implements InterpolatingProverEnvironment<T
   /* ########################## Delegate methods of ProverEnvironment ########################## */
 
   @Override
-  public void pop() {
+  public void pop() throws InterruptedException {
     itpProver.pop();
   }
 
@@ -98,12 +99,12 @@ class InterpolatingProverDelegate<T> implements InterpolatingProverEnvironment<T
   }
 
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModel() throws SolverException, InterruptedException {
     return itpProver.getModel();
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
+  public List<BooleanFormula> getUnsatCore() throws InterruptedException {
     return itpProver.getUnsatCore();
   }
 
@@ -111,6 +112,11 @@ class InterpolatingProverDelegate<T> implements InterpolatingProverEnvironment<T
   public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
       Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException {
     return itpProver.unsatCoreOverAssumptions(assumptions);
+  }
+
+  @Override
+  public ImmutableMap<String, String> getStatistics() throws InterruptedException {
+    return itpProver.getStatistics();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
@@ -39,29 +39,33 @@ public class OptimizationProverDelegate implements OptimizationProverEnvironment
 
   @SuppressWarnings("resource")
   @Override
-  public int maximize(Formula objective) {
+  public int maximize(Formula objective) throws InterruptedException {
     getDelegateAsAbstractProver().checkClosed();
+    getDelegateAsAbstractProver().shutdownIfNecessary();
     return optimizationProver.maximize(objective);
   }
 
   @SuppressWarnings("resource")
   @Override
-  public int minimize(Formula objective) {
+  public int minimize(Formula objective) throws InterruptedException {
     getDelegateAsAbstractProver().checkClosed();
+    getDelegateAsAbstractProver().shutdownIfNecessary();
     return optimizationProver.minimize(objective);
   }
 
   @SuppressWarnings("resource")
   @Override
-  public Optional<Rational> upper(int handle, Rational epsilon) {
+  public Optional<Rational> upper(int handle, Rational epsilon) throws InterruptedException {
     getDelegateAsAbstractProver().checkGenerateModels();
+    getDelegateAsAbstractProver().shutdownIfNecessary();
     return optimizationProver.upper(handle, epsilon);
   }
 
   @SuppressWarnings("resource")
   @Override
-  public Optional<Rational> lower(int handle, Rational epsilon) {
+  public Optional<Rational> lower(int handle, Rational epsilon) throws InterruptedException {
     getDelegateAsAbstractProver().checkGenerateModels();
+    getDelegateAsAbstractProver().shutdownIfNecessary();
     return optimizationProver.lower(handle, epsilon);
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of JavaSMT,
+ * an API wrapper for a collection of SMT solvers:
+ * https://github.com/sosy-lab/java-smt
+ *
+ * SPDX-FileCopyrightText: 2026 Dirk Beyer <https://www.sosy-lab.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.sosy_lab.java_smt.basicimpl;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.sosy_lab.common.rationals.Rational;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.Formula;
+import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.java_smt.api.OptimizationProverEnvironment;
+import org.sosy_lab.java_smt.api.SolverException;
+
+/**
+ * This delegate enables common implementations for methods in {@link OptimizationProverEnvironment}
+ * based on the implementations in the abstract/theorem prover that can not be done using abstract
+ * implementations.
+ */
+public class OptimizationProverDelegate implements OptimizationProverEnvironment {
+
+  private final OptimizationProverEnvironment optimizationProver;
+
+  OptimizationProverDelegate(OptimizationProverEnvironment pBaseProver) {
+    optimizationProver = checkNotNull(pBaseProver);
+  }
+
+  @SuppressWarnings("resource")
+  @Override
+  public int maximize(Formula objective) {
+    getDelegateAsAbstractProver().checkClosed();
+    return optimizationProver.maximize(objective);
+  }
+
+  @SuppressWarnings("resource")
+  @Override
+  public int minimize(Formula objective) {
+    getDelegateAsAbstractProver().checkClosed();
+    return optimizationProver.minimize(objective);
+  }
+
+  @SuppressWarnings("resource")
+  @Override
+  public Optional<Rational> upper(int handle, Rational epsilon) {
+    getDelegateAsAbstractProver().checkGenerateModels();
+    return optimizationProver.upper(handle, epsilon);
+  }
+
+  @SuppressWarnings("resource")
+  @Override
+  public Optional<Rational> lower(int handle, Rational epsilon) {
+    getDelegateAsAbstractProver().checkGenerateModels();
+    return optimizationProver.lower(handle, epsilon);
+  }
+
+  @Override
+  public OptStatus check() throws InterruptedException, SolverException {
+    // We don't need to do anything for check, as it is already handled in AbstractProver
+    return optimizationProver.check();
+  }
+
+  /* ########################## Delegate methods of ProverEnvironment ########################## */
+
+  @SuppressWarnings("resource")
+  @Override
+  public Model getModel() throws SolverException {
+    // getModel does not use a implementation/delegate and needs to be checked here!
+    getDelegateAsAbstractProver().checkGenerateModels();
+    return optimizationProver.getModel();
+  }
+
+  @Override
+  public void pop() {
+    optimizationProver.pop();
+  }
+
+  @Override
+  public @Nullable Void addConstraint(BooleanFormula constraint) throws InterruptedException {
+    return optimizationProver.addConstraint(constraint);
+  }
+
+  @Override
+  public void push() throws InterruptedException {
+    optimizationProver.push();
+  }
+
+  @Override
+  public int size() {
+    return optimizationProver.size();
+  }
+
+  @Override
+  public boolean isUnsat() throws SolverException, InterruptedException {
+    return optimizationProver.isUnsat();
+  }
+
+  @Override
+  public boolean isUnsatWithAssumptions(Collection<BooleanFormula> assumptions)
+      throws SolverException, InterruptedException {
+    return optimizationProver.isUnsatWithAssumptions(assumptions);
+  }
+
+  @Override
+  public List<BooleanFormula> getUnsatCore() {
+    return optimizationProver.getUnsatCore();
+  }
+
+  @Override
+  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
+      Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException {
+    return optimizationProver.unsatCoreOverAssumptions(assumptions);
+  }
+
+  @Override
+  public void close() {
+    optimizationProver.close();
+  }
+
+  @Override
+  public <R> R allSat(AllSatCallback<R> callback, List<BooleanFormula> important)
+      throws InterruptedException, SolverException {
+    return optimizationProver.allSat(callback, important);
+  }
+
+  /* ############################### Utility methods ############################### */
+  @SuppressWarnings("unchecked")
+  private AbstractProver<?> getDelegateAsAbstractProver() {
+    return (AbstractProver<?>) optimizationProver;
+  }
+}

--- a/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
@@ -75,8 +75,6 @@ public class OptimizationProverDelegate implements OptimizationProverEnvironment
   @SuppressWarnings("resource")
   @Override
   public Model getModel() throws SolverException {
-    // getModel does not use a implementation/delegate and needs to be checked here!
-    getDelegateAsAbstractProver().checkGenerateModels();
     return optimizationProver.getModel();
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
@@ -12,6 +12,7 @@ package org.sosy_lab.java_smt.basicimpl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -74,12 +75,13 @@ public class OptimizationProverDelegate implements OptimizationProverEnvironment
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModel() throws SolverException, InterruptedException {
+    // TODO: add checks here?
     return optimizationProver.getModel();
   }
 
   @Override
-  public void pop() {
+  public void pop() throws InterruptedException {
     optimizationProver.pop();
   }
 
@@ -110,7 +112,7 @@ public class OptimizationProverDelegate implements OptimizationProverEnvironment
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
+  public List<BooleanFormula> getUnsatCore() throws InterruptedException {
     return optimizationProver.getUnsatCore();
   }
 
@@ -118,6 +120,11 @@ public class OptimizationProverDelegate implements OptimizationProverEnvironment
   public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
       Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException {
     return optimizationProver.unsatCoreOverAssumptions(assumptions);
+  }
+
+  @Override
+  public ImmutableMap<String, String> getStatistics() throws InterruptedException {
+    return optimizationProver.getStatistics();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/OptimizationProverDelegate.java
@@ -10,6 +10,7 @@
 
 package org.sosy_lab.java_smt.basicimpl;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
@@ -33,6 +34,7 @@ public class OptimizationProverDelegate implements OptimizationProverEnvironment
   private final OptimizationProverEnvironment optimizationProver;
 
   OptimizationProverDelegate(OptimizationProverEnvironment pBaseProver) {
+    checkArgument(pBaseProver instanceof AbstractProver<?>);
     optimizationProver = checkNotNull(pBaseProver);
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/PackageSanityTest.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/PackageSanityTest.java
@@ -18,6 +18,9 @@ public class PackageSanityTest extends AbstractPackageSanityTests {
   {
     setDistinctValues(FormulaType.class, FormulaType.BooleanType, FormulaType.IntegerType);
     setDefault(ShutdownNotifier.class, ShutdownManager.create().getNotifier());
-    ignoreClasses(c -> c.equals(InterpolatingProverDelegate.class));
+    ignoreClasses(
+        c ->
+            c.equals(InterpolatingProverDelegate.class)
+                || c.equals(OptimizationProverDelegate.class));
   }
 }

--- a/src/org/sosy_lab/java_smt/basicimpl/withAssumptionsWrapper/BasicProverWithAssumptionsWrapper.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/withAssumptionsWrapper/BasicProverWithAssumptionsWrapper.java
@@ -29,7 +29,7 @@ class BasicProverWithAssumptionsWrapper<T, P extends BasicProverEnvironment<T>>
     delegate = pDelegate;
   }
 
-  protected void clearAssumptions() {
+  protected void clearAssumptions() throws InterruptedException {
     for (int i = 0; i < solverAssumptionsAsFormula.size(); i++) {
       delegate.pop();
     }
@@ -37,7 +37,7 @@ class BasicProverWithAssumptionsWrapper<T, P extends BasicProverEnvironment<T>>
   }
 
   @Override
-  public void pop() {
+  public void pop() throws InterruptedException {
     clearAssumptions();
     delegate.pop();
   }
@@ -82,17 +82,18 @@ class BasicProverWithAssumptionsWrapper<T, P extends BasicProverEnvironment<T>>
   protected void registerPushedFormula(@SuppressWarnings("unused") T pPushResult) {}
 
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModel() throws SolverException, InterruptedException {
     return delegate.getModel();
   }
 
   @Override
-  public ImmutableList<Model.ValueAssignment> getModelAssignments() throws SolverException {
+  public ImmutableList<Model.ValueAssignment> getModelAssignments()
+      throws SolverException, InterruptedException {
     return delegate.getModelAssignments();
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
+  public List<BooleanFormula> getUnsatCore() throws InterruptedException {
     return delegate.getUnsatCore();
   }
 
@@ -110,7 +111,7 @@ class BasicProverWithAssumptionsWrapper<T, P extends BasicProverEnvironment<T>>
   }
 
   @Override
-  public ImmutableMap<String, String> getStatistics() {
+  public ImmutableMap<String, String> getStatistics() throws InterruptedException {
     return delegate.getStatistics();
   }
 

--- a/src/org/sosy_lab/java_smt/basicimpl/withAssumptionsWrapper/InterpolatingProverWithAssumptionsWrapper.java
+++ b/src/org/sosy_lab/java_smt/basicimpl/withAssumptionsWrapper/InterpolatingProverWithAssumptionsWrapper.java
@@ -81,7 +81,7 @@ public class InterpolatingProverWithAssumptionsWrapper<T>
   }
 
   @Override
-  protected void clearAssumptions() {
+  protected void clearAssumptions() throws InterruptedException {
     super.clearAssumptions();
     solverAssumptionsFromPush.clear();
   }

--- a/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingBasicProverEnvironment.java
@@ -10,6 +10,7 @@ package org.sosy_lab.java_smt.delegate.debugging;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -30,7 +31,7 @@ class DebuggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public void pop() {
+  public void pop() throws InterruptedException {
     debugging.assertThreadLocal();
     delegate.pop();
   }
@@ -72,13 +73,13 @@ class DebuggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModel() throws SolverException, InterruptedException {
     debugging.assertThreadLocal();
     return new DebuggingModel(delegate.getModel(), debugging);
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
+  public List<BooleanFormula> getUnsatCore() throws InterruptedException {
     debugging.assertThreadLocal();
     return delegate.getUnsatCore();
   }
@@ -107,5 +108,10 @@ class DebuggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
       debugging.assertFormulaInContext(f);
     }
     return delegate.allSat(callback, important);
+  }
+
+  @Override
+  public ImmutableMap<String, String> getStatistics() throws InterruptedException {
+    return delegate.getStatistics();
   }
 }

--- a/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingOptimizationProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/debugging/DebuggingOptimizationProverEnvironment.java
@@ -27,14 +27,14 @@ class DebuggingOptimizationProverEnvironment extends DebuggingBasicProverEnviron
   }
 
   @Override
-  public int maximize(Formula objective) {
+  public int maximize(Formula objective) throws InterruptedException {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(objective);
     return delegate.maximize(objective);
   }
 
   @Override
-  public int minimize(Formula objective) {
+  public int minimize(Formula objective) throws InterruptedException {
     debugging.assertThreadLocal();
     debugging.assertFormulaInContext(objective);
     return delegate.maximize(objective);
@@ -47,13 +47,13 @@ class DebuggingOptimizationProverEnvironment extends DebuggingBasicProverEnviron
   }
 
   @Override
-  public Optional<Rational> upper(int handle, Rational epsilon) {
+  public Optional<Rational> upper(int handle, Rational epsilon) throws InterruptedException {
     debugging.assertThreadLocal();
     return delegate.upper(handle, epsilon);
   }
 
   @Override
-  public Optional<Rational> lower(int handle, Rational epsilon) {
+  public Optional<Rational> lower(int handle, Rational epsilon) throws InterruptedException {
     debugging.assertThreadLocal();
     return delegate.lower(handle, epsilon);
   }

--- a/src/org/sosy_lab/java_smt/delegate/logging/LoggingBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/logging/LoggingBasicProverEnvironment.java
@@ -46,7 +46,7 @@ class LoggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public void pop() {
+  public void pop() throws InterruptedException {
     logger.log(Level.FINER, "down to level " + level--);
     wrapped.pop();
   }
@@ -87,21 +87,22 @@ class LoggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModel() throws SolverException, InterruptedException {
     Model m = wrapped.getModel();
     logger.log(Level.FINE, "model", m);
     return m;
   }
 
   @Override
-  public ImmutableList<ValueAssignment> getModelAssignments() throws SolverException {
+  public ImmutableList<ValueAssignment> getModelAssignments()
+      throws SolverException, InterruptedException {
     ImmutableList<ValueAssignment> m = wrapped.getModelAssignments();
     logger.log(Level.FINE, "model", m);
     return m;
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
+  public List<BooleanFormula> getUnsatCore() throws InterruptedException {
     List<BooleanFormula> unsatCore = wrapped.getUnsatCore();
     logger.log(Level.FINE, "unsat-core", unsatCore);
     return unsatCore;
@@ -116,7 +117,7 @@ class LoggingBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public ImmutableMap<String, String> getStatistics() {
+  public ImmutableMap<String, String> getStatistics() throws InterruptedException {
     return wrapped.getStatistics();
   }
 

--- a/src/org/sosy_lab/java_smt/delegate/logging/LoggingOptimizationProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/logging/LoggingOptimizationProverEnvironment.java
@@ -30,13 +30,13 @@ class LoggingOptimizationProverEnvironment extends LoggingBasicProverEnvironment
   }
 
   @Override
-  public int maximize(Formula objective) {
+  public int maximize(Formula objective) throws InterruptedException {
     logger.log(Level.FINE, "Maximizing:", objective);
     return wrapped.maximize(objective);
   }
 
   @Override
-  public int minimize(Formula objective) {
+  public int minimize(Formula objective) throws InterruptedException {
     logger.log(Level.FINE, "Minimizing:", objective);
     return wrapped.minimize(objective);
   }
@@ -49,12 +49,12 @@ class LoggingOptimizationProverEnvironment extends LoggingBasicProverEnvironment
   }
 
   @Override
-  public Optional<Rational> upper(int handle, Rational epsilon) {
+  public Optional<Rational> upper(int handle, Rational epsilon) throws InterruptedException {
     return wrapped.upper(handle, epsilon);
   }
 
   @Override
-  public Optional<Rational> lower(int handle, Rational epsilon) {
+  public Optional<Rational> lower(int handle, Rational epsilon) throws InterruptedException {
     return wrapped.lower(handle, epsilon);
   }
 }

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsBasicProverEnvironment.java
@@ -10,6 +10,7 @@ package org.sosy_lab.java_smt.delegate.statistics;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -36,7 +37,7 @@ class StatisticsBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public void pop() {
+  public void pop() throws InterruptedException {
     stats.pop.getAndIncrement();
     delegate.pop();
   }
@@ -81,13 +82,13 @@ class StatisticsBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModel() throws SolverException, InterruptedException {
     stats.model.getAndIncrement();
     return new StatisticsModel(delegate.getModel(), stats);
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
+  public List<BooleanFormula> getUnsatCore() throws InterruptedException {
     stats.unsatCore.getAndIncrement();
     return delegate.getUnsatCore();
   }
@@ -97,6 +98,11 @@ class StatisticsBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
       Collection<BooleanFormula> pAssumptions) throws SolverException, InterruptedException {
     stats.unsatCore.getAndIncrement();
     return delegate.unsatCoreOverAssumptions(pAssumptions);
+  }
+
+  @Override
+  public ImmutableMap<String, String> getStatistics() throws InterruptedException {
+    return delegate.getStatistics();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsOptimizationProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/statistics/StatisticsOptimizationProverEnvironment.java
@@ -26,12 +26,12 @@ class StatisticsOptimizationProverEnvironment extends StatisticsBasicProverEnvir
   }
 
   @Override
-  public int maximize(Formula pObjective) {
+  public int maximize(Formula pObjective) throws InterruptedException {
     return delegate.maximize(pObjective);
   }
 
   @Override
-  public int minimize(Formula pObjective) {
+  public int minimize(Formula pObjective) throws InterruptedException {
     return delegate.minimize(pObjective);
   }
 
@@ -46,12 +46,12 @@ class StatisticsOptimizationProverEnvironment extends StatisticsBasicProverEnvir
   }
 
   @Override
-  public Optional<Rational> upper(int pHandle, Rational pEpsilon) {
+  public Optional<Rational> upper(int pHandle, Rational pEpsilon) throws InterruptedException {
     return delegate.upper(pHandle, pEpsilon);
   }
 
   @Override
-  public Optional<Rational> lower(int pHandle, Rational pEpsilon) {
+  public Optional<Rational> lower(int pHandle, Rational pEpsilon) throws InterruptedException {
     return delegate.lower(pHandle, pEpsilon);
   }
 }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironment.java
@@ -32,7 +32,7 @@ class SynchronizedBasicProverEnvironment<T> implements BasicProverEnvironment<T>
   }
 
   @Override
-  public void pop() {
+  public void pop() throws InterruptedException {
     synchronized (sync) {
       delegate.pop();
     }
@@ -76,14 +76,14 @@ class SynchronizedBasicProverEnvironment<T> implements BasicProverEnvironment<T>
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModel() throws SolverException, InterruptedException {
     synchronized (sync) {
       return new SynchronizedModel(delegate.getModel(), sync);
     }
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
+  public List<BooleanFormula> getUnsatCore() throws InterruptedException {
     synchronized (sync) {
       return delegate.getUnsatCore();
     }
@@ -98,7 +98,7 @@ class SynchronizedBasicProverEnvironment<T> implements BasicProverEnvironment<T>
   }
 
   @Override
-  public ImmutableMap<String, String> getStatistics() {
+  public ImmutableMap<String, String> getStatistics() throws InterruptedException {
     synchronized (sync) {
       return delegate.getStatistics();
     }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironmentWithContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedBasicProverEnvironmentWithContext.java
@@ -53,7 +53,7 @@ class SynchronizedBasicProverEnvironmentWithContext<T> implements BasicProverEnv
   }
 
   @Override
-  public void pop() {
+  public void pop() throws InterruptedException {
     delegate.pop();
   }
 
@@ -91,14 +91,14 @@ class SynchronizedBasicProverEnvironmentWithContext<T> implements BasicProverEnv
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModel() throws SolverException, InterruptedException {
     synchronized (sync) {
       return new SynchronizedModelWithContext(delegate.getModel(), sync, manager, otherManager);
     }
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
+  public List<BooleanFormula> getUnsatCore() throws InterruptedException {
     return translate(delegate.getUnsatCore(), otherManager, manager);
   }
 
@@ -115,7 +115,7 @@ class SynchronizedBasicProverEnvironmentWithContext<T> implements BasicProverEnv
   }
 
   @Override
-  public ImmutableMap<String, String> getStatistics() {
+  public ImmutableMap<String, String> getStatistics() throws InterruptedException {
     synchronized (sync) {
       return delegate.getStatistics();
     }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedOptimizationProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedOptimizationProverEnvironment.java
@@ -27,14 +27,14 @@ class SynchronizedOptimizationProverEnvironment extends SynchronizedBasicProverE
   }
 
   @Override
-  public int maximize(Formula pObjective) {
+  public int maximize(Formula pObjective) throws InterruptedException {
     synchronized (sync) {
       return delegate.maximize(pObjective);
     }
   }
 
   @Override
-  public int minimize(Formula pObjective) {
+  public int minimize(Formula pObjective) throws InterruptedException {
     synchronized (sync) {
       return delegate.minimize(pObjective);
     }
@@ -48,14 +48,14 @@ class SynchronizedOptimizationProverEnvironment extends SynchronizedBasicProverE
   }
 
   @Override
-  public Optional<Rational> upper(int pHandle, Rational pEpsilon) {
+  public Optional<Rational> upper(int pHandle, Rational pEpsilon) throws InterruptedException {
     synchronized (sync) {
       return delegate.upper(pHandle, pEpsilon);
     }
   }
 
   @Override
-  public Optional<Rational> lower(int pHandle, Rational pEpsilon) {
+  public Optional<Rational> lower(int pHandle, Rational pEpsilon) throws InterruptedException {
     synchronized (sync) {
       return delegate.lower(pHandle, pEpsilon);
     }

--- a/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedSolverContext.java
+++ b/src/org/sosy_lab/java_smt/delegate/synchronize/SynchronizedSolverContext.java
@@ -40,12 +40,12 @@ public class SynchronizedSolverContext implements SolverContext {
   private final SolverContext sync;
   private final Configuration config;
   private final LogManager logger;
-  private final ShutdownNotifier shutdownNotifier;
+  private final ShutdownNotifier contextShutdownNotifier;
 
   public SynchronizedSolverContext(
       Configuration pConfig,
       LogManager pLogger,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       SolverContext pDelegate)
       throws InvalidConfigurationException {
     pConfig.inject(this, SynchronizedSolverContext.class);
@@ -53,7 +53,7 @@ public class SynchronizedSolverContext implements SolverContext {
     sync = delegate;
     config = pConfig;
     logger = pLogger;
-    shutdownNotifier = pShutdownNotifier;
+    contextShutdownNotifier = pContextShutdownNotifier;
   }
 
   @SuppressWarnings("resource")
@@ -62,7 +62,7 @@ public class SynchronizedSolverContext implements SolverContext {
     try {
       otherContext =
           SolverContextFactory.createSolverContext(
-              config, logger, shutdownNotifier, delegate.getSolverName());
+              config, logger, contextShutdownNotifier, delegate.getSolverName());
     } catch (InvalidConfigurationException e) {
       throw new AssertionError("should not happen, current context was already created before.");
     }

--- a/src/org/sosy_lab/java_smt/delegate/trace/TraceBasicProverEnvironment.java
+++ b/src/org/sosy_lab/java_smt/delegate/trace/TraceBasicProverEnvironment.java
@@ -10,6 +10,7 @@
 
 package org.sosy_lab.java_smt.delegate.trace;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +36,7 @@ class TraceBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public void pop() {
+  public void pop() throws InterruptedException {
     logger.logStmt(logger.toVariable(this), "pop()", delegate::pop);
   }
 
@@ -73,7 +74,7 @@ class TraceBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModel() throws SolverException, InterruptedException {
     return logger.logDefKeep(
         logger.toVariable(this),
         "getModel()",
@@ -81,7 +82,7 @@ class TraceBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
+  public List<BooleanFormula> getUnsatCore() throws InterruptedException {
     return mgr.rebuildAll(
         logger.logDefDiscard(logger.toVariable(this), "getUnsatCore()", delegate::getUnsatCore));
   }
@@ -96,6 +97,12 @@ class TraceBasicProverEnvironment<T> implements BasicProverEnvironment<T> {
                 .formatted(logger.toVariables(assumptions)),
             () -> delegate.unsatCoreOverAssumptions(assumptions))
         .map(mgr::rebuildAll);
+  }
+
+  @Override
+  public ImmutableMap<String, String> getStatistics() throws InterruptedException {
+    return logger.logDefDiscard(
+        logger.toVariable(this), "getStatistics()", delegate::getStatistics);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -8,7 +8,6 @@
 
 package org.sosy_lab.java_smt.solvers.bitwuzla;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -194,11 +193,8 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
    *     assumptions which is unsatisfiable with the original constraints otherwise.
    */
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
       Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException {
-    Preconditions.checkNotNull(assumptions);
-    checkGenerateUnsatCoresOverAssumptions();
-
     changedSinceLastSatQuery = true;
 
     Collection<Term> newAssumptions = new LinkedHashSet<>();

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -55,10 +55,10 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
   BitwuzlaAbstractProver(
       BitwuzlaFormulaManager pManager,
       BitwuzlaFormulaCreator pCreator,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Set<ProverOptions> pOptions,
       Options pSolverOptions) {
-    super(pOptions, pManager.getBooleanFormulaManager(), pShutdownNotifier);
+    super(pOptions, pManager.getBooleanFormulaManager(), pContextShutdownNotifier);
     creator = pCreator;
 
     // Bitwuzla guarantees that Terms and Sorts are shared

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -41,8 +41,7 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
       new Terminator() {
         @Override
         public boolean terminate() {
-          return contextShutdownNotifier
-              .shouldShutdown(); // shutdownNotifer is defined in the superclass
+          return shouldShutdown();
         }
       };
   private static final UniqueIdGenerator ID_GENERATOR = new UniqueIdGenerator();

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -41,7 +41,8 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
       new Terminator() {
         @Override
         public boolean terminate() {
-          return shutdownNotifier.shouldShutdown(); // shutdownNotifer is defined in the superclass
+          return contextShutdownNotifier
+              .shouldShutdown(); // shutdownNotifer is defined in the superclass
         }
       };
   private static final UniqueIdGenerator ID_GENERATOR = new UniqueIdGenerator();
@@ -130,7 +131,7 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
       return false;
     } else if (resultValue == Result.UNSAT) {
       return true;
-    } else if (resultValue == Result.UNKNOWN && shutdownNotifier.shouldShutdown()) {
+    } else if (resultValue == Result.UNKNOWN && contextShutdownNotifier.shouldShutdown()) {
       throw new InterruptedException();
     } else {
       throw new SolverException("Bitwuzla returned UNKNOWN.");

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -165,8 +165,7 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
    */
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     // special case for Bitwuzla: Models are not permanent and need to be closed
     // before any change is applied to the prover stack. So, we register the Model as Evaluator.
     return registerEvaluator(

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -181,8 +181,7 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
    * returned <code>false</code>.
    */
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    checkGenerateUnsatCores();
+  public List<BooleanFormula> getUnsatCoreImpl() {
     return Lists.transform(env.get_unsat_core(), creator::encapsulateBoolean);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -131,7 +131,7 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
       return false;
     } else if (resultValue == Result.UNSAT) {
       return true;
-    } else if (resultValue == Result.UNKNOWN && contextShutdownNotifier.shouldShutdown()) {
+    } else if (resultValue == Result.UNKNOWN && shouldShutdown()) {
       throw new InterruptedException();
     } else {
       throw new SolverException("Bitwuzla returned UNKNOWN.");

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -165,7 +165,7 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
    */
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     // special case for Bitwuzla: Models are not permanent and need to be closed
     // before any change is applied to the prover stack. So, we register the Model as Evaluator.
     return registerEvaluator(

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -164,7 +164,7 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
    */
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     // special case for Bitwuzla: Models are not permanent and need to be closed
     // before any change is applied to the prover stack. So, we register the Model as Evaluator.
     return registerEvaluator(

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
@@ -34,10 +34,15 @@ class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
   BitwuzlaInterpolatingProver(
       BitwuzlaFormulaManager pManager,
       BitwuzlaFormulaCreator pCreator,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Set<ProverOptions> pOptions,
       Options pSolverOptions) {
-    super(pManager, pCreator, pShutdownNotifier, pOptions, enableInterpolation(pSolverOptions));
+    super(
+        pManager,
+        pCreator,
+        pContextShutdownNotifier,
+        pOptions,
+        enableInterpolation(pSolverOptions));
   }
 
   private static Options enableInterpolation(Options pSolverOptions) {

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaSolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaSolverContext.java
@@ -82,7 +82,7 @@ public final class BitwuzlaSolverContext extends AbstractSolverContext {
 
   private final BitwuzlaFormulaManager manager;
   private final BitwuzlaFormulaCreator creator;
-  private final ShutdownNotifier shutdownNotifier;
+  private final ShutdownNotifier contextShutdownNotifier;
 
   private final Options solverOptions;
 
@@ -94,19 +94,19 @@ public final class BitwuzlaSolverContext extends AbstractSolverContext {
   BitwuzlaSolverContext(
       BitwuzlaFormulaManager pManager,
       BitwuzlaFormulaCreator pCreator,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Options pOptions) {
     super(pManager);
     manager = pManager;
     creator = pCreator;
-    shutdownNotifier = pShutdownNotifier;
+    contextShutdownNotifier = pContextShutdownNotifier;
     solverOptions = pOptions;
   }
 
   @SuppressWarnings("unused")
   public static BitwuzlaSolverContext create(
       Configuration config,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       @Nullable PathCounterTemplate solverLogfile,
       long randomSeed,
       FloatingPointRoundingMode pFloatingPointRoundingMode,
@@ -144,7 +144,7 @@ public final class BitwuzlaSolverContext extends AbstractSolverContext {
             arrayTheory,
             solverOptions);
 
-    return new BitwuzlaSolverContext(manager, creator, pShutdownNotifier, solverOptions);
+    return new BitwuzlaSolverContext(manager, creator, pContextShutdownNotifier, solverOptions);
   }
 
   @VisibleForTesting
@@ -271,14 +271,16 @@ public final class BitwuzlaSolverContext extends AbstractSolverContext {
   @Override
   protected ProverEnvironment newProverEnvironment0(Set<ProverOptions> options) {
     Preconditions.checkState(!closed, "solver context is already closed");
-    return new BitwuzlaTheoremProver(manager, creator, shutdownNotifier, options, solverOptions);
+    return new BitwuzlaTheoremProver(
+        manager, creator, contextShutdownNotifier, options, solverOptions);
   }
 
   @Override
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> pF) {
     Preconditions.checkState(!closed, "solver context is already closed");
-    return new BitwuzlaInterpolatingProver(manager, creator, shutdownNotifier, pF, solverOptions);
+    return new BitwuzlaInterpolatingProver(
+        manager, creator, contextShutdownNotifier, pF, solverOptions);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaTheoremProver.java
@@ -23,10 +23,10 @@ class BitwuzlaTheoremProver extends BitwuzlaAbstractProver<Void> implements Prov
   BitwuzlaTheoremProver(
       BitwuzlaFormulaManager pManager,
       BitwuzlaFormulaCreator pCreator,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Set<ProverOptions> pOptions,
       Options pSolverOptions) {
-    super(pManager, pCreator, pShutdownNotifier, pOptions, pSolverOptions);
+    super(pManager, pCreator, pContextShutdownNotifier, pOptions, pSolverOptions);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorSolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorSolverContext.java
@@ -62,23 +62,23 @@ public final class BoolectorSolverContext extends AbstractSolverContext {
 
   private final BoolectorFormulaManager manager;
   private final BoolectorFormulaCreator creator;
-  private final ShutdownNotifier shutdownNotifier;
+  private final ShutdownNotifier contextShutdownNotifier;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final AtomicBoolean isAnyStackAlive = new AtomicBoolean(false);
 
   BoolectorSolverContext(
       BoolectorFormulaManager pManager,
       BoolectorFormulaCreator pCreator,
-      ShutdownNotifier pShutdownNotifier) {
+      ShutdownNotifier pContextShutdownNotifier) {
     super(pManager);
     manager = pManager;
     creator = pCreator;
-    shutdownNotifier = pShutdownNotifier;
+    contextShutdownNotifier = pContextShutdownNotifier;
   }
 
   public static BoolectorSolverContext create(
       Configuration config,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       @Nullable PathCounterTemplate solverLogfile,
       long randomSeed,
       Consumer<String> pLoader)
@@ -98,7 +98,7 @@ public final class BoolectorSolverContext extends AbstractSolverContext {
     BoolectorFormulaManager manager =
         new BoolectorFormulaManager(
             creator, functionTheory, booleanTheory, bitvectorTheory, arrayTheory);
-    return new BoolectorSolverContext(manager, creator, pShutdownNotifier);
+    return new BoolectorSolverContext(manager, creator, pContextShutdownNotifier);
   }
 
   @Override
@@ -198,7 +198,7 @@ public final class BoolectorSolverContext extends AbstractSolverContext {
   protected ProverEnvironment newProverEnvironment0(Set<ProverOptions> pOptions) {
     Preconditions.checkState(!closed.get(), "solver context is already closed");
     return new BoolectorTheoremProver(
-        manager, creator, creator.getEnv(), shutdownNotifier, pOptions, isAnyStackAlive);
+        manager, creator, creator.getEnv(), contextShutdownNotifier, pOptions, isAnyStackAlive);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
@@ -127,8 +127,7 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
   }
 
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
@@ -143,11 +143,6 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    throw new UnsupportedOperationException(UNSAT_CORE_NOT_SUPPORTED);
-  }
-
-  @Override
   public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
       Collection<BooleanFormula> pAssumptions) throws SolverException, InterruptedException {
     throw new UnsupportedOperationException(UNSAT_CORE_WITH_ASSUMPTIONS_NOT_SUPPORTED);

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
@@ -48,7 +48,7 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
     this.manager = manager;
     this.creator = creator;
     this.btor = btor;
-    terminationCallback = shutdownNotifier::shouldShutdown;
+    terminationCallback = pShutdownNotifier::shouldShutdown;
     terminationCallbackHelper = addTerminationCallback();
 
     isAnyStackAlive = pIsAnyStackAlive;

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
@@ -23,7 +23,6 @@ import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractProverWithAllSat;
-import org.sosy_lab.java_smt.solvers.boolector.BtorJNI.TerminationCallback;
 
 class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements ProverEnvironment {
 
@@ -33,7 +32,6 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
   private final long btor;
   private final BoolectorFormulaManager manager;
   private final BoolectorFormulaCreator creator;
-  private final TerminationCallback terminationCallback;
   private final long terminationCallbackHelper;
 
   // Used/Built by TheoremProver
@@ -48,7 +46,6 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
     this.manager = manager;
     this.creator = creator;
     this.btor = btor;
-    terminationCallback = pContextShutdownNotifier::shouldShutdown;
     terminationCallbackHelper = addTerminationCallback();
 
     isAnyStackAlive = pIsAnyStackAlive;
@@ -167,6 +164,6 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
 
   private long addTerminationCallback() {
     Preconditions.checkState(!closed, "solver context is already closed");
-    return BtorJNI.boolector_set_termination(btor, terminationCallback);
+    return BtorJNI.boolector_set_termination(btor, this::shouldShutdown);
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
@@ -127,7 +127,7 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
   }
 
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
@@ -143,8 +143,8 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
   }
 
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
-      Collection<BooleanFormula> pAssumptions) throws SolverException, InterruptedException {
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
+      Collection<BooleanFormula> pAssumptions) {
     throw new UnsupportedOperationException(UNSAT_CORE_WITH_ASSUMPTIONS_NOT_SUPPORTED);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/boolector/BoolectorTheoremProver.java
@@ -41,14 +41,14 @@ class BoolectorTheoremProver extends AbstractProverWithAllSat<Void> implements P
       BoolectorFormulaManager manager,
       BoolectorFormulaCreator creator,
       long btor,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Set<ProverOptions> pOptions,
       AtomicBoolean pIsAnyStackAlive) {
-    super(pOptions, manager.getBooleanFormulaManager(), pShutdownNotifier);
+    super(pOptions, manager.getBooleanFormulaManager(), pContextShutdownNotifier);
     this.manager = manager;
     this.creator = creator;
     this.btor = btor;
-    terminationCallback = pShutdownNotifier::shouldShutdown;
+    terminationCallback = pContextShutdownNotifier::shouldShutdown;
     terminationCallbackHelper = addTerminationCallback();
 
     isAnyStackAlive = pIsAnyStackAlive;

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4SolverContext.java
@@ -31,23 +31,23 @@ public final class CVC4SolverContext extends AbstractSolverContext {
 
   // creator is final, except after closing, then null.
   private CVC4FormulaCreator creator;
-  private final ShutdownNotifier shutdownNotifier;
+  private final ShutdownNotifier contextShutdownNotifier;
   private final int randomSeed;
 
   private CVC4SolverContext(
       CVC4FormulaCreator creator,
       CVC4FormulaManager manager,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       int pRandomSeed) {
     super(manager);
     this.creator = creator;
-    shutdownNotifier = pShutdownNotifier;
+    contextShutdownNotifier = pContextShutdownNotifier;
     randomSeed = pRandomSeed;
   }
 
   public static SolverContext create(
       LogManager pLogger,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       int randomSeed,
       NonLinearArithmetic pNonLinearArithmetic,
       FloatingPointRoundingMode pFloatingPointRoundingMode,
@@ -106,7 +106,7 @@ public final class CVC4SolverContext extends AbstractSolverContext {
             slTheory,
             strTheory);
 
-    return new CVC4SolverContext(creator, manager, pShutdownNotifier, randomSeed);
+    return new CVC4SolverContext(creator, manager, pContextShutdownNotifier, randomSeed);
   }
 
   @Override
@@ -130,7 +130,7 @@ public final class CVC4SolverContext extends AbstractSolverContext {
   public ProverEnvironment newProverEnvironment0(Set<ProverOptions> pOptions) {
     return new CVC4TheoremProver(
         creator,
-        shutdownNotifier,
+        contextShutdownNotifier,
         randomSeed,
         pOptions,
         getFormulaManager().getBooleanFormulaManager());

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -155,7 +155,7 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
   }
 
   @Override
-  public Evaluator getEvaluatorImpl() {
+  protected Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -182,13 +182,13 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
     }
 
     Result result;
-    try (ShutdownHook hook = new ShutdownHook(shutdownNotifier, smtEngine::interrupt)) {
-      shutdownNotifier.shutdownIfNecessary();
+    try (ShutdownHook hook = new ShutdownHook(contextShutdownNotifier, smtEngine::interrupt)) {
+      contextShutdownNotifier.shutdownIfNecessary();
       result = smtEngine.checkSat();
     } catch (Exception e) {
       throw new SolverException("CVC4 failed during satisfiability check", e);
     } finally {
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
     }
     return convertSatResult(result);
   }

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -183,12 +183,12 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
 
     Result result;
     try (ShutdownHook hook = new ShutdownHook(contextShutdownNotifier, smtEngine::interrupt)) {
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
       result = smtEngine.checkSat();
     } catch (Exception e) {
       throw new SolverException("CVC4 failed during satisfiability check", e);
     } finally {
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
     }
     return convertSatResult(result);
   }

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -226,8 +226,8 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
   }
 
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
-      Collection<BooleanFormula> pAssumptions) throws SolverException, InterruptedException {
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
+      Collection<BooleanFormula> pAssumptions) {
     throw new UnsupportedOperationException(UNSAT_CORE_WITH_ASSUMPTIONS_NOT_SUPPORTED);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -211,8 +211,7 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    checkGenerateUnsatCores();
+  public List<BooleanFormula> getUnsatCoreImpl() {
     List<BooleanFormula> converted = new ArrayList<>();
     for (Expr aCore : smtEngine.getUnsatCore()) {
       converted.add(creator.encapsulateBoolean(exportExpr(aCore)));

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -143,8 +143,7 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
 
   @SuppressWarnings("resource")
   @Override
-  public CVC4Model getModel() throws SolverException {
-    checkGenerateModels();
+  public CVC4Model getModelImpl() throws SolverException {
     // special case for CVC4: Models are not permanent and need to be closed
     // before any change is applied to the prover stack. So, we register the Model as Evaluator.
     return registerEvaluator(
@@ -156,8 +155,7 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
   }
 
   @Override
-  public Evaluator getEvaluator() {
-    checkGenerateModels();
+  public Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc4/CVC4TheoremProver.java
@@ -58,11 +58,11 @@ class CVC4TheoremProver extends AbstractProverWithAllSat<Void>
 
   CVC4TheoremProver(
       CVC4FormulaCreator pFormulaCreator,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       int pRandomSeed,
       Set<ProverOptions> pOptions,
       BooleanFormulaManager pBmgr) {
-    super(pOptions, pBmgr, pShutdownNotifier);
+    super(pOptions, pBmgr, pContextShutdownNotifier);
 
     creator = pFormulaCreator;
     randomSeed = pRandomSeed;

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -210,7 +210,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
       throw new SolverException("CVC5 failed during satisfiability check", e);
     } finally {
       /* Shutdown currently not possible in CVC5. */
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
     }
     return convertSatResult(result);
   }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -309,8 +309,8 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
-      Collection<BooleanFormula> pAssumptions) throws SolverException, InterruptedException {
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
+      Collection<BooleanFormula> pAssumptions) {
     throw new UnsupportedOperationException(UNSAT_CORE_WITH_ASSUMPTIONS_NOT_SUPPORTED);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -294,8 +294,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    checkGenerateUnsatCores();
+  public List<BooleanFormula> getUnsatCoreImpl() {
     List<BooleanFormula> converted = new ArrayList<>();
     for (Term aCore : solver.getUnsatCore()) {
       converted.add(creator.encapsulateBoolean(aCore));

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -165,8 +165,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public CVC5Model getModel() throws SolverException {
-    checkGenerateModels();
+  public CVC5Model getModelImpl() throws SolverException {
     // special case for CVC5: Models are not permanent and need to be closed
     // before any change is applied to the prover stack. So, we register the Model as Evaluator.
     return registerEvaluator(
@@ -175,8 +174,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public Evaluator getEvaluator() {
-    checkGenerateModels();
+  public Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -174,7 +174,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public Evaluator getEvaluatorImpl() {
+  protected Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -210,7 +210,7 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
       throw new SolverException("CVC5 failed during satisfiability check", e);
     } finally {
       /* Shutdown currently not possible in CVC5. */
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
     }
     return convertSatResult(result);
   }

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5AbstractProver.java
@@ -64,12 +64,12 @@ abstract class CVC5AbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   CVC5AbstractProver(
       CVC5FormulaCreator pFormulaCreator,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       int pRandomSeed,
       ImmutableSet<ProverOptions> pOptions,
       FormulaManager pMgr,
       ImmutableMap<String, String> pFurtherOptionsMap) {
-    super(pOptions, pMgr.getBooleanFormulaManager(), pShutdownNotifier);
+    super(pOptions, pMgr.getBooleanFormulaManager(), pContextShutdownNotifier);
 
     creator = pFormulaCreator;
     furtherOptionsMap = pFurtherOptionsMap;

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5InterpolatingProver.java
@@ -42,13 +42,14 @@ class CVC5InterpolatingProver extends CVC5AbstractProver<String>
 
   CVC5InterpolatingProver(
       CVC5FormulaCreator pFormulaCreator,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       int pRandomSeed,
       ImmutableSet<ProverOptions> pOptions,
       FormulaManager pMgr,
       ImmutableMap<String, String> pFurtherOptionsMap,
       boolean pValidateInterpolants) {
-    super(pFormulaCreator, pShutdownNotifier, pRandomSeed, pOptions, pMgr, pFurtherOptionsMap);
+    super(
+        pFormulaCreator, pContextShutdownNotifier, pRandomSeed, pOptions, pMgr, pFurtherOptionsMap);
     mgr = pMgr;
     bmgr = (CVC5BooleanFormulaManager) mgr.getBooleanFormulaManager();
     validateInterpolants = pValidateInterpolants;

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5SolverContext.java
@@ -78,7 +78,7 @@ public final class CVC5SolverContext extends AbstractSolverContext {
   // creator is final, except after closing, then null.
   private CVC5FormulaCreator creator;
   private final Solver solver;
-  private final ShutdownNotifier shutdownNotifier;
+  private final ShutdownNotifier contextShutdownNotifier;
   private final int randomSeed;
   private final CVC5Settings settings;
   private boolean closed = false;
@@ -89,13 +89,13 @@ public final class CVC5SolverContext extends AbstractSolverContext {
   private CVC5SolverContext(
       CVC5FormulaCreator pCreator,
       CVC5FormulaManager pManager,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Solver pSolver,
       int pRandomSeed,
       CVC5Settings pSettings) {
     super(pManager);
     creator = pCreator;
-    shutdownNotifier = pShutdownNotifier;
+    contextShutdownNotifier = pContextShutdownNotifier;
     randomSeed = pRandomSeed;
     solver = pSolver;
     settings = pSettings;
@@ -114,7 +114,7 @@ public final class CVC5SolverContext extends AbstractSolverContext {
   public static SolverContext create(
       LogManager pLogger,
       Configuration pConfig,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       int randomSeed,
       NonLinearArithmetic pNonLinearArithmetic,
       FloatingPointRoundingMode pFloatingPointRoundingMode,
@@ -180,7 +180,7 @@ public final class CVC5SolverContext extends AbstractSolverContext {
             enumTheory);
 
     return new CVC5SolverContext(
-        pCreator, manager, pShutdownNotifier, newSolver, randomSeed, settings);
+        pCreator, manager, pContextShutdownNotifier, newSolver, randomSeed, settings);
   }
 
   /**
@@ -239,7 +239,7 @@ public final class CVC5SolverContext extends AbstractSolverContext {
     Preconditions.checkState(!closed, "solver context is already closed");
     return new CVC5TheoremProver(
         creator,
-        shutdownNotifier,
+        contextShutdownNotifier,
         randomSeed,
         ImmutableSet.copyOf(pOptions),
         getFormulaManager(),
@@ -257,7 +257,7 @@ public final class CVC5SolverContext extends AbstractSolverContext {
     Preconditions.checkState(!closed, "solver context is already closed");
     return new CVC5InterpolatingProver(
         creator,
-        shutdownNotifier,
+        contextShutdownNotifier,
         randomSeed,
         ImmutableSet.copyOf(pOptions),
         getFormulaManager(),

--- a/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/cvc5/CVC5TheoremProver.java
@@ -23,12 +23,13 @@ class CVC5TheoremProver extends CVC5AbstractProver<Void>
 
   CVC5TheoremProver(
       CVC5FormulaCreator pFormulaCreator,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       int pRandomSeed,
       ImmutableSet<ProverOptions> pOptions,
       FormulaManager pMgr,
       ImmutableMap<String, String> pFurtherOptionsMap) {
-    super(pFormulaCreator, pShutdownNotifier, pRandomSeed, pOptions, pMgr, pFurtherOptionsMap);
+    super(
+        pFormulaCreator, pContextShutdownNotifier, pRandomSeed, pOptions, pMgr, pFurtherOptionsMap);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -57,19 +57,17 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
   protected final long curEnv;
   private final long curConfig;
   protected final Mathsat5FormulaCreator creator;
-  private final ShutdownNotifier shutdownNotifier;
 
   protected Mathsat5AbstractProver(
       Mathsat5SolverContext pContext,
       Set<ProverOptions> pOptions,
       Mathsat5FormulaCreator pCreator,
-      ShutdownNotifier pShutdownNotifier) {
-    super(pOptions, pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(pOptions, pContextShutdownNotifier);
     context = pContext;
     creator = pCreator;
     curConfig = buildConfig(pOptions);
     curEnv = context.createEnvironment(curConfig);
-    shutdownNotifier = pShutdownNotifier;
   }
 
   private long buildConfig(Set<ProverOptions> opts) {
@@ -268,7 +266,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
 
     @Override
     public void callback(long[] model) throws InterruptedException {
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
       clientCallback.apply(Longs.asList(model).stream().map(creator::encapsulateBoolean).toList());
     }
   }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -211,9 +211,8 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
   }
 
   @Override
-  public ImmutableMap<String, String> getStatistics() {
+  public ImmutableMap<String, String> getStatisticsImpl() {
     // Mathsat sigsevs if you try to get statistics for closed environments
-    Preconditions.checkState(!closed);
     final String stats = msat_get_search_stats(curEnv);
     return ImmutableMap.copyOf(
         Splitter.on("\n").trimResults().omitEmptyStrings().withKeyValueSeparator(" ").split(stats));

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -191,11 +191,8 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
   }
 
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
       Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException {
-    Preconditions.checkNotNull(assumptions);
-    checkGenerateUnsatCoresOverAssumptions();
-
     closeAllEvaluators();
 
     if (!isUnsatWithAssumptions(assumptions)) {

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -144,8 +144,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return new CachingModel(new Mathsat5Model(getMsatModel(), creator, this));
   }
 
@@ -159,8 +158,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
 
   @SuppressWarnings("resource")
   @Override
-  public Evaluator getEvaluator() {
-    checkGenerateModels();
+  public Evaluator getEvaluatorImpl() {
     return registerEvaluator(new Mathsat5Evaluator(this, creator, curEnv));
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -64,7 +64,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
       Set<ProverOptions> pOptions,
       Mathsat5FormulaCreator pCreator,
       ShutdownNotifier pShutdownNotifier) {
-    super(pOptions);
+    super(pOptions, pShutdownNotifier);
     context = pContext;
     creator = pCreator;
     curConfig = buildConfig(pOptions);

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -144,7 +144,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return new CachingModel(new Mathsat5Model(getMsatModel(), creator, this));
   }
 
@@ -158,7 +158,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
 
   @SuppressWarnings("resource")
   @Override
-  public Evaluator getEvaluatorImpl() {
+  protected Evaluator getEvaluatorImpl() {
     return registerEvaluator(new Mathsat5Evaluator(this, creator, curEnv));
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -185,8 +185,7 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    checkGenerateUnsatCores();
+  public List<BooleanFormula> getUnsatCoreImpl() {
     long[] terms = msat_get_unsat_core(curEnv);
     return encapsulate(terms);
   }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -233,9 +233,8 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
   }
 
   @Override
-  public <T> T allSat(AllSatCallback<T> callback, List<BooleanFormula> important)
+  protected <T> T allSatImpl(AllSatCallback<T> callback, List<BooleanFormula> important)
       throws InterruptedException, SolverException {
-    checkGenerateAllSat();
     closeAllEvaluators();
 
     long[] imp = new long[important.size()];

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5AbstractProver.java
@@ -152,7 +152,6 @@ abstract class Mathsat5AbstractProver<T2> extends AbstractProver<T2> {
    * @throws SolverException if an expected MathSAT failure occurs
    */
   protected long getMsatModel() throws SolverException {
-    checkGenerateModels();
     return Mathsat5NativeApi.msat_get_model(curEnv);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5InterpolatingProver.java
@@ -138,7 +138,7 @@ class Mathsat5InterpolatingProver extends Mathsat5AbstractProver<Integer>
   }
 
   @Override
-  public <T> T allSat(AllSatCallback<T> callback, List<BooleanFormula> important) {
+  protected <T> T allSatImpl(AllSatCallback<T> callback, List<BooleanFormula> important) {
     // TODO how can we support allsat in MathSat5-interpolation-prover?
     // error: "allsat is not compatible wwith proof generation"
     throw new UnsupportedOperationException(

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5InterpolatingProver.java
@@ -54,10 +54,10 @@ class Mathsat5InterpolatingProver extends Mathsat5AbstractProver<Integer>
 
   Mathsat5InterpolatingProver(
       Mathsat5SolverContext pMgr,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Mathsat5FormulaCreator creator,
       Set<ProverOptions> options) {
-    super(pMgr, options, creator, pShutdownNotifier);
+    super(pMgr, options, creator, pContextShutdownNotifier);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
@@ -139,7 +139,7 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
   }
 
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     if (!objectiveMap.isEmpty()) {
       msat_load_objective_model(curEnv, objectiveMap.values().iterator().next());
     }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
@@ -56,10 +56,10 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
 
   Mathsat5OptimizationProver(
       Mathsat5SolverContext pMgr,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Mathsat5FormulaCreator creator,
       Set<ProverOptions> options) {
-    super(pMgr, options, creator, pShutdownNotifier);
+    super(pMgr, options, creator, pContextShutdownNotifier);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
@@ -8,7 +8,6 @@
 
 package org.sosy_lab.java_smt.solvers.mathsat5;
 
-import static com.google.common.base.Preconditions.checkState;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5FormulaManager.getMsatTerm;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.MSAT_OPTIMUM;
 import static org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi.msat_assert_formula;
@@ -77,7 +76,6 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
 
   @Override
   public int maximize(Formula objective) {
-    checkState(!closed);
     long objectiveId = msat_make_maximize(curEnv, getMsatTerm(objective));
     msat_assert_objective(curEnv, objectiveId);
     int id = idGenerator.getFreshId(); // mapping needed to avoid long-int-conversion
@@ -87,7 +85,6 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
 
   @Override
   public int minimize(Formula objective) {
-    checkState(!closed);
     long objectiveId = msat_make_minimize(curEnv, getMsatTerm(objective));
     msat_assert_objective(curEnv, objectiveId);
     int id = idGenerator.getFreshId(); // mapping needed to avoid long-int-conversion
@@ -119,15 +116,11 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
 
   @Override
   public Optional<Rational> upper(int handle, Rational epsilon) {
-    checkState(!closed);
-    checkGenerateModels();
     return getValue(handle, epsilon);
   }
 
   @Override
   public Optional<Rational> lower(int handle, Rational epsilon) {
-    checkState(!closed);
-    checkGenerateModels();
     return getValue(handle, epsilon);
   }
 
@@ -147,8 +140,6 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
 
   @Override
   public Model getModel() throws SolverException {
-    checkState(!closed);
-    checkGenerateModels(); // Needed before loading objective model!
     if (!objectiveMap.isEmpty()) {
       msat_load_objective_model(curEnv, objectiveMap.values().iterator().next());
     }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5OptimizationProver.java
@@ -139,10 +139,10 @@ class Mathsat5OptimizationProver extends Mathsat5AbstractProver<Void>
   }
 
   @Override
-  public Model getModel() throws SolverException {
+  public Model getModelImpl() throws SolverException {
     if (!objectiveMap.isEmpty()) {
       msat_load_objective_model(curEnv, objectiveMap.values().iterator().next());
     }
-    return super.getModel();
+    return super.getModelImpl();
   }
 }

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5SolverContext.java
@@ -115,7 +115,7 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
   private final Mathsat5Settings settings;
   private final long randomSeed;
 
-  private final ShutdownNotifier shutdownNotifier;
+  private final ShutdownNotifier contextShutdownNotifier;
   private final TerminationCallback terminationTest;
   private final Mathsat5FormulaCreator creator;
   private boolean closed = false;
@@ -128,7 +128,7 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
       long mathsatConfig,
       Mathsat5Settings settings,
       long randomSeed,
-      final ShutdownNotifier shutdownNotifier,
+      final ShutdownNotifier contextShutdownNotifier,
       Mathsat5FormulaManager manager,
       Mathsat5FormulaCreator creator) {
     super(manager);
@@ -138,12 +138,12 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
     this.mathsatConfig = mathsatConfig;
     this.settings = settings;
     this.randomSeed = randomSeed;
-    this.shutdownNotifier = shutdownNotifier;
+    this.contextShutdownNotifier = contextShutdownNotifier;
     this.creator = creator;
 
     terminationTest =
         () -> {
-          shutdownNotifier.shutdownIfNecessary();
+          contextShutdownNotifier.shutdownIfNecessary();
           return false;
         };
   }
@@ -165,7 +165,7 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
   public static Mathsat5SolverContext create(
       LogManager logger,
       Configuration config,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       @Nullable PathCounterTemplate solverLogFile,
       long randomSeed,
       FloatingPointRoundingMode pFloatingPointRoundingMode,
@@ -233,7 +233,7 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
             settings.useExtendedSMTLIB2Output,
             settings.dumpSMTLIB2LetExpressions);
     return new Mathsat5SolverContext(
-        logger, msatConf, settings, randomSeed, pShutdownNotifier, manager, creator);
+        logger, msatConf, settings, randomSeed, pContextShutdownNotifier, manager, creator);
   }
 
   @VisibleForTesting
@@ -287,21 +287,21 @@ public final class Mathsat5SolverContext extends AbstractSolverContext {
   @Override
   protected ProverEnvironment newProverEnvironment0(Set<ProverOptions> options) {
     Preconditions.checkState(!closed, "solver context is already closed");
-    return new Mathsat5TheoremProver(this, shutdownNotifier, creator, options);
+    return new Mathsat5TheoremProver(this, contextShutdownNotifier, creator, options);
   }
 
   @Override
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> options) {
     Preconditions.checkState(!closed, "solver context is already closed");
-    return new Mathsat5InterpolatingProver(this, shutdownNotifier, creator, options);
+    return new Mathsat5InterpolatingProver(this, contextShutdownNotifier, creator, options);
   }
 
   @Override
   public OptimizationProverEnvironment newOptimizationProverEnvironment0(
       Set<ProverOptions> options) {
     Preconditions.checkState(!closed, "solver context is already closed");
-    return new Mathsat5OptimizationProver(this, shutdownNotifier, creator, options);
+    return new Mathsat5OptimizationProver(this, contextShutdownNotifier, creator, options);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/mathsat5/Mathsat5TheoremProver.java
@@ -24,10 +24,10 @@ class Mathsat5TheoremProver extends Mathsat5AbstractProver<Void> implements Prov
 
   Mathsat5TheoremProver(
       Mathsat5SolverContext pMgr,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Mathsat5FormulaCreator creator,
       Set<ProverOptions> options) {
-    super(pMgr, options, creator, pShutdownNotifier);
+    super(pMgr, options, creator, pContextShutdownNotifier);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -241,8 +241,7 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    checkGenerateUnsatCores();
+  public List<BooleanFormula> getUnsatCoreImpl() {
     return Lists.transform(osmtSolver.getUnsatCore(), creator::encapsulateBoolean);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -252,8 +252,8 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
-      Collection<BooleanFormula> pAssumptions) throws SolverException, InterruptedException {
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
+      Collection<BooleanFormula> pAssumptions) {
     throw new UnsupportedOperationException(UNSAT_CORE_WITH_ASSUMPTIONS_NOT_SUPPORTED);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -208,8 +208,9 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
   protected boolean isUnsatImpl() throws InterruptedException, SolverException {
     closeAllEvaluators();
     sstat result;
-    try (ShutdownHook listener = new ShutdownHook(shutdownNotifier, osmtSolver::notifyStop)) {
-      shutdownNotifier.shutdownIfNecessary();
+    try (ShutdownHook listener =
+        new ShutdownHook(contextShutdownNotifier, osmtSolver::notifyStop)) {
+      contextShutdownNotifier.shutdownIfNecessary();
       try {
         result = osmtSolver.check();
       } catch (Exception e) {
@@ -228,7 +229,7 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
           throw new SolverException("OpenSMT crashed while checking satisfiability.", e);
         }
       }
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
     }
 
     if (result.equals(sstat.Error())) {

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -117,14 +117,14 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() {
+  protected Model getModelImpl() {
     return registerEvaluator(
         new OpenSmtModel(
             this, creator, Collections2.transform(getAssertedFormulas(), creator::extractInfo)));
   }
 
   @Override
-  public Evaluator getEvaluatorImpl() {
+  protected Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -47,10 +47,10 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
   OpenSmtAbstractProver(
       OpenSmtFormulaCreator pFormulaCreator,
       FormulaManager pMgr,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       SMTConfig pConfig,
       Set<ProverOptions> pOptions) {
-    super(pOptions, pMgr.getBooleanFormulaManager(), pShutdownNotifier);
+    super(pOptions, pMgr.getBooleanFormulaManager(), pContextShutdownNotifier);
 
     creator = pFormulaCreator;
 

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -117,16 +117,14 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() {
-    checkGenerateModels();
+  public Model getModelImpl() {
     return registerEvaluator(
         new OpenSmtModel(
             this, creator, Collections2.transform(getAssertedFormulas(), creator::extractInfo)));
   }
 
   @Override
-  public Evaluator getEvaluator() {
-    checkGenerateModels();
+  public Evaluator getEvaluatorImpl() {
     return getEvaluatorWithoutChecks();
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -210,7 +210,7 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
     sstat result;
     try (ShutdownHook listener =
         new ShutdownHook(contextShutdownNotifier, osmtSolver::notifyStop)) {
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
       try {
         result = osmtSolver.check();
       } catch (Exception e) {
@@ -229,7 +229,7 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
           throw new SolverException("OpenSMT crashed while checking satisfiability.", e);
         }
       }
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
     }
 
     if (result.equals(sstat.Error())) {

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtInterpolatingProver.java
@@ -36,13 +36,13 @@ class OpenSmtInterpolatingProver extends OpenSmtAbstractProver<Integer>
   OpenSmtInterpolatingProver(
       OpenSmtFormulaCreator pFormulaCreator,
       FormulaManager pMgr,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Set<ProverOptions> pOptions,
       OpenSMTOptions pSolverOptions) {
     super(
         pFormulaCreator,
         pMgr,
-        pShutdownNotifier,
+        pContextShutdownNotifier,
         getConfigInstance(pOptions, pSolverOptions, true),
         pOptions);
     trackedConstraints.push(0); // initialize first level

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtSolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtSolverContext.java
@@ -37,7 +37,7 @@ public final class OpenSmtSolverContext extends AbstractSolverContext {
   @SuppressWarnings("unused")
   private final LogManager logger;
 
-  private final ShutdownNotifier shutdownNotifier;
+  private final ShutdownNotifier contextShutdownNotifier;
   private final OpenSMTOptions solverOptions;
 
   private boolean closed = false;
@@ -97,21 +97,21 @@ public final class OpenSmtSolverContext extends AbstractSolverContext {
       OpenSmtFormulaCreator pCreator,
       OpenSmtFormulaManager pManager,
       LogManager pLogger,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       OpenSMTOptions pSolverOptions) {
 
     super(pManager);
     creator = pCreator;
     manager = pManager;
     logger = pLogger;
-    shutdownNotifier = pShutdownNotifier;
+    contextShutdownNotifier = pContextShutdownNotifier;
     solverOptions = pSolverOptions;
   }
 
   public static SolverContext create(
       Configuration config,
       LogManager pLogger,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       long pRandom,
       NonLinearArithmetic pNonLinearArithmetic,
       Consumer<String> pLoader)
@@ -139,7 +139,8 @@ public final class OpenSmtSolverContext extends AbstractSolverContext {
         new OpenSmtFormulaManager(
             creator, functionTheory, booleanTheory, integerTheory, rationalTheory, arrayTheory);
 
-    return new OpenSmtSolverContext(creator, manager, pLogger, pShutdownNotifier, solverOptions);
+    return new OpenSmtSolverContext(
+        creator, manager, pLogger, pContextShutdownNotifier, solverOptions);
   }
 
   @Override
@@ -171,7 +172,7 @@ public final class OpenSmtSolverContext extends AbstractSolverContext {
       Set<SolverContext.ProverOptions> pProverOptions) {
     Preconditions.checkState(!closed, "solver context is already closed");
     return new OpenSmtTheoremProver(
-        creator, manager, shutdownNotifier, pProverOptions, solverOptions);
+        creator, manager, contextShutdownNotifier, pProverOptions, solverOptions);
   }
 
   @Override
@@ -179,7 +180,7 @@ public final class OpenSmtSolverContext extends AbstractSolverContext {
       Set<SolverContext.ProverOptions> pProverOptions) {
     Preconditions.checkState(!closed, "solver context is already closed");
     return new OpenSmtInterpolatingProver(
-        creator, manager, shutdownNotifier, pProverOptions, solverOptions);
+        creator, manager, contextShutdownNotifier, pProverOptions, solverOptions);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtTheoremProver.java
@@ -21,13 +21,13 @@ class OpenSmtTheoremProver extends OpenSmtAbstractProver<Void> implements Prover
   OpenSmtTheoremProver(
       OpenSmtFormulaCreator pFormulaCreator,
       FormulaManager pMgr,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Set<ProverOptions> pOptions,
       OpenSMTOptions pSolverOptions) {
     super(
         pFormulaCreator,
         pMgr,
-        pShutdownNotifier,
+        pContextShutdownNotifier,
         getConfigInstance(pOptions, pSolverOptions, false),
         pOptions);
   }

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
@@ -130,8 +130,7 @@ abstract class PrincessAbstractProver<E> extends AbstractProverWithAllSat<E> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
@@ -162,8 +162,7 @@ abstract class PrincessAbstractProver<E> extends AbstractProverWithAllSat<E> {
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    checkGenerateUnsatCores();
+  public List<BooleanFormula> getUnsatCoreImpl() {
     final List<BooleanFormula> result = new ArrayList<>();
     final Set<Object> core = asJava(api.getUnsatCore());
     for (Object partitionId : core) {

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
@@ -57,9 +57,9 @@ abstract class PrincessAbstractProver<E> extends AbstractProverWithAllSat<E> {
       PrincessFormulaManager pMgr,
       PrincessFormulaCreator creator,
       SimpleAPI pApi,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Set<ProverOptions> pOptions) {
-    super(pOptions, pMgr.getBooleanFormulaManager(), pShutdownNotifier);
+    super(pOptions, pMgr.getBooleanFormulaManager(), pContextShutdownNotifier);
     this.mgr = pMgr;
     this.creator = creator;
     this.api = checkNotNull(pApi);

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
@@ -130,7 +130,7 @@ abstract class PrincessAbstractProver<E> extends AbstractProverWithAllSat<E> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessAbstractProver.java
@@ -172,8 +172,8 @@ abstract class PrincessAbstractProver<E> extends AbstractProverWithAllSat<E> {
   }
 
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
-      Collection<BooleanFormula> assumptions) {
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
+      Collection<BooleanFormula> pAssumptions) {
     throw new UnsupportedOperationException(UNSAT_CORE_WITH_ASSUMPTIONS_NOT_SUPPORTED);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
@@ -177,7 +177,7 @@ class PrincessEnvironment {
 
   private final int randomSeed;
   private final @Nullable PathCounterTemplate basicLogfile;
-  private final ShutdownNotifier shutdownNotifier;
+  private final ShutdownNotifier contextShutdownNotifier;
 
   /**
    * The wrapped API is the first created API. It will never be used outside this class and never be
@@ -191,13 +191,13 @@ class PrincessEnvironment {
   PrincessEnvironment(
       Configuration config,
       @Nullable final PathCounterTemplate pBasicLogfile,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       final int pRandomSeed)
       throws InvalidConfigurationException {
     config.inject(this);
 
     basicLogfile = pBasicLogfile;
-    shutdownNotifier = pShutdownNotifier;
+    contextShutdownNotifier = pContextShutdownNotifier;
     randomSeed = pRandomSeed;
 
     // this api is only used local in this environment, no need for interpolation
@@ -224,9 +224,10 @@ class PrincessEnvironment {
 
     PrincessAbstractProver<?> prover;
     if (useForInterpolation) {
-      prover = new PrincessInterpolatingProver(mgr, creator, newApi, shutdownNotifier, pOptions);
+      prover =
+          new PrincessInterpolatingProver(mgr, creator, newApi, contextShutdownNotifier, pOptions);
     } else {
-      prover = new PrincessTheoremProver(mgr, creator, newApi, shutdownNotifier, pOptions);
+      prover = new PrincessTheoremProver(mgr, creator, newApi, contextShutdownNotifier, pOptions);
     }
     registeredProvers.add(prover);
     return prover;
@@ -402,7 +403,7 @@ class PrincessEnvironment {
           appendTo0(out);
         } catch (scala.MatchError e) {
           // exception might be thrown in case of interrupt, then we wrap it in an interrupt.
-          if (shutdownNotifier.shouldShutdown()) {
+          if (contextShutdownNotifier.shouldShutdown()) {
             InterruptedException interrupt = new InterruptedException();
             interrupt.addSuppressed(e);
             throwCheckedAsUnchecked(interrupt);

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessInterpolatingProver.java
@@ -43,9 +43,9 @@ class PrincessInterpolatingProver extends PrincessAbstractProver<Integer>
       PrincessFormulaManager pMgr,
       PrincessFormulaCreator creator,
       SimpleAPI pApi,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Set<ProverOptions> pOptions) {
-    super(pMgr, creator, pApi, pShutdownNotifier, pOptions);
+    super(pMgr, creator, pApi, pContextShutdownNotifier, pOptions);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessSolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessSolverContext.java
@@ -36,13 +36,13 @@ public final class PrincessSolverContext extends AbstractSolverContext {
 
   public static SolverContext create(
       Configuration config,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       @Nullable PathCounterTemplate pLogfileTemplate,
       int pRandomSeed,
       NonLinearArithmetic pNonLinearArithmetic)
       throws InvalidConfigurationException {
     PrincessEnvironment env =
-        new PrincessEnvironment(config, pLogfileTemplate, pShutdownNotifier, pRandomSeed);
+        new PrincessEnvironment(config, pLogfileTemplate, pContextShutdownNotifier, pRandomSeed);
     PrincessFormulaCreator creator = new PrincessFormulaCreator(env);
 
     // Create managers

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessTheoremProver.java
@@ -22,9 +22,9 @@ class PrincessTheoremProver extends PrincessAbstractProver<Void> implements Prov
       PrincessFormulaManager pMgr,
       PrincessFormulaCreator creator,
       SimpleAPI pApi,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Set<ProverOptions> pOptions) {
-    super(pMgr, creator, pApi, pShutdownNotifier, pOptions);
+    super(pMgr, creator, pApi, pContextShutdownNotifier, pOptions);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/LoggingSmtInterpolInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/LoggingSmtInterpolInterpolatingProver.java
@@ -37,10 +37,10 @@ class LoggingSmtInterpolInterpolatingProver extends SmtInterpolInterpolatingProv
       SmtInterpolFormulaManager pMgr,
       Script pScript,
       Set<ProverOptions> pOptions,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Map<String, Object> pGlobalOptions,
       Path pLogfile) {
-    super(pMgr, pScript, pOptions, pShutdownNotifier);
+    super(pMgr, pScript, pOptions, pContextShutdownNotifier);
     try {
       out = initializeLoggerForInterpolation(pGlobalOptions, pLogfile);
     } catch (IOException e) {

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/LoggingSmtInterpolInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/LoggingSmtInterpolInterpolatingProver.java
@@ -77,9 +77,9 @@ class LoggingSmtInterpolInterpolatingProver extends SmtInterpolInterpolatingProv
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
+  public List<BooleanFormula> getUnsatCoreImpl() {
     out.println("(get-unsat-core)");
-    return super.getUnsatCore();
+    return super.getUnsatCoreImpl();
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/LoggingSmtInterpolInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/LoggingSmtInterpolInterpolatingProver.java
@@ -83,10 +83,10 @@ class LoggingSmtInterpolInterpolatingProver extends SmtInterpolInterpolatingProv
   }
 
   @Override
-  public <R> R allSat(AllSatCallback<R> callback, List<BooleanFormula> predicates)
+  protected <R> R allSatImpl(AllSatCallback<R> callback, List<BooleanFormula> predicates)
       throws InterruptedException, SolverException {
     out.println("(all-sat (" + Joiner.on(", ").join(predicates) + "))");
-    return super.allSat(callback, predicates);
+    return super.allSatImpl(callback, predicates);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
@@ -51,7 +51,6 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
   protected final FormulaCreator<Term, Sort, Script, FunctionSymbol> creator;
   protected final SmtInterpolFormulaManager mgr;
   protected final Deque<PersistentMap<String, BooleanFormula>> annotatedTerms = new ArrayDeque<>();
-  protected final ShutdownNotifier shutdownNotifier;
 
   private static final String PREFIX = "term_"; // for termnames
   private static final UniqueIdGenerator termIdGenerator =
@@ -61,12 +60,11 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
       SmtInterpolFormulaManager pMgr,
       Script pEnv,
       Set<ProverOptions> options,
-      ShutdownNotifier pShutdownNotifier) {
-    super(options, pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(options, pContextShutdownNotifier);
     mgr = pMgr;
     creator = pMgr.getFormulaCreator();
     env = pEnv;
-    shutdownNotifier = pShutdownNotifier;
     annotatedTerms.add(PathCopyingPersistentTreeMap.of());
   }
 
@@ -111,7 +109,7 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
     // by using a shutdown listener. However, SmtInterpol resets the
     // mStopEngine flag in DPLLEngine before starting to solve,
     // so we check here, too.
-    shutdownNotifier.shutdownIfNecessary();
+    contextShutdownNotifier.shutdownIfNecessary();
 
     LBool result = env.checkSat();
     return switch (result) {
@@ -127,7 +125,7 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
               // SMTInterpol catches OOM, but we want to have it thrown.
               throw new OutOfMemoryError("Out of memory during SMTInterpol operation");
           case CANCELLED -> {
-            shutdownNotifier.shutdownIfNecessary(); // expected if we requested termination
+            contextShutdownNotifier.shutdownIfNecessary(); // expected if we requested termination
             throw new SMTLIBException("checkSat returned UNKNOWN with unexpected reason " + reason);
           }
           default ->
@@ -235,7 +233,7 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
     // by using a shutdown listener. However, SmtInterpol resets the
     // mStopEngine flag in DPLLEngine before starting to solve,
     // so we check here, too.
-    shutdownNotifier.shutdownIfNecessary();
+    contextShutdownNotifier.shutdownIfNecessary();
     for (Term[] model : env.checkAllsat(importantTerms)) {
       callback.apply(Collections3.transformedImmutableListCopy(model, creator::encapsulateBoolean));
     }

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
@@ -224,10 +224,8 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
   }
 
   @Override
-  public <R> R allSat(AllSatCallback<R> callback, List<BooleanFormula> important)
+  protected <R> R allSatImpl(AllSatCallback<R> callback, List<BooleanFormula> important)
       throws InterruptedException, SolverException {
-    checkGenerateAllSat();
-
     Term[] importantTerms = new Term[important.size()];
     int i = 0;
     for (BooleanFormula impF : important) {

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
@@ -165,8 +165,7 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    checkGenerateUnsatCores();
+  public List<BooleanFormula> getUnsatCoreImpl() {
     return getUnsatCore0(annotatedTerms.peek());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
@@ -186,9 +186,8 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
   }
 
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
       Collection<BooleanFormula> assumptions) throws InterruptedException, SolverException {
-    checkGenerateUnsatCoresOverAssumptions();
     Map<String, BooleanFormula> annotatedConstraints = new LinkedHashMap<>();
     push();
     for (BooleanFormula assumption : assumptions) {

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
@@ -201,7 +201,7 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
   }
 
   @Override
-  public ImmutableMap<String, String> getStatistics() {
+  public ImmutableMap<String, String> getStatisticsImpl() {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     SmtInterpolSolverContext.flatten(builder, "", env.getInfo(":all-statistics"));
     return builder.buildOrThrow();

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
@@ -140,8 +140,7 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public org.sosy_lab.java_smt.api.Model getModel() {
-    checkGenerateModels();
+  public org.sosy_lab.java_smt.api.Model getModelImpl() {
     final Model model;
     try {
       model = env.getModel();

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolAbstractProver.java
@@ -62,7 +62,7 @@ abstract class SmtInterpolAbstractProver<T> extends AbstractProver<T> {
       Script pEnv,
       Set<ProverOptions> options,
       ShutdownNotifier pShutdownNotifier) {
-    super(options);
+    super(options, pShutdownNotifier);
     mgr = pMgr;
     creator = pMgr.getFormulaCreator();
     env = pEnv;

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolInterpolatingProver.java
@@ -33,8 +33,8 @@ class SmtInterpolInterpolatingProver extends SmtInterpolAbstractProver<String>
       SmtInterpolFormulaManager pMgr,
       Script pScript,
       Set<ProverOptions> options,
-      ShutdownNotifier pShutdownNotifier) {
-    super(pMgr, pScript, options, pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(pMgr, pScript, options, pContextShutdownNotifier);
   }
 
   @Override
@@ -87,7 +87,7 @@ class SmtInterpolInterpolatingProver extends SmtInterpolAbstractProver<String>
       }
     } catch (SMTLIBException e) {
       if ("Timeout exceeded".equals(e.getMessage())) {
-        shutdownNotifier.shutdownIfNecessary();
+        contextShutdownNotifier.shutdownIfNecessary();
       }
       throw new AssertionError(e);
     }

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolSolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolSolverContext.java
@@ -97,25 +97,25 @@ public final class SmtInterpolSolverContext extends AbstractSolverContext {
 
   private SmtInterpolSolverContext(
       SmtInterpolFormulaManager pManager,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       SmtInterpolSettings pSettings) {
     super(pManager);
     settings = pSettings;
-    shutdownNotifier = checkNotNull(pShutdownNotifier);
+    shutdownNotifier = checkNotNull(pContextShutdownNotifier);
     manager = pManager;
   }
 
   public static SmtInterpolSolverContext create(
       Configuration config,
       LogManager logger,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       @Nullable PathCounterTemplate smtLogfile,
       long randomSeed,
       NonLinearArithmetic pNonLinearArithmetic)
       throws InvalidConfigurationException {
 
     SmtInterpolSettings settings = new SmtInterpolSettings(config, randomSeed, smtLogfile);
-    Script script = getSmtInterpolScript(pShutdownNotifier, smtLogfile, settings, logger);
+    Script script = getSmtInterpolScript(pContextShutdownNotifier, smtLogfile, settings, logger);
 
     SmtInterpolFormulaCreator creator = new SmtInterpolFormulaCreator(script);
     SmtInterpolUFManager functionTheory = new SmtInterpolUFManager(creator);
@@ -134,12 +134,12 @@ public final class SmtInterpolSolverContext extends AbstractSolverContext {
             rationalTheory,
             arrayTheory,
             logger);
-    return new SmtInterpolSolverContext(manager, pShutdownNotifier, settings);
+    return new SmtInterpolSolverContext(manager, pContextShutdownNotifier, settings);
   }
 
   /** instantiate the central SMTInterpol script from where all others are copied. */
   private static Script getSmtInterpolScript(
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       @javax.annotation.Nullable PathCounterTemplate smtLogfile,
       SmtInterpolSettings settings,
       LogManager logger)
@@ -147,7 +147,7 @@ public final class SmtInterpolSolverContext extends AbstractSolverContext {
     LogProxyForwarder smtInterpolLogProxy =
         new LogProxyForwarder(logger.withComponentName("SMTInterpol"));
     final SMTInterpol smtInterpol =
-        new SMTInterpol(smtInterpolLogProxy, pShutdownNotifier::shouldShutdown);
+        new SMTInterpol(smtInterpolLogProxy, pContextShutdownNotifier::shouldShutdown);
 
     final Script script = wrapInLoggingScriptIfNeeded(smtInterpol, smtLogfile);
 

--- a/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/smtinterpol/SmtInterpolTheoremProver.java
@@ -23,8 +23,8 @@ class SmtInterpolTheoremProver extends SmtInterpolAbstractProver<Void>
       SmtInterpolFormulaManager pMgr,
       Script pEnv,
       Set<ProverOptions> options,
-      ShutdownNotifier pShutdownNotifier) {
-    super(pMgr, pEnv, options, pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(pMgr, pEnv, options, pContextShutdownNotifier);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
@@ -69,9 +69,9 @@ abstract class Yices2AbstractProver<T> extends AbstractProverWithAllSat<T>
       Yices2FormulaCreator pCreator,
       Set<ProverOptions> pOptions,
       BooleanFormulaManager pBmgr,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       String pSolverType) {
-    super(pOptions, pBmgr, pShutdownNotifier);
+    super(pOptions, pBmgr, pContextShutdownNotifier);
     creator = pCreator;
     curEnv = newContext(pSolverType);
     stack.push(PathCopyingPersistentTreeMap.of());

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
@@ -251,9 +251,8 @@ abstract class Yices2AbstractProver<T> extends AbstractProverWithAllSat<T>
   }
 
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
       Collection<BooleanFormula> pAssumptions) throws SolverException, InterruptedException {
-    checkGenerateUnsatCoresOverAssumptions();
     boolean sat = !isUnsatWithAssumptions(pAssumptions);
     return sat ? Optional.empty() : Optional.of(encapsulate(curEnv.getUnsatCore()));
   }

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
@@ -162,12 +162,12 @@ abstract class Yices2AbstractProver<T> extends AbstractProverWithAllSat<T>
           !satCheckWithShutdownNotifier(
               () -> curEnv.checkWithAssumptions(DEFAULT_PARAMS, getAllConstraints()),
               curEnv,
-              shutdownNotifier);
+              contextShutdownNotifier);
 
     } else {
       unsat =
           !satCheckWithShutdownNotifier(
-              () -> curEnv.check(DEFAULT_PARAMS), curEnv, shutdownNotifier);
+              () -> curEnv.check(DEFAULT_PARAMS), curEnv, contextShutdownNotifier);
 
       if (unsat && stackSizeToUnsat == Integer.MAX_VALUE) {
         stackSizeToUnsat = size();
@@ -198,7 +198,7 @@ abstract class Yices2AbstractProver<T> extends AbstractProverWithAllSat<T>
         !satCheckWithShutdownNotifier(
             () -> curEnv.checkWithAssumptions(DEFAULT_PARAMS, uncapsulate(pAssumptions)),
             curEnv,
-            shutdownNotifier);
+            contextShutdownNotifier);
     if (!isUnsat) {
       wasLastSatCheckSatisfiable = true;
     }

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
@@ -207,7 +207,7 @@ abstract class Yices2AbstractProver<T> extends AbstractProverWithAllSat<T>
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
@@ -207,8 +207,7 @@ abstract class Yices2AbstractProver<T> extends AbstractProverWithAllSat<T>
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2AbstractProver.java
@@ -246,8 +246,7 @@ abstract class Yices2AbstractProver<T> extends AbstractProverWithAllSat<T>
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    checkGenerateUnsatCores();
+  public List<BooleanFormula> getUnsatCoreImpl() {
     return encapsulate(curEnv.getUnsatCore());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
@@ -71,9 +71,9 @@ class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
 
       // TODO How to abort this?
       // For now, let's just check before and after the call:
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
       var status = context.check(DEFAULT_PARAMS, false);
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
       if (status == Status.UNSAT) {
         return context.getInterpolant();
       } else {

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
@@ -37,9 +37,9 @@ class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
       Yices2FormulaCreator creator,
       Set<ProverOptions> pOptions,
       BooleanFormulaManager pBmgr,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       String pSolverType) {
-    super(creator, pOptions, pBmgr, pShutdownNotifier, pSolverType);
+    super(creator, pOptions, pBmgr, pContextShutdownNotifier, pSolverType);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
@@ -71,9 +71,9 @@ class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
 
       // TODO How to abort this?
       // For now, let's just check before and after the call:
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
       var status = context.check(DEFAULT_PARAMS, false);
-      contextShutdownNotifier.shutdownIfNecessary();
+      shutdownIfNecessary();
       if (status == Status.UNSAT) {
         return context.getInterpolant();
       } else {

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2Prover.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2Prover.java
@@ -23,9 +23,9 @@ class Yices2Prover extends Yices2AbstractProver<Void> implements ProverEnvironme
       Yices2FormulaCreator creator,
       Set<ProverOptions> pOptions,
       BooleanFormulaManager pBmgr,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       String pSolverType) {
-    super(creator, pOptions, pBmgr, pShutdownNotifier, pSolverType);
+    super(creator, pOptions, pBmgr, pContextShutdownNotifier, pSolverType);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2SolverContext.java
@@ -42,7 +42,7 @@ public final class Yices2SolverContext extends AbstractSolverContext {
 
   private final Yices2FormulaCreator creator;
   private final BooleanFormulaManager bfmgr;
-  private final ShutdownNotifier shutdownManager;
+  private final ShutdownNotifier contextShutdownManager;
   private final Yices2Parameters parameters;
 
   private static int numLoadedInstances = 0;
@@ -52,12 +52,12 @@ public final class Yices2SolverContext extends AbstractSolverContext {
       FormulaManager pFmgr,
       Yices2FormulaCreator creator,
       BooleanFormulaManager pBfmgr,
-      ShutdownNotifier pShutdownManager,
+      ShutdownNotifier pContextShutdownManager,
       Yices2Parameters pParameters) {
     super(pFmgr);
     this.creator = creator;
     bfmgr = pBfmgr;
-    shutdownManager = pShutdownManager;
+    contextShutdownManager = pContextShutdownManager;
     parameters = pParameters;
   }
 
@@ -132,14 +132,15 @@ public final class Yices2SolverContext extends AbstractSolverContext {
 
   @Override
   protected ProverEnvironment newProverEnvironment0(Set<ProverOptions> pOptions) {
-    return new Yices2Prover(creator, pOptions, bfmgr, shutdownManager, parameters.solverType);
+    return new Yices2Prover(
+        creator, pOptions, bfmgr, contextShutdownManager, parameters.solverType);
   }
 
   @Override
   protected InterpolatingProverEnvironment<?> newProverEnvironmentWithInterpolation0(
       Set<ProverOptions> pOptions) {
     return new Yices2InterpolatingProver(
-        creator, pOptions, bfmgr, shutdownManager, parameters.solverType);
+        creator, pOptions, bfmgr, contextShutdownManager, parameters.solverType);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -188,9 +188,8 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
   }
 
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
       Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException {
-    checkGenerateUnsatCoresOverAssumptions();
     if (!isUnsatWithAssumptions(assumptions)) {
       return Optional.empty();
     }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -116,8 +116,7 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -116,7 +116,7 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -259,10 +259,10 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
   }
 
   @Override
-  public <R> R allSat(AllSatCallback<R> callback, List<BooleanFormula> important)
+  protected <R> R allSatImpl(AllSatCallback<R> callback, List<BooleanFormula> important)
       throws InterruptedException, SolverException {
     try {
-      return super.allSat(callback, important);
+      return super.allSatImpl(callback, important);
     } catch (Z3Exception e) {
       throw creator.handleZ3Exception(e);
     }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -167,8 +167,7 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
   protected abstract long getUnsatCore0();
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    checkGenerateUnsatCores();
+  public List<BooleanFormula> getUnsatCoreImpl() {
     if (storedConstraints == null) {
       throw new UnsupportedOperationException(
           "Option to generate the UNSAT core wasn't enabled when creating the prover environment.");

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -59,8 +59,8 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
       Engine pEngine,
       Set<ProverOptions> pOptions,
       @Nullable PathCounterTemplate pLogfile,
-      ShutdownNotifier pShutdownNotifier) {
-    super(pOptions, pMgr.getBooleanFormulaManager(), pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(pOptions, pMgr.getBooleanFormulaManager(), pContextShutdownNotifier);
     creator = pCreator;
     z3context = creator.getEnv();
     logic = pLogic;

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3AbstractProver.java
@@ -207,10 +207,7 @@ abstract class Z3AbstractProver extends AbstractProverWithAllSat<Void> {
   protected abstract long getStatistics0();
 
   @Override
-  public ImmutableMap<String, String> getStatistics() {
-    // Z3 sigsevs if you try to get statistics for closed environments
-    Preconditions.checkState(!closed);
-
+  public ImmutableMap<String, String> getStatisticsImpl() {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     Set<String> seenKeys = new HashSet<>();
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3FormulaCreator.java
@@ -131,7 +131,7 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
 
   // todo: getters for statistic.
   private final Timer cleanupTimer = new Timer();
-  protected final ShutdownNotifier shutdownNotifier;
+  protected final ShutdownNotifier contextShutdownNotifier;
 
   @SuppressWarnings("ParameterNumber")
   Z3FormulaCreator(
@@ -142,10 +142,10 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
       long pStringType,
       long pRegexType,
       Configuration config,
-      ShutdownNotifier pShutdownNotifier)
+      ShutdownNotifier pContextShutdownNotifier)
       throws InvalidConfigurationException {
     super(pEnv, pBoolType, pIntegerType, pRealType, pStringType, pRegexType);
-    shutdownNotifier = pShutdownNotifier;
+    contextShutdownNotifier = pContextShutdownNotifier;
     config.inject(this);
 
     if (usePhantomReferences) {
@@ -168,7 +168,7 @@ class Z3FormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
   final SolverException handleZ3Exception(Z3Exception e)
       throws SolverException, InterruptedException {
     if (Z3_INTERRUPT_ERRORS.contains(e.getMessage())) {
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
     }
     throw new SolverException("Z3 has thrown an exception", e);
   }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3OptimizationProver.java
@@ -46,8 +46,8 @@ class Z3OptimizationProver extends Z3AbstractProver implements OptimizationProve
       Set<ProverOptions> pOptions,
       ImmutableMap<String, Object> pSolverOptions,
       @Nullable PathCounterTemplate pLogfile,
-      ShutdownNotifier pShutdownNotifier) {
-    super(creator, pMgr, pLogic, pEngine, pOptions, pLogfile, pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(creator, pMgr, pLogic, pEngine, pOptions, pLogfile, pContextShutdownNotifier);
     z3optSolver = Native.mkOptimize(z3context);
     Native.optimizeIncRef(z3context, z3optSolver);
     logger = pLogger;
@@ -89,7 +89,7 @@ class Z3OptimizationProver extends Z3AbstractProver implements OptimizationProve
     if (status == Z3_lbool.Z3_L_FALSE.toInt()) {
       return OptStatus.UNSAT;
     } else if (status == Z3_lbool.Z3_L_UNDEF.toInt()) {
-      creator.shutdownNotifier.shutdownIfNecessary();
+      creator.contextShutdownNotifier.shutdownIfNecessary();
       logger.log(
           Level.INFO,
           "Solver returned an unknown status, explanation: ",

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3OptimizationProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3OptimizationProver.java
@@ -8,8 +8,6 @@
 
 package org.sosy_lab.java_smt.solvers.z3;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.z3.Native;
@@ -66,13 +64,11 @@ class Z3OptimizationProver extends Z3AbstractProver implements OptimizationProve
 
   @Override
   public int maximize(Formula objective) {
-    Preconditions.checkState(!closed);
     return Native.optimizeMaximize(z3context, z3optSolver, creator.extractInfo(objective));
   }
 
   @Override
   public int minimize(Formula objective) {
-    checkState(!closed);
     return Native.optimizeMinimize(z3context, z3optSolver, creator.extractInfo(objective));
   }
 
@@ -149,15 +145,11 @@ class Z3OptimizationProver extends Z3AbstractProver implements OptimizationProve
 
   @Override
   public Optional<Rational> upper(int handle, Rational epsilon) {
-    checkState(!closed);
-    checkGenerateModels();
     return round(handle, epsilon, Native::optimizeGetUpperAsVector);
   }
 
   @Override
   public Optional<Rational> lower(int handle, Rational epsilon) {
-    checkState(!closed);
-    checkGenerateModels();
     return round(handle, epsilon, Native::optimizeGetLowerAsVector);
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3SolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3SolverContext.java
@@ -51,7 +51,7 @@ import org.sosy_lab.java_smt.basicimpl.AbstractSolverContext;
 public final class Z3SolverContext extends AbstractSolverContext {
 
   private final ShutdownRequestListener interruptListener;
-  private final ShutdownNotifier shutdownNotifier;
+  private final ShutdownNotifier contextShutdownNotifier;
   private final LogManager logger;
   private final ExtraOptions extraOptions;
   private final Z3FormulaCreator creator;
@@ -235,7 +235,7 @@ public final class Z3SolverContext extends AbstractSolverContext {
 
   private Z3SolverContext(
       Z3FormulaCreator pFormulaCreator,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       LogManager pLogger,
       Z3FormulaManager pManager,
       ExtraOptions pExtraOptions) {
@@ -243,8 +243,8 @@ public final class Z3SolverContext extends AbstractSolverContext {
 
     creator = pFormulaCreator;
     interruptListener = reason -> Native.interrupt(pFormulaCreator.getEnv());
-    shutdownNotifier = pShutdownNotifier;
-    pShutdownNotifier.register(interruptListener);
+    contextShutdownNotifier = pContextShutdownNotifier;
+    pContextShutdownNotifier.register(interruptListener);
     logger = pLogger;
     manager = pManager;
     extraOptions = pExtraOptions;
@@ -259,7 +259,7 @@ public final class Z3SolverContext extends AbstractSolverContext {
   public static synchronized Z3SolverContext create(
       LogManager logger,
       Configuration config,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       @Nullable PathCounterTemplate solverLogfile,
       long randomSeed,
       FloatingPointRoundingMode pFloatingPointRoundingMode,
@@ -322,7 +322,7 @@ public final class Z3SolverContext extends AbstractSolverContext {
             stringSort,
             regexSort,
             config,
-            pShutdownNotifier);
+            pContextShutdownNotifier);
 
     // Create managers
     Z3UFManager functionTheory = new Z3UFManager(creator);
@@ -358,7 +358,7 @@ public final class Z3SolverContext extends AbstractSolverContext {
             arrayManager,
             stringTheory,
             enumTheory);
-    return new Z3SolverContext(creator, pShutdownNotifier, logger, manager, extraOptions);
+    return new Z3SolverContext(creator, pContextShutdownNotifier, logger, manager, extraOptions);
   }
 
   @Override
@@ -372,7 +372,7 @@ public final class Z3SolverContext extends AbstractSolverContext {
         options,
         buildSolverOptions(options),
         extraOptions.logfile,
-        shutdownNotifier);
+        contextShutdownNotifier);
   }
 
   @Override
@@ -394,7 +394,7 @@ public final class Z3SolverContext extends AbstractSolverContext {
         options,
         buildOptimizationSolverOptions(),
         extraOptions.logfile,
-        shutdownNotifier);
+        contextShutdownNotifier);
   }
 
   @Override
@@ -417,7 +417,7 @@ public final class Z3SolverContext extends AbstractSolverContext {
     if (!closed.getAndSet(true)) {
       long context = creator.getEnv();
       creator.forceClose();
-      shutdownNotifier.unregister(interruptListener);
+      contextShutdownNotifier.unregister(interruptListener);
       Native.closeLog();
       Native.delContext(context);
     }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
@@ -59,7 +59,7 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
     Native.solverIncRef(z3context, z3solver);
 
     interruptListener = reason -> Native.solverInterrupt(z3context, z3solver);
-    shutdownNotifier.register(interruptListener);
+    contextShutdownNotifier.register(interruptListener);
 
     long z3params = Native.mkParams(z3context);
     Native.paramsIncRef(z3context, z3params);
@@ -215,7 +215,7 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
         propagator.close();
         propagator = null;
       }
-      shutdownNotifier.unregister(interruptListener);
+      contextShutdownNotifier.unregister(interruptListener);
     }
     super.close();
   }

--- a/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3/Z3TheoremProver.java
@@ -46,8 +46,8 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
       Set<ProverOptions> pOptions,
       ImmutableMap<String, Object> pSolverOptions,
       @Nullable PathCounterTemplate pLogfile,
-      ShutdownNotifier pShutdownNotifier) {
-    super(creator, pMgr, pLogic, pEngine, pOptions, pLogfile, pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(creator, pMgr, pLogic, pEngine, pOptions, pLogfile, pContextShutdownNotifier);
     if (!logic.orElse("ALL").equalsIgnoreCase("ALL")) {
       // mkSolverForLogic() allows setting logics,
       // which seem to be getting ignored if set via options
@@ -141,7 +141,7 @@ class Z3TheoremProver extends Z3AbstractProver implements ProverEnvironment {
   private void undefinedStatusToException(int solverStatus)
       throws SolverException, InterruptedException {
     if (solverStatus == Z3_lbool.Z3_L_UNDEF.toInt()) {
-      creator.shutdownNotifier.shutdownIfNecessary();
+      creator.contextShutdownNotifier.shutdownIfNecessary();
       final String reason = Native.solverGetReasonUnknown(z3context, z3solver);
       switch (reason) {
         // see Z3:

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
@@ -386,10 +386,10 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public <R> R allSat(AllSatCallback<R> callback, List<BooleanFormula> important)
+  protected <R> R allSatImpl(AllSatCallback<R> callback, List<BooleanFormula> important)
       throws InterruptedException, SolverException {
     try {
-      return super.allSat(callback, important);
+      return super.allSatImpl(callback, important);
     } catch (Z3Exception e) {
       throw creator.handleZ3Exception(e);
     }

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
@@ -289,9 +289,7 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public List<BooleanFormula> getUnsatCore() {
-    Preconditions.checkState(!closed);
-    checkGenerateUnsatCores();
+  public List<BooleanFormula> getUnsatCoreImpl() {
     if (storedConstraints == null) {
       throw new UnsupportedOperationException(
           "Option to generate the UNSAT core wasn't enabled when creating the prover environment.");

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
@@ -121,8 +121,7 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModel() throws SolverException {
-    checkGenerateModels();
+  public Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
@@ -69,7 +69,7 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
     Native.solverIncRef(z3context, z3solver);
 
     interruptListener = reason -> Native.interrupt(z3context);
-    shutdownNotifier.register(interruptListener);
+    contextShutdownNotifier.register(interruptListener);
 
     if (pOptions.contains(ProverOptions.GENERATE_UNSAT_CORE)) {
       storedConstraints = new ArrayDeque<>();
@@ -374,7 +374,7 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
 
       Native.solverReset(z3context, z3solver); // remove all assertions from the solver
       Native.solverDecRef(z3context, z3solver);
-      shutdownNotifier.unregister(interruptListener);
+      contextShutdownNotifier.unregister(interruptListener);
       if (storedConstraints != null) {
         storedConstraints.clear();
       }

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
@@ -327,10 +327,7 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public ImmutableMap<String, String> getStatistics() {
-    // Z3 sigsevs if you try to get statistics for closed environments
-    Preconditions.checkState(!closed);
-
+  public ImmutableMap<String, String> getStatisticsImpl() {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     Set<String> seenKeys = new HashSet<>();
 

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
@@ -121,7 +121,7 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  public Model getModelImpl() throws SolverException {
+  protected Model getModelImpl() throws SolverException {
     return new CachingModel(getEvaluatorWithoutChecks());
   }
 

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
@@ -60,8 +60,8 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
       Z3LegacyFormulaManager pMgr,
       Set<ProverOptions> pOptions,
       @Nullable PathCounterTemplate pLogfile,
-      ShutdownNotifier pShutdownNotifier) {
-    super(pOptions, pMgr.getBooleanFormulaManager(), pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(pOptions, pMgr.getBooleanFormulaManager(), pContextShutdownNotifier);
     creator = pCreator;
     z3context = creator.getEnv();
     z3solver = Native.mkSolver(z3context);
@@ -239,7 +239,7 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
   private void undefinedStatusToException(int solverStatus)
       throws SolverException, InterruptedException {
     if (solverStatus == Z3_lbool.Z3_L_UNDEF.toInt()) {
-      creator.shutdownNotifier.shutdownIfNecessary();
+      creator.contextShutdownNotifier.shutdownIfNecessary();
       final String reason = Native.solverGetReasonUnknown(z3context, z3solver);
       switch (reason) {
         // see Z3:

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyAbstractProver.java
@@ -310,9 +310,8 @@ abstract class Z3LegacyAbstractProver<T> extends AbstractProverWithAllSat<T> {
   }
 
   @Override
-  public Optional<List<BooleanFormula>> unsatCoreOverAssumptions(
+  protected Optional<List<BooleanFormula>> unsatCoreOverAssumptionsImpl(
       Collection<BooleanFormula> assumptions) throws SolverException, InterruptedException {
-    checkGenerateUnsatCoresOverAssumptions();
     if (!isUnsatWithAssumptions(assumptions)) {
       return Optional.empty();
     }

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyFormulaCreator.java
@@ -135,7 +135,7 @@ class Z3LegacyFormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
 
   // todo: getters for statistic.
   private final Timer cleanupTimer = new Timer();
-  protected final ShutdownNotifier shutdownNotifier;
+  protected final ShutdownNotifier contextShutdownNotifier;
 
   @SuppressWarnings("ParameterNumber")
   Z3LegacyFormulaCreator(
@@ -146,10 +146,10 @@ class Z3LegacyFormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
       long pStringType,
       long pRegexType,
       Configuration config,
-      ShutdownNotifier pShutdownNotifier)
+      ShutdownNotifier pContextShutdownNotifier)
       throws InvalidConfigurationException {
     super(pEnv, pBoolType, pIntegerType, pRealType, pStringType, pRegexType);
-    shutdownNotifier = pShutdownNotifier;
+    contextShutdownNotifier = pContextShutdownNotifier;
     config.inject(this);
 
     if (usePhantomReferences) {
@@ -172,7 +172,7 @@ class Z3LegacyFormulaCreator extends FormulaCreator<Long, Long, Long, Long> {
   final SolverException handleZ3Exception(Z3Exception e)
       throws SolverException, InterruptedException {
     if (Z3_INTERRUPT_ERRORS.contains(e.getMessage())) {
-      shutdownNotifier.shutdownIfNecessary();
+      contextShutdownNotifier.shutdownIfNecessary();
     }
     throw new SolverException("Z3 has thrown an exception", e);
   }

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyInterpolatingProver.java
@@ -51,8 +51,8 @@ class Z3LegacyInterpolatingProver extends Z3LegacyAbstractProver<Long>
       Z3LegacyFormulaManager pMgr,
       Set<ProverOptions> pOptions,
       @Nullable PathCounterTemplate pLogfile,
-      ShutdownNotifier pShutdownNotifier) {
-    super(pCreator, pMgr, pOptions, pLogfile, pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(pCreator, pMgr, pOptions, pLogfile, pContextShutdownNotifier);
   }
 
   @CanIgnoreReturnValue

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacySolverContext.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacySolverContext.java
@@ -44,7 +44,7 @@ import org.sosy_lab.java_smt.basicimpl.AbstractSolverContext;
 public final class Z3LegacySolverContext extends AbstractSolverContext {
 
   private final ShutdownRequestListener interruptListener;
-  private final ShutdownNotifier shutdownNotifier;
+  private final ShutdownNotifier contextShutdownNotifier;
   private final ExtraOptions extraOptions;
   private final Z3LegacyFormulaCreator creator;
   private final Z3LegacyFormulaManager manager;
@@ -81,15 +81,15 @@ public final class Z3LegacySolverContext extends AbstractSolverContext {
 
   private Z3LegacySolverContext(
       Z3LegacyFormulaCreator pFormulaCreator,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       Z3LegacyFormulaManager pManager,
       ExtraOptions pExtraOptions) {
     super(pManager);
 
     creator = pFormulaCreator;
     interruptListener = reason -> Native.interrupt(pFormulaCreator.getEnv());
-    shutdownNotifier = pShutdownNotifier;
-    pShutdownNotifier.register(interruptListener);
+    contextShutdownNotifier = pContextShutdownNotifier;
+    pContextShutdownNotifier.register(interruptListener);
     manager = pManager;
     extraOptions = pExtraOptions;
   }
@@ -98,7 +98,7 @@ public final class Z3LegacySolverContext extends AbstractSolverContext {
   public static synchronized Z3LegacySolverContext create(
       LogManager logger,
       Configuration config,
-      ShutdownNotifier pShutdownNotifier,
+      ShutdownNotifier pContextShutdownNotifier,
       @Nullable PathCounterTemplate solverLogfile,
       long randomSeed,
       FloatingPointRoundingMode pFloatingPointRoundingMode,
@@ -164,7 +164,7 @@ public final class Z3LegacySolverContext extends AbstractSolverContext {
             stringSort,
             regexSort,
             config,
-            pShutdownNotifier);
+            pContextShutdownNotifier);
 
     // Create managers
     Z3LegacyUFManager functionTheory = new Z3LegacyUFManager(creator);
@@ -201,7 +201,7 @@ public final class Z3LegacySolverContext extends AbstractSolverContext {
             arrayManager,
             stringTheory,
             enumTheory);
-    return new Z3LegacySolverContext(creator, pShutdownNotifier, manager, extraOptions);
+    return new Z3LegacySolverContext(creator, pContextShutdownNotifier, manager, extraOptions);
   }
 
   @Override
@@ -220,7 +220,7 @@ public final class Z3LegacySolverContext extends AbstractSolverContext {
                     || options.contains(ProverOptions.GENERATE_UNSAT_CORE_OVER_ASSUMPTIONS))
             .buildOrThrow();
     return new Z3LegacyTheoremProver(
-        creator, manager, options, solverOptions, extraOptions.logfile, shutdownNotifier);
+        creator, manager, options, solverOptions, extraOptions.logfile, contextShutdownNotifier);
   }
 
   @Override
@@ -235,7 +235,7 @@ public final class Z3LegacySolverContext extends AbstractSolverContext {
     Native.paramsSetBool(
         z3context, z3params, Native.mkStringSymbol(z3context, ":unsat_core"), false);
     return new Z3LegacyInterpolatingProver(
-        creator, manager, options, extraOptions.logfile, shutdownNotifier);
+        creator, manager, options, extraOptions.logfile, contextShutdownNotifier);
   }
 
   @Override
@@ -264,7 +264,7 @@ public final class Z3LegacySolverContext extends AbstractSolverContext {
     if (!closed.getAndSet(true)) {
       long context = creator.getEnv();
       creator.forceClose();
-      shutdownNotifier.unregister(interruptListener);
+      contextShutdownNotifier.unregister(interruptListener);
       Native.closeLog();
       Native.delContext(context);
     }

--- a/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyTheoremProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/z3legacy/Z3LegacyTheoremProver.java
@@ -28,8 +28,8 @@ class Z3LegacyTheoremProver extends Z3LegacyAbstractProver<Void> implements Prov
       Set<ProverOptions> pOptions,
       ImmutableMap<String, Object> pSolverOptions,
       @Nullable PathCounterTemplate pLogfile,
-      ShutdownNotifier pShutdownNotifier) {
-    super(creator, pMgr, pOptions, pLogfile, pShutdownNotifier);
+      ShutdownNotifier pContextShutdownNotifier) {
+    super(creator, pMgr, pOptions, pLogfile, pContextShutdownNotifier);
     long z3params = Native.mkParams(z3context);
     Native.paramsIncRef(z3context, z3params);
     for (Entry<String, Object> entry : pSolverOptions.entrySet()) {


### PR DESCRIPTION
This PR adds `ProverException`s and `InterruptedException`s to all `Prover*`, `Evaluator`* and `Model`* interface methods interacting with solvers in preparation for Prover based interrupts.

This PR is based on #674 and should only be merged after it.