### PR TITLE
Remove experimental FP-to-BV impl from Bitwuzla

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaAbstractProver.java
@@ -29,7 +29,6 @@ import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractProverWithAllSat;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Bitwuzla;
-import org.sosy_lab.java_smt.solvers.bitwuzla.api.Kind;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Option;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Options;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Result;
@@ -103,9 +102,6 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
   @CanIgnoreReturnValue
   protected int addConstraint0(BooleanFormula constraint) {
     Term formula = creator.extractInfo(constraint);
-    for (Term t : creator.getConstraintsForTerm(formula)) {
-      formula = creator.getEnv().mk_term(Kind.AND, formula, t);
-    }
     env.assert_formula(formula);
 
     var label = BitwuzlaAbstractProver.ID_GENERATOR.getFreshId();
@@ -207,7 +203,6 @@ abstract class BitwuzlaAbstractProver<T> extends AbstractProverWithAllSat<T> {
     for (BooleanFormula formula : assumptions) {
       Term term = creator.extractInfo(formula);
       newAssumptions.add(term);
-      newAssumptions.addAll(creator.getConstraintsForTerm(term));
     }
     Result result = env.check_sat(new Vector_Term(newAssumptions));
 

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFloatingPointManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFloatingPointManager.java
@@ -10,7 +10,6 @@ package org.sosy_lab.java_smt.solvers.bitwuzla;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import org.sosy_lab.common.UniqueIdGenerator;
 import org.sosy_lab.common.rationals.Rational;
 import org.sosy_lab.java_smt.api.FloatingPointFormula;
 import org.sosy_lab.java_smt.api.FloatingPointNumber.Sign;
@@ -26,17 +25,13 @@ import org.sosy_lab.java_smt.solvers.bitwuzla.api.TermManager;
 
 class BitwuzlaFloatingPointManager
     extends AbstractFloatingPointFormulaManager<Term, Sort, TermManager, BitwuzlaDeclaration> {
-  private final BitwuzlaFormulaCreator bitwuzlaCreator;
+
   private final TermManager termManager;
   private final Term roundingMode;
-
-  // Keeps track of the temporary variables that are created for fp-to-bv casts
-  private static final UniqueIdGenerator counter = new UniqueIdGenerator();
 
   BitwuzlaFloatingPointManager(
       BitwuzlaFormulaCreator pCreator, FloatingPointRoundingMode pFloatingPointRoundingMode) {
     super(pCreator);
-    bitwuzlaCreator = pCreator;
     termManager = pCreator.getEnv();
     roundingMode = getRoundingModeImpl(pFloatingPointRoundingMode);
   }
@@ -192,44 +187,9 @@ class BitwuzlaFloatingPointManager
 
   @Override
   protected Term toIeeeBitvectorImpl(Term pNumber) {
-    int sizeExp = pNumber.sort().fp_exp_size();
-    int sizeSig = pNumber.sort().fp_sig_size();
-
-    Sort bvSort = termManager.mk_bv_sort(sizeExp + sizeSig);
-
-    // The following code creates a new variable that is returned as result.
-    // Additionally, we track constraints about the equality of the new variable and the FP number,
-    // which is added onto the prover stack whenever the new variable is used as assertion.
-
-    // TODO This internal implementation is a technical dept and should be removed.
-    //   The additional constraints are not transparent in all cases, e.g., when visiting a
-    //   formula, creating a model, or transferring the assertions onto another prover stack.
-    //   A better way would be a direct implementation of this in Bitwuzla, without interfering
-    //   with JavaSMT.
-
-    // Note that NaN is handled as a special case in this method. This is not strictly necessary,
-    // but if we just use "fpTerm = to_fp(bvVar)" the NaN will be given a random payload (and
-    // sign). Since NaN payloads are not preserved here anyway we might as well pick a canonical
-    // representation, e.g., which is "0 11111111 10000000000000000000000" for single precision.
-    String nanRepr = "0" + "1".repeat(sizeExp + 1) + "0".repeat(sizeSig - 2);
-    Term bvNaN = termManager.mk_bv_value(bvSort, nanRepr);
-
-    // TODO creating our own utility variables might eb unexpected from the user.
-    //   We might need to exclude such variables in models and formula traversal.
-    String newVariable = "__JAVASMT__CAST_FROM_BV_" + counter.getFreshId();
-    Term bvVar = termManager.mk_const(bvSort, newVariable);
-    Term equal =
-        termManager.mk_term(
-            Kind.ITE,
-            termManager.mk_term(Kind.FP_IS_NAN, pNumber),
-            termManager.mk_term(Kind.EQUAL, bvVar, bvNaN),
-            termManager.mk_term(
-                Kind.EQUAL,
-                termManager.mk_term(Kind.FP_TO_FP_FROM_BV, bvVar, sizeExp, sizeSig),
-                pNumber));
-
-    bitwuzlaCreator.addConstraintForVariable(newVariable, equal);
-    return bvVar;
+    throw new UnsupportedOperationException(
+        "Bitwuzla does not support transforming "
+            + "floating-point formulas to IEEE bitvectors natively");
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaCreator.java
@@ -9,7 +9,6 @@
 package org.sosy_lab.java_smt.solvers.bitwuzla;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.sosy_lab.common.collect.Collections3.transformedImmutableSetCopy;
 import static org.sosy_lab.java_smt.api.FormulaType.getFloatingPointTypeFromSizesWithHiddenBit;
 
 import com.google.common.base.Preconditions;
@@ -20,17 +19,8 @@ import com.google.common.collect.Table;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiConsumer;
 import org.sosy_lab.java_smt.api.ArrayFormula;
 import org.sosy_lab.java_smt.api.BitvectorFormula;
@@ -65,22 +55,6 @@ import org.sosy_lab.java_smt.solvers.bitwuzla.api.Vector_Term;
 class BitwuzlaFormulaCreator extends FormulaCreator<Term, Sort, TermManager, BitwuzlaDeclaration> {
 
   private final Table<String, Sort, Term> formulaCache = HashBasedTable.create();
-
-  /**
-   * This mapping stores symbols and their constraints, such as from fp-to-bv casts with their
-   * defining equation.
-   *
-   * <p>Bitwuzla does not support casts from floating-point to bitvector natively. The reason given
-   * is that the value is undefined for NaN and that the SMT-LIB standard also does not include such
-   * an operation. We try to work around this limitation by introducing a fresh variable <code>
-   * __CAST_FROM_BV_XXX</code>for the result and then adding the constraint <code>
-   * fp.to_fp(__CAST_FROM_BV_XXX) = &lt;float-term&gt;</code> as a side-condition. This is also what
-   * is recommended by the SMT-LIB2 standard. The map <code>variableCasts</code> is used to store
-   * these side-conditions so that they can later be added as assertions. The keys of the map are
-   * the newly introduced variable symbols and the values are the defining equations as mentioned
-   * above.
-   */
-  private final Map<String, Term> constraintsForVariables = new HashMap<>();
 
   BitwuzlaFormulaCreator(TermManager pTermManager) {
     super(pTermManager, pTermManager.mk_bool_sort(), null, null, null, null);
@@ -566,22 +540,6 @@ class BitwuzlaFormulaCreator extends FormulaCreator<Term, Sort, TermManager, Bit
     return formulaCache;
   }
 
-  // True if the entered String has an existing variable in the cache.
-  protected boolean formulaCacheContains(String variable) {
-    // There is always only 1 type permitted per variable
-    return formulaCache.containsRow(variable);
-  }
-
-  // Optional that contains the variable to the entered String if there is one.
-  protected Optional<Term> getFormulaFromCache(String variable) {
-    Iterator<Entry<Sort, Term>> entrySetIter = formulaCache.row(variable).entrySet().iterator();
-    if (entrySetIter.hasNext()) {
-      // If there is a non-empty row for an entry, there is only one entry
-      return Optional.of(entrySetIter.next().getValue());
-    }
-    return Optional.empty();
-  }
-
   @Override
   public Object convertValue(Term term) {
     Preconditions.checkArgument(term.is_value(), "Term \"%s\" is not a value.", term);
@@ -604,37 +562,6 @@ class BitwuzlaFormulaCreator extends FormulaCreator<Term, Sort, TermManager, Bit
           getFloatingPointTypeFromSizesWithHiddenBit(exponentSize, mantissaSizeWithHiddenBit));
     }
     throw new AssertionError("Unknown value type.");
-  }
-
-  /** Add a constraint that is pushed onto the prover stack whenever the variable is used. */
-  public void addConstraintForVariable(String variable, Term constraint) {
-    constraintsForVariables.put(variable, constraint);
-  }
-
-  /**
-   * Returns a set of additional constraints (side-conditions) that are needed to use some variables
-   * from the given term, such as utility variables from casts.
-   *
-   * <p>Bitwuzla does not support fp-to-bv conversion natively. We have to use side-conditions as a
-   * workaround. When a term containing fp-to-bv casts is added to the assertion stack these
-   * side-conditions need to be collected by calling this method and then also adding them to the
-   * assertion stack.
-   */
-  public Collection<Term> getConstraintsForTerm(Term pTerm) {
-    final Set<String> usedConstraintVariables = new LinkedHashSet<>();
-    final Deque<String> waitlist = new ArrayDeque<>(extractVariablesAndUFs(pTerm, false).keySet());
-    while (!waitlist.isEmpty()) {
-      String current = waitlist.pop();
-      if (constraintsForVariables.containsKey(current)) { // ignore variables without constraints
-        if (usedConstraintVariables.add(current)) {
-          // if we found a new variable with constraint, get transitive variables from constraint
-          Term constraint = constraintsForVariables.get(current);
-          waitlist.addAll(extractVariablesAndUFs(constraint, false).keySet());
-        }
-      }
-    }
-
-    return transformedImmutableSetCopy(usedConstraintVariables, constraintsForVariables::get);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaFormulaManager.java
@@ -231,9 +231,6 @@ final class BitwuzlaFormulaManager
       return "(assert %s)".formatted(pTerm);
     }
     Bitwuzla bitwuzla = new Bitwuzla(creator.getEnv());
-    for (Term t : creator.getConstraintsForTerm(pTerm)) {
-      bitwuzla.assert_formula(t);
-    }
     bitwuzla.assert_formula(pTerm);
     return bitwuzla.print_formula();
   }

--- a/src/org/sosy_lab/java_smt/test/SolverVisitorTest.java
+++ b/src/org/sosy_lab/java_smt/test/SolverVisitorTest.java
@@ -618,10 +618,7 @@ public class SolverVisitorTest extends SolverBasedTest0.ParameterizedSolverBased
   public void fpToBvTest() {
     requireFloats();
     requireBitvectors();
-    assume()
-        .withMessage("FP-to-BV conversion not available for CVC4 and CVC5")
-        .that(solverToUse())
-        .isNoneOf(Solvers.CVC4, Solvers.CVC5);
+    requireFPToBitvector();
 
     var fpType = FormulaType.getFloatingPointTypeFromSizesWithoutHiddenBit(5, 10);
     var visitor =


### PR DESCRIPTION
Remove experimental FP-to-BV impl from Bitwuzla as it adds new formulas to the solver stack silently and in unexpected circumstances. This PR pulls these changes from #512, to reduce the amount of changes in #512.