### PR TITLE
Throw `SolverException` when interpolation fails

### DIFF
--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
@@ -17,6 +17,7 @@ import com.google.common.collect.Iterables;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -52,13 +53,27 @@ class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
     return addConstraint0(constraint);
   }
 
+  /** Catches interpolation errors and throws a {@link SolverException}. */
+  private <A, B> B callWithError(Function<A, B> f, A args) throws SolverException {
+    try {
+      return f.apply(args);
+    } catch (IllegalArgumentException e) {
+      if (e.getMessage().endsWith("not supported")) {
+        throw new SolverException(e.getMessage());
+      } else {
+        throw e;
+      }
+    }
+  }
+
   @Override
   public BooleanFormula getInterpolant(Collection<Integer> formulasOfA)
       throws SolverException, InterruptedException {
     return creator.encapsulateBoolean(
         formulasOfA.isEmpty()
             ? creator.getEnv().mk_true()
-            : env.get_interpolant(
+            : callWithError(
+                env::get_interpolant,
                 new Vector_Term(FluentIterable.from(formulasOfA).transform(stack.peek()::get))));
   }
 
@@ -72,7 +87,7 @@ class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
             FluentIterable.from(partitionedFormulas)
                 .transform(
                     p -> new Vector_Term(FluentIterable.from(p).transform(stack.peek()::get))));
-    Vector_Term itps = env.get_interpolants(partitions);
+    Vector_Term itps = callWithError(env::get_interpolants, partitions);
     checkState(
         creator.getEnv().mk_false().equals(Iterables.getLast(itps)),
         "the last interpolant should be false");

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
@@ -66,10 +66,10 @@ class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
     if (formulasOfA.isEmpty()) {
       interpolant = creator.getEnv().mk_true();
     } else {
+      Vector_Term itpVector =
+          new Vector_Term(FluentIterable.from(formulasOfA).transform(stack.peek()::get));
       try {
-        interpolant =
-            env.get_interpolant(
-                new Vector_Term(FluentIterable.from(formulasOfA).transform(stack.peek()::get)));
+        interpolant = env.get_interpolant(itpVector);
 
       } catch (IllegalArgumentException e) {
         // TODO Starting with Bitwuzla 0.9.2 we could catch the Unsupported exception in C++

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
@@ -33,7 +33,7 @@ import org.sosy_lab.java_smt.solvers.bitwuzla.api.Vector_Vector_Term;
 class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
     implements InterpolatingProverEnvironment<Integer> {
 
-  private static final ImmutableSet<String> INTERPOLATION_ERROR_MESSAGES =
+  private static final ImmutableSet<String> ACCEPTED_INTERPOLATION_ERROR_MESSAGES =
       ImmutableSet.of(
           "interpolation queries with lemmas that use fresh variables not supported",
           "interpolation queries with mixed lemmas not supported");
@@ -73,7 +73,7 @@ class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
 
       } catch (IllegalArgumentException e) {
         // TODO Starting with Bitwuzla 0.9.2 we could catch the Unsupported exception in C++
-        if (INTERPOLATION_ERROR_MESSAGES.contains(e.getMessage())) {
+        if (ACCEPTED_INTERPOLATION_ERROR_MESSAGES.contains(e.getMessage())) {
           throw new SolverException(e.getMessage());
         } else {
           throw e;
@@ -97,7 +97,7 @@ class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
     try {
       itps = env.get_interpolants(partitions);
     } catch (IllegalArgumentException e) {
-      if (INTERPOLATION_ERROR_MESSAGES.contains(e.getMessage())) {
+      if (ACCEPTED_INTERPOLATION_ERROR_MESSAGES.contains(e.getMessage())) {
         throw new SolverException(e.getMessage());
       } else {
         throw e;

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
@@ -13,6 +13,7 @@ package org.sosy_lab.java_smt.solvers.bitwuzla;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.util.Collection;
 import java.util.List;
@@ -31,6 +32,11 @@ import org.sosy_lab.java_smt.solvers.bitwuzla.api.Vector_Vector_Term;
 
 class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
     implements InterpolatingProverEnvironment<Integer> {
+
+  private ImmutableSet<String> INTERPOLATION_ERROR_MESSAGES =
+      ImmutableSet.of(
+          "interpolation queries with lemmas that use fresh variables not supported",
+          "interpolation queries with mixed lemmas not supported");
 
   BitwuzlaInterpolatingProver(
       BitwuzlaFormulaManager pManager,
@@ -66,7 +72,8 @@ class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
                 new Vector_Term(FluentIterable.from(formulasOfA).transform(stack.peek()::get)));
 
       } catch (IllegalArgumentException e) {
-        if (e.getMessage().endsWith("not supported")) {
+        // TODO Starting with Bitwuzla 0.9.2 we could catch the Unsupported exception in C++
+        if (INTERPOLATION_ERROR_MESSAGES.contains(e.getMessage())) {
           throw new SolverException(e.getMessage());
         } else {
           throw e;
@@ -90,7 +97,7 @@ class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
     try {
       itps = env.get_interpolants(partitions);
     } catch (IllegalArgumentException e) {
-      if (e.getMessage().endsWith("not supported")) {
+      if (INTERPOLATION_ERROR_MESSAGES.contains(e.getMessage())) {
         throw new SolverException(e.getMessage());
       } else {
         throw e;

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
@@ -33,7 +33,7 @@ import org.sosy_lab.java_smt.solvers.bitwuzla.api.Vector_Vector_Term;
 class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
     implements InterpolatingProverEnvironment<Integer> {
 
-  private ImmutableSet<String> INTERPOLATION_ERROR_MESSAGES =
+  private static final ImmutableSet<String> INTERPOLATION_ERROR_MESSAGES =
       ImmutableSet.of(
           "interpolation queries with lemmas that use fresh variables not supported",
           "interpolation queries with mixed lemmas not supported");

--- a/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/bitwuzla/BitwuzlaInterpolatingProver.java
@@ -17,7 +17,6 @@ import com.google.common.collect.Iterables;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -26,6 +25,7 @@ import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Option;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Options;
+import org.sosy_lab.java_smt.solvers.bitwuzla.api.Term;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Vector_Term;
 import org.sosy_lab.java_smt.solvers.bitwuzla.api.Vector_Vector_Term;
 
@@ -53,28 +53,27 @@ class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
     return addConstraint0(constraint);
   }
 
-  /** Catches interpolation errors and throws a {@link SolverException}. */
-  private <A, B> B callWithError(Function<A, B> f, A args) throws SolverException {
-    try {
-      return f.apply(args);
-    } catch (IllegalArgumentException e) {
-      if (e.getMessage().endsWith("not supported")) {
-        throw new SolverException(e.getMessage());
-      } else {
-        throw e;
-      }
-    }
-  }
-
   @Override
   public BooleanFormula getInterpolant(Collection<Integer> formulasOfA)
       throws SolverException, InterruptedException {
-    return creator.encapsulateBoolean(
-        formulasOfA.isEmpty()
-            ? creator.getEnv().mk_true()
-            : callWithError(
-                env::get_interpolant,
-                new Vector_Term(FluentIterable.from(formulasOfA).transform(stack.peek()::get))));
+    Term interpolant;
+    if (formulasOfA.isEmpty()) {
+      interpolant = creator.getEnv().mk_true();
+    } else {
+      try {
+        interpolant =
+            env.get_interpolant(
+                new Vector_Term(FluentIterable.from(formulasOfA).transform(stack.peek()::get)));
+
+      } catch (IllegalArgumentException e) {
+        if (e.getMessage().endsWith("not supported")) {
+          throw new SolverException(e.getMessage());
+        } else {
+          throw e;
+        }
+      }
+    }
+    return creator.encapsulateBoolean(interpolant);
   }
 
   @Override
@@ -87,7 +86,16 @@ class BitwuzlaInterpolatingProver extends BitwuzlaAbstractProver<Integer>
             FluentIterable.from(partitionedFormulas)
                 .transform(
                     p -> new Vector_Term(FluentIterable.from(p).transform(stack.peek()::get))));
-    Vector_Term itps = callWithError(env::get_interpolants, partitions);
+    Vector_Term itps;
+    try {
+      itps = env.get_interpolants(partitions);
+    } catch (IllegalArgumentException e) {
+      if (e.getMessage().endsWith("not supported")) {
+        throw new SolverException(e.getMessage());
+      } else {
+        throw e;
+      }
+    }
     checkState(
         creator.getEnv().mk_false().equals(Iterables.getLast(itps)),
         "the last interpolant should be false");

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtAbstractProver.java
@@ -117,7 +117,7 @@ abstract class OpenSmtAbstractProver<T> extends AbstractProverWithAllSat<T> {
 
   @SuppressWarnings("resource")
   @Override
-  protected Model getModelImpl() {
+  protected Model getModelImpl() throws SolverException {
     return registerEvaluator(
         new OpenSmtModel(
             this, creator, Collections2.transform(getAssertedFormulas(), creator::extractInfo)));

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtInterpolatingProver.java
@@ -69,13 +69,21 @@ class OpenSmtInterpolatingProver extends OpenSmtAbstractProver<Integer>
     super.popImpl();
   }
 
-  @Override
-  public BooleanFormula getInterpolant(Collection<Integer> formulasOfA) throws SolverException {
+  /**
+   * Check if OpenSMT supports interpolation for the current logic, and throw an {@link
+   * SolverException} otherwise.
+   */
+  private void checkLogicSupportInterpolation() throws SolverException {
     if (!creator.getLogic().doesLogicSupportInterpolation()) {
       throw new SolverException(
           "OpenSMT does not support interpolation for the specified logic %s."
               .formatted(creator.getLogic()));
     }
+  }
+
+  @Override
+  public BooleanFormula getInterpolant(Collection<Integer> formulasOfA) throws SolverException {
+    checkLogicSupportInterpolation();
     return creator.encapsulateBoolean(
         osmtSolver.getInterpolationContext().getSingleInterpolant(new VectorInt(formulasOfA)));
   }
@@ -83,12 +91,7 @@ class OpenSmtInterpolatingProver extends OpenSmtAbstractProver<Integer>
   @Override
   public List<BooleanFormula> getSeqInterpolants(
       List<? extends Collection<Integer>> partitionedFormulas) throws SolverException {
-    if (!creator.getLogic().doesLogicSupportInterpolation()) {
-      throw new SolverException(
-          "OpenSMT does not support interpolation for the specified logic %s."
-              .formatted(creator.getLogic()));
-    }
-
+    checkLogicSupportInterpolation();
     VectorVectorInt partitions = new VectorVectorInt();
     for (int i = 1; i < partitionedFormulas.size(); i++) {
       VectorInt prefix = new VectorInt();

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtInterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtInterpolatingProver.java
@@ -19,6 +19,7 @@ import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FormulaManager;
 import org.sosy_lab.java_smt.api.InterpolatingProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
+import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.solvers.opensmt.OpenSmtSolverContext.OpenSMTOptions;
 import org.sosy_lab.java_smt.solvers.opensmt.api.PTRef;
 import org.sosy_lab.java_smt.solvers.opensmt.api.VectorInt;
@@ -69,14 +70,25 @@ class OpenSmtInterpolatingProver extends OpenSmtAbstractProver<Integer>
   }
 
   @Override
-  public BooleanFormula getInterpolant(Collection<Integer> formulasOfA) {
+  public BooleanFormula getInterpolant(Collection<Integer> formulasOfA) throws SolverException {
+    if (!creator.getLogic().doesLogicSupportInterpolation()) {
+      throw new SolverException(
+          "OpenSMT does not support interpolation for the specified logic %s."
+              .formatted(creator.getLogic()));
+    }
     return creator.encapsulateBoolean(
         osmtSolver.getInterpolationContext().getSingleInterpolant(new VectorInt(formulasOfA)));
   }
 
   @Override
   public List<BooleanFormula> getSeqInterpolants(
-      List<? extends Collection<Integer>> partitionedFormulas) {
+      List<? extends Collection<Integer>> partitionedFormulas) throws SolverException {
+    if (!creator.getLogic().doesLogicSupportInterpolation()) {
+      throw new SolverException(
+          "OpenSMT does not support interpolation for the specified logic %s."
+              .formatted(creator.getLogic()));
+    }
+
     VectorVectorInt partitions = new VectorVectorInt();
     for (int i = 1; i < partitionedFormulas.size(); i++) {
       VectorInt prefix = new VectorInt();

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtModel.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtModel.java
@@ -71,7 +71,8 @@ class OpenSmtModel extends AbstractModel<PTRef, SRef, Logic> {
       if (osmtLogic.isArraySort(sort)) {
         // INFO: Disable model generation if arrays are used
         // https://github.com/usi-verification-and-security/opensmt/issues/630
-        throw new SolverException("OpenSMT does not support model generation when arrays are used");
+        throw new SolverException("OpenSMT2 can not return satisfiable assignments for arrays. To avoid wrong" +
+                "interpretation, we disallow model export for queries including arrays.");
       }
 
       if (numArgs == 0) {

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtModel.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtModel.java
@@ -71,8 +71,9 @@ class OpenSmtModel extends AbstractModel<PTRef, SRef, Logic> {
       if (osmtLogic.isArraySort(sort)) {
         // INFO: Disable model generation if arrays are used
         // https://github.com/usi-verification-and-security/opensmt/issues/630
-        throw new SolverException("OpenSMT2 can not return satisfiable assignments for arrays. To avoid wrong" +
-                "interpretation, we disallow model export for queries including arrays.");
+        throw new SolverException(
+            "OpenSMT2 can not return satisfiable assignments for arrays. To avoid wrong"
+                + "interpretation, we disallow model export for queries including arrays.");
       }
 
       if (numArgs == 0) {

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtModel.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtModel.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractModel;
 import org.sosy_lab.java_smt.solvers.opensmt.api.Logic;
@@ -40,7 +39,8 @@ class OpenSmtModel extends AbstractModel<PTRef, SRef, Logic> {
   OpenSmtModel(
       OpenSmtAbstractProver<?> pProver,
       OpenSmtFormulaCreator pCreator,
-      Collection<PTRef> pAssertedTerms) throws SolverException {
+      Collection<PTRef> pAssertedTerms)
+      throws SolverException {
     super(pProver, pCreator);
 
     osmtLogic = pCreator.getEnv();

--- a/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtModel.java
+++ b/src/org/sosy_lab/java_smt/solvers/opensmt/OpenSmtModel.java
@@ -18,6 +18,8 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.sosy_lab.java_smt.api.SolverException;
 import org.sosy_lab.java_smt.basicimpl.AbstractModel;
 import org.sosy_lab.java_smt.solvers.opensmt.api.Logic;
 import org.sosy_lab.java_smt.solvers.opensmt.api.Model;
@@ -38,7 +40,7 @@ class OpenSmtModel extends AbstractModel<PTRef, SRef, Logic> {
   OpenSmtModel(
       OpenSmtAbstractProver<?> pProver,
       OpenSmtFormulaCreator pCreator,
-      Collection<PTRef> pAssertedTerms) {
+      Collection<PTRef> pAssertedTerms) throws SolverException {
     super(pProver, pCreator);
 
     osmtLogic = pCreator.getEnv();
@@ -51,7 +53,7 @@ class OpenSmtModel extends AbstractModel<PTRef, SRef, Logic> {
   }
 
   private ImmutableList<ValueAssignment> generateModel(
-      OpenSmtFormulaCreator pCreator, Collection<PTRef> pAssertedTerms) {
+      OpenSmtFormulaCreator pCreator, Collection<PTRef> pAssertedTerms) throws SolverException {
     Map<String, PTRef> userDeclarations = new LinkedHashMap<>();
     for (PTRef asserted : pAssertedTerms) {
       userDeclarations.putAll(creator.extractVariablesAndUFs(asserted, true));
@@ -69,8 +71,7 @@ class OpenSmtModel extends AbstractModel<PTRef, SRef, Logic> {
       if (osmtLogic.isArraySort(sort)) {
         // INFO: Disable model generation if arrays are used
         // https://github.com/usi-verification-and-security/opensmt/issues/630
-        throw new UnsupportedOperationException(
-            "OpenSMT does not support model generation when arrays are used");
+        throw new SolverException("OpenSMT does not support model generation when arrays are used");
       }
 
       if (numArgs == 0) {

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
@@ -90,7 +90,7 @@ class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
       if (status == Status.UNSAT) {
         return context.getInterpolant();
       } else {
-        throw new IllegalArgumentException("Solver state must be unsat");
+        throw new IllegalStateException("Solver state must be unsat");
       }
     }
   }

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
@@ -35,7 +35,7 @@ import org.sosy_lab.java_smt.api.SolverException;
 class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
     implements InterpolatingProverEnvironment<Integer> {
 
-  private ImmutableSet<String> INTERPOLATION_ERROR_MESSAGES =
+  private static final ImmutableSet<String> INTERPOLATION_ERROR_MESSAGES =
       ImmutableSet.of(
           "mcsat: unsupported theory\n",
           "mcsat: assumption variable has a type that mcsat cannot decide on\n");

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
@@ -34,6 +34,12 @@ import org.sosy_lab.java_smt.api.SolverException;
 
 class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
     implements InterpolatingProverEnvironment<Integer> {
+
+  private ImmutableSet<String> INTERPOLATION_ERROR_MESSAGES =
+      ImmutableSet.of(
+          "mcsat: unsupported theory\n",
+          "mcsat: assumption variable has a type that mcsat cannot decide on\n");
+
   Yices2InterpolatingProver(
       Yices2FormulaCreator creator,
       Set<ProverOptions> pOptions,
@@ -77,10 +83,7 @@ class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
       try {
         status = context.check(DEFAULT_PARAMS, false);
       } catch (YicesException e) {
-        if (ImmutableSet.of(
-                "mcsat: unsupported theory\n",
-                "mcsat: assumption variable has a type that mcsat cannot decide on\n")
-            .contains(e.getMessage())) {
+        if (INTERPOLATION_ERROR_MESSAGES.contains(e.getMessage())) {
           throw new SolverException(e.getMessage().stripTrailing());
         } else {
           throw e;

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
@@ -19,6 +19,7 @@ import com.google.common.primitives.Ints;
 import com.sri.yices.InterpolationContext;
 import com.sri.yices.Status;
 import com.sri.yices.Terms;
+import com.sri.yices.YicesException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -61,7 +62,7 @@ class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
   }
 
   private int interpolate(Collection<Integer> setA, Collection<Integer> setB)
-      throws InterruptedException {
+      throws InterruptedException, SolverException {
     try (var ctxA = newContext("mcsat");
         var ctxB = newContext("mcsat")) {
 
@@ -72,7 +73,19 @@ class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
       // TODO How to abort this?
       // For now, let's just check before and after the call:
       shutdownNotifier.shutdownIfNecessary();
-      var status = context.check(DEFAULT_PARAMS, false);
+      Status status;
+      try {
+        status = context.check(DEFAULT_PARAMS, false);
+      } catch (YicesException e) {
+        if (ImmutableSet.of(
+                "mcsat: unsupported theory\n",
+                "mcsat: assumption variable has a type that mcsat cannot decide on\n")
+            .contains(e.getMessage())) {
+          throw new SolverException(e.getMessage().stripTrailing());
+        } else {
+          throw e;
+        }
+      }
       shutdownNotifier.shutdownIfNecessary();
       if (status == Status.UNSAT) {
         return context.getInterpolant();

--- a/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
+++ b/src/org/sosy_lab/java_smt/solvers/yices2/Yices2InterpolatingProver.java
@@ -35,7 +35,7 @@ import org.sosy_lab.java_smt.api.SolverException;
 class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
     implements InterpolatingProverEnvironment<Integer> {
 
-  private static final ImmutableSet<String> INTERPOLATION_ERROR_MESSAGES =
+  private static final ImmutableSet<String> ACCEPTED_INTERPOLATION_ERROR_MESSAGES =
       ImmutableSet.of(
           "mcsat: unsupported theory\n",
           "mcsat: assumption variable has a type that mcsat cannot decide on\n");
@@ -83,7 +83,7 @@ class Yices2InterpolatingProver extends Yices2AbstractProver<Integer>
       try {
         status = context.check(DEFAULT_PARAMS, false);
       } catch (YicesException e) {
-        if (INTERPOLATION_ERROR_MESSAGES.contains(e.getMessage())) {
+        if (ACCEPTED_INTERPOLATION_ERROR_MESSAGES.contains(e.getMessage())) {
           throw new SolverException(e.getMessage().stripTrailing());
         } else {
           throw e;


### PR DESCRIPTION
Hello,

this PR changes some runtime exceptions to `SolverExceptions` so that they can be better caught by the user. Specifically, we now throw a `SolverException` if interpolation fails in Bitwuzla or Yices. This is in line with how interpolation failures are handled in MathSAT, which also only has partial interpolation support for some theories. In addition we throw a `SolverException` in OpenSMT when model generation or interpolation are not available for the selected logic

Closes #643