### PR TITLE
Princess: Add work-around for parsing issues

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
@@ -304,7 +304,7 @@ class PrincessEnvironment {
     Preconditions.checkState(registeredProvers.isEmpty());
   }
 
-  public List<? extends IExpression> parseStringToTerms(String s, PrincessFormulaCreator creator) {
+  public List<? extends IExpression> parseStringToTerms(String s) {
     Tuple4<
             Seq<IFormula>,
             scala.collection.immutable.Map<IFunction, SMTFunctionType>,

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
@@ -43,6 +43,7 @@ import ap.types.Sort.MultipleValueBool$;
 import ap.util.Debug;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -332,6 +333,7 @@ class PrincessEnvironment {
       sortedVariablesCache.put(constant.name(), new IConstant(constant));
     }
     for (Predicate predicate : nullaryPredicates.keySet()) {
+      Verify.verify(predicate.arity() == 0);
       boolVariablesCache.put(predicate.name(), new IAtom(predicate, toSeq(ImmutableList.of())));
     }
     return asserts;

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessEnvironment.java
@@ -305,7 +305,6 @@ class PrincessEnvironment {
   }
 
   public List<? extends IExpression> parseStringToTerms(String s, PrincessFormulaCreator creator) {
-
     Tuple4<
             Seq<IFormula>,
             scala.collection.immutable.Map<IFunction, SMTFunctionType>,
@@ -319,26 +318,23 @@ class PrincessEnvironment {
       throw new IllegalArgumentException(nested);
     }
 
-    final List<IFormula> formulas = asJava(parserResult._1());
+    List<IFormula> asserts = asJava(parserResult._1());
+    Map<IFunction, SMTFunctionType> ufs = asJava(parserResult._2());
+    Map<ConstantTerm, SMTType> constants = asJava(parserResult._3());
+    Map<Predicate, SMTFunctionType> nullaryPredicates = asJava(parserResult._4());
 
-    ImmutableSet.Builder<IExpression> declaredFunctions = ImmutableSet.builder();
-    for (IExpression f : formulas) {
-      declaredFunctions.addAll(creator.extractVariablesAndUFs(f, true).values());
+    for (Entry<IFunction, SMTFunctionType> entry : ufs.entrySet()) {
+      functionsCache.put(
+          entry.getKey().name(),
+          new PrincessIFunctionDeclaration(entry.getKey(), entry.getValue()));
     }
-    for (IExpression var : declaredFunctions.build()) {
-      if (var instanceof IConstant iConstant) {
-        sortedVariablesCache.put(iConstant.c().name(), iConstant);
-        addSymbol(iConstant);
-      } else if (var instanceof IAtom iAtom) {
-        boolVariablesCache.put(iAtom.pred().name(), iAtom);
-        addSymbol(iAtom);
-      } else if (var instanceof IFunApp app) {
-        IFunction fun = app.fun();
-        functionsCache.put(fun.name(), new PrincessIFunctionDeclaration(app));
-        addFunction(fun);
-      }
+    for (ConstantTerm constant : constants.keySet()) {
+      sortedVariablesCache.put(constant.name(), new IConstant(constant));
     }
-    return formulas;
+    for (Predicate predicate : nullaryPredicates.keySet()) {
+      boolVariablesCache.put(predicate.name(), new IAtom(predicate, toSeq(ImmutableList.of())));
+    }
+    return asserts;
   }
 
   /**
@@ -580,7 +576,7 @@ class PrincessEnvironment {
     }
   }
 
-  private static FormulaType<?> getFormulaTypeFromSort(final Sort sort) {
+  static FormulaType<?> getFormulaTypeFromSort(final Sort sort) {
     if (sort == PrincessEnvironment.BOOL_SORT) {
       return FormulaType.BooleanType;
     } else if (sort == PrincessEnvironment.INTEGER_SORT || sort == PrincessEnvironment.NAT_SORT) {

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaManager.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessFormulaManager.java
@@ -71,7 +71,7 @@ final class PrincessFormulaManager
   protected List<IExpression> parseAllImpl(String pSmtScript) throws IllegalArgumentException {
     // Princess's parseStringToTerms already handles multiple assertions and returns them as a list.
     // The cast is safe because parseStringToTerms returns List<? extends IExpression>.
-    return (List<IExpression>) getEnvironment().parseStringToTerms(pSmtScript, creator);
+    return (List<IExpression>) getEnvironment().parseStringToTerms(pSmtScript);
   }
 
   @Override

--- a/src/org/sosy_lab/java_smt/solvers/princess/PrincessFunctionDeclaration.java
+++ b/src/org/sosy_lab/java_smt/solvers/princess/PrincessFunctionDeclaration.java
@@ -21,6 +21,7 @@ import ap.parser.IFunction;
 import ap.parser.IIntLit;
 import ap.parser.ITerm;
 import ap.parser.ITermITE;
+import ap.parser.SMTParser2InputAbsy.SMTFunctionType;
 import ap.terfor.preds.Predicate;
 import ap.theories.nia.GroebnerMultiplication;
 import ap.types.Sort;
@@ -85,6 +86,20 @@ abstract sealed class PrincessFunctionDeclaration {
 
       argSorts = pArgSorts;
       returnSort = pReturnSort;
+      function = pFunction;
+    }
+
+    PrincessIFunctionDeclaration(IFunction pFunction, SMTFunctionType pType) {
+      super(pFunction);
+
+      ImmutableList.Builder<FormulaType<?>> builder = ImmutableList.builder();
+      for (int i = 0; i < pType.arguments().size(); i++) {
+        builder.add(
+            PrincessEnvironment.getFormulaTypeFromSort(pType.arguments().apply(i).toSort()));
+      }
+
+      argSorts = builder.build();
+      returnSort = PrincessEnvironment.getFormulaTypeFromSort(pType.result().toSort());
       function = pFunction;
     }
 

--- a/src/org/sosy_lab/java_smt/test/ParserTest.java
+++ b/src/org/sosy_lab/java_smt/test/ParserTest.java
@@ -285,4 +285,14 @@ public class ParserTest extends SolverBasedTest0.ParameterizedSolverBasedTest0 {
 
     assertThat(g).isEqualTo(f);
   }
+
+  @Test
+  public void parseAllEpsilonTermTest() throws SolverException, InterruptedException {
+    // Princess rewrites the assertion as an epsilon term, which caused issues while parsing as it
+    // introduces a new variable
+    requireRationals();
+    BooleanFormula f = mgr.parse("(assert (> (/ 1.0 2.0) 0.0))");
+
+    assertThatFormula(f).isTautological();
+  }
 }


### PR DESCRIPTION
Hello,

this PR fixes some parsing issues in Princess. We've so far used a visitor to collect terms after parsing, so that they can be added to the variable cache. This can cause crashes as Princess will often rewrite formulas with epsilon terms, and epsilon terms are not supported by our visitor. To avoid the issue, this PR now switches to getting the parsed symbols from the parser itself